### PR TITLE
Fix that lnd might not be detected on Mac OS due to misaligned `ps` output

### DIFF
--- a/app/lib/lnd/util.js
+++ b/app/lib/lnd/util.js
@@ -187,7 +187,7 @@ export const createMacaroonCreds = async macaroonPath => {
 export const isLndRunning = () => {
   return new Promise((resolve, reject) => {
     mainLog.info('Looking for existing lnd process')
-    lookup({ command: 'lnd' }, (err, results) => {
+    lookup({ command: 'lnd', psargs: 'x -o pid,command' }, (err, results) => {
       // There was an error checking for the LND process.
       if (err) {
         return reject(err)


### PR DESCRIPTION
On mac, the ps output can be misaligned which prevents lnd from being detected, e.g. when some VSZ field is longer than expected.

The default ps-node lookup is via ps lx, which includes:

```
  -l Display information associated with the following keywords:
    uid, pid, ppid, flags, cpu, pri, nice, vsz=SZ, rss, wchan,
    state=S, paddr=ADDR, tty, time, and command=CMD.
```

Here's some example misaligned output from `ps lx`

```
  501 19344     1   0   4  0  4376668   1804 -      S      ??    0:01.23 /System/Library/PrivateFrameworks/IMDPersistence.framework/IMAutomaticHistoryDeletionAgent.a
  501 33800     1   0   4  0 21481005020 172224 -      S      ??    1:35.79 /Applications/GitX.app/Contents/MacOS/GitX
  501 34520     1   0   4  0  4453292   3568 -      S      ??    0:04.03 /System/Library/CoreServices/navd
  501 34689   352   0  31  0  5668268  43616 -      S      ??    2:01.09 /Applications/Slack.app/Contents/Frameworks/Slack Helper.app/Contents/MacOS/Slack Helper --t
```

Many of these fields are unnecessary because we're looking up by name only,
so we can lookup using only the `-o pid,command` output.

https://github.com/neekey/table-parser/issues/11
https://github.com/neekey/ps/pull/64