### PR TITLE
Escape space in Mac Lnd/ path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ After the repo is cloned, you'll want to generate a Node.js compatible cert
 # For Linux
 $ cd ~/.lnd
 # For Mac
-$ cd /Users/{your_user_name}/Library/Application Support/Lnd
+$ cd ~/Library/Application\ Support/Lnd
 # For Windows
 $ cd \Users\{your_user_name}\AppData\Local\Lnd
 


### PR DESCRIPTION
This makes a small change to the README to escape the space in the path to `Lnd/`. It also parallels the Linux path and leverages the tilde to reference the home directory.