### PR TITLE
Fix that Channels was not passing down closeChannel to Channel

### DIFF
--- a/app/components/Channels/Channels.js
+++ b/app/components/Channels/Channels.js
@@ -29,7 +29,7 @@ const Channels = ({
     // store event in icon so we dont get an error when react clears it
     const icon = event.currentTarget
 
-    // fetch channels 
+    // fetch channels
     fetchChannels()
 
     // clear animation after the second so we can reuse it
@@ -108,6 +108,7 @@ const Channels = ({
                   channel={channel}
                   setChannel={setChannel}
                   currentTicker={currentTicker}
+                  closeChannel={closeChannel}
                 />
               )
             })


### PR DESCRIPTION
This prop is required, so this fixes a warning and potential bad behavior if "Close Channel" is clicked while the prop is null.

Note channel closing may already be possible via ChannelModal closeChannel.