### PR TITLE
Bring CI runtime down from ~19 to ~13 minutes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,5 +36,4 @@ before_script:
   - sleep 3
 
 script:
-  - node --version
   - "yarn $TEST"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ env:
   - TEST=test-ci
 
 node_js:
+  - node
   - 8
-  - 7
 
 cache:
   yarn: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ cache:
   yarn: true
   directories:
     - node_modules
+    - flow-typed
     - app/node_modules
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ node_js:
   - 8
 
 cache:
+  apt: true
   yarn: true
   directories:
     - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ sudo: false
 
 language: node_js
 
+env:
+  - TEST=lint-ci
+  - TEST=test-ci
+
 node_js:
   - 8
   - 7
@@ -36,7 +40,4 @@ before_script:
 
 script:
   - node --version
-  - yarn lint
-  - yarn package
-  - yarn test
-  - yarn test-e2e
+  - "yarn $TEST"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,17 +19,13 @@ cache:
 
 addons:
   apt:
-    sources:
-      - ubuntu-toolchain-r-test
     packages:
-      - g++-4.8
       - icnsutils
       - graphicsmagick
       - xz-utils
       - xorriso
 
 install:
-  - export CXX="g++-4.8"
   - yarn
   - cd app && yarn && cd ..
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "flow-typed": "rimraf flow-typed/npm && flow-typed install --overwrite || true",
     "lint": "eslint --cache --format=node_modules/eslint-formatter-pretty .",
     "lint-fix": "npm run lint -- --fix",
+    "lint-ci": "npm run lint && npm run flow",
     "lint-styles": "stylelint app/*.css app/components/*.css --syntax scss",
     "lint-styles-fix": "stylefmt -r app/*.css app/components/*.css",
     "package": "npm run build && build --publish never",
@@ -27,6 +28,7 @@
     "test": "cross-env NODE_ENV=test BABEL_DISABLE_CACHE=1 node --trace-warnings ./test/runTests.js",
     "test-all": "npm run lint && npm run flow && npm run build && npm run test && npm run test-e2e",
     "test-e2e": "cross-env NODE_ENV=test BABEL_DISABLE_CACHE=1 node --trace-warnings ./test/runTests.js e2e",
+    "test-ci": "npm run package && npm run test && npm run test-e2e",
     "test-watch": "npm test -- --watch",
     "install-grpc": "cd app && npm run install-grpc"
   },


### PR DESCRIPTION
This parallelizes the lint and test efforts, and caches more of the setup results, most notably apt.

Note this also changes the tests to cover Node 8 & 9 rather than 7 & 8, and relies on the default build environment on Travis rather than setting up g++ 4.8 from the ubuntu dev sources.