### PR TITLE
Changed linux instruction for tls.cert

### DIFF
--- a/app/lnd/config/index.js
+++ b/app/lnd/config/index.js
@@ -1,6 +1,6 @@
 // Cert will be located depending on your machine
 // Mac OS X: /Users/user/Library/Application Support/Lnd/tls.cert
-// Linux: ~/.lnd/tls.cert
+// Linux: /home/user/.lnd/tls.cert
 // Windows: TODO find out where cert is located for windows machine
 export default {
   lightningRpc: `${__dirname}/rpc.proto`,


### PR DESCRIPTION
~/.lnd/tls.cert path did not work for tls.cert but /home/user/.lnd/tls.cert did