### PR TITLE
Error message enhancements

### DIFF
--- a/app/components/GlobalError/GlobalError.js
+++ b/app/components/GlobalError/GlobalError.js
@@ -3,16 +3,20 @@ import PropTypes from 'prop-types'
 import { MdClose } from 'react-icons/lib/md'
 import styles from './GlobalError.scss'
 
-const GlobalError = ({ error, clearError }) => (
-  <div className={`${styles.container} ${!error && styles.closed}`}>
-    <div className={styles.content}>
-      <div className={styles.close} onClick={clearError}>
-        <MdClose />
+const GlobalError = ({ error, clearError }) => {
+  setTimeout(clearError, 10000)
+
+  return (
+    <div className={`${styles.container} ${!error && styles.closed}`}>
+      <div className={styles.content}>
+        <div className={styles.close} onClick={clearError}>
+          <MdClose />
+        </div>
+        <h2>{error}</h2>
       </div>
-      <h2>{error}</h2>
     </div>
-  </div>
-)
+  )
+}
 
 
 GlobalError.propTypes = {

--- a/app/components/GlobalError/GlobalError.scss
+++ b/app/components/GlobalError/GlobalError.scss
@@ -24,12 +24,17 @@
 
     .close {
       position: absolute;
-      top: calc(50% - 8px);
+      top: 50%;
       right: 10%;
+      transform: translateY(-50%);
       cursor: pointer;
+      font-size: 2rem;
     }
 
     h2 {
+      max-width: 75%;
+      margin-left: auto;
+      margin-right: auto;
       font-size: 20px;
       letter-spacing: 1.5px;
       font-weight: bold;


### PR DESCRIPTION
Solves #138 and #136 

`clearError` is automatically called after 10 seconds.
Styles were adjusted so that close icon is more visible and error message does not overflow over it.