### PR TITLE
Generate witness addresses instead of p2pkh.

### DIFF
--- a/app/components/Wallet/ReceiveModal.js
+++ b/app/components/Wallet/ReceiveModal.js
@@ -64,7 +64,7 @@ const ReceiveModal = ({ isOpen, hideActivityModal, pubkey, address, newAddress, 
         <section>
           <div className={styles.addressHeader}>
             <h4>Deposit Address</h4>
-            <span className={styles.newAddress} onClick={() => newAddress('p2pkh')}>New Address</span>
+            <span className={styles.newAddress} onClick={() => newAddress('np2wkh')}>New Address</span>
           </div>
           <p>
             <span>{address}</span>

--- a/app/routes/app/components/App.js
+++ b/app/routes/app/components/App.js
@@ -14,7 +14,7 @@ class App extends Component {
     fetchTicker()
     fetchBalance()
     fetchInfo()
-    newAddress('p2pkh')
+    newAddress('np2wkh')
   }
 
   render() {


### PR DESCRIPTION
lnd requires inputs to funding transactions to spend from pay-to-witness outputs.