### PR TITLE
Format ticker USD price with dollar symbol and two decimal places

### DIFF
--- a/app/routes/app/components/components/Nav.js
+++ b/app/routes/app/components/components/Nav.js
@@ -6,7 +6,7 @@ import { MdAccountBalanceWallet } from 'react-icons/lib/md'
 import { FaClockO, FaDollar } from 'react-icons/lib/fa'
 import CryptoIcon from '../../../../components/CryptoIcon'
 import CurrencyIcon from '../../../../components/CurrencyIcon'
-import { btc } from '../../../../utils'
+import { btc, usd } from '../../../../utils'
 import styles from './Nav.scss'
 
 const Nav = ({ ticker, balance, setCurrency, formClicked, currentTicker }) => (
@@ -14,7 +14,7 @@ const Nav = ({ ticker, balance, setCurrency, formClicked, currentTicker }) => (
     <ul className={styles.info}>
       <li className={`${styles.currencies} ${styles.link}`}>
         <span
-          data-hint={currentTicker ? currentTicker.price_usd : null}
+          data-hint={currentTicker ? usd.formatUsd(currentTicker.price_usd) : null}
           className={`${styles.currency} ${ticker.currency === ticker.crypto ? styles.active : ''} hint--bottom`}
           onClick={() => setCurrency(ticker.crypto)}
         >

--- a/app/utils/usd.js
+++ b/app/utils/usd.js
@@ -1,3 +1,7 @@
+export function formatUsd(usd) {
+  return `$${(+usd).toFixed(2)}`
+}
+
 export function usdToBtc(usd, rate) {
   if (usd === undefined || usd === null || usd === '') return null
 
@@ -5,5 +9,6 @@ export function usdToBtc(usd, rate) {
 }
 
 export default {
+  formatUsd,
   usdToBtc
 }

--- a/test/utils/usd.spec.js
+++ b/test/utils/usd.spec.js
@@ -1,0 +1,30 @@
+import {
+  formatUsd,
+  usdToBtc
+} from '../../app/utils/usd'
+
+describe('usd', () => {
+  describe('formatUsd', () => {
+    it('should handle a string value', () => {
+      expect(formatUsd('42.0')).toBe('$42.00')
+    })
+
+    it('should handle a numerical value', () => {
+      expect(formatUsd(42.0)).toBe('$42.00')
+    })
+
+    it('should round to two decimal places', () => {
+      expect(formatUsd('42.416')).toBe('$42.42')
+    })
+  })
+
+  describe('usdToBtc', () => {
+    it('should convert USD to BTC using rate', () => {
+      expect(usdToBtc(1, 50)).toBe('0.02000000')
+    })
+
+    it('should round to eight decimal places', () => {
+      expect(usdToBtc(2, 3)).toBe('0.66666667')
+    })
+  })
+})


### PR DESCRIPTION
This adds a utility for formatting a USD price so that it includes the dollar symbol and two decimal places. It uses this utility to format the ticker USD price.

Note: This was primarily an exercise in familiarizing. It may be worthwhile to leverage something like [accounting](https://github.com/openexchangerates/accounting.js) to do this sort of thing. This would [also handle](https://github.com/openexchangerates/accounting.js/commit/9d65e654a7cd4db0248bbeb99388642b3517f8fb) the native [toFixed rounding issue](https://stackoverflow.com/questions/10015027/javascript-tofixed-not-rounding).

Before:

![screen shot 2017-09-05 at 12 26 46 am](https://user-images.githubusercontent.com/2092395/30045712-d5bbd2b6-91d3-11e7-815a-9751fc7ded3a.png)

After:

![screen shot 2017-09-05 at 12 23 09 am](https://user-images.githubusercontent.com/2092395/30045719-dd4d24a8-91d3-11e7-8a32-3772894a42d2.png)

