### PR TITLE
Drop node 7 support, declare minimum versions in package.json

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,7 @@
   "presets": [
     ["env", {
       "targets": {
-        "node": 7,
+        "node": 8,
         "browsers": "electron 1.7"
       },
       "useBuiltIns": true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ env:
   - TEST=test-ci
 
 node_js:
+  - node
   - 8
-  - 7
 
 cache:
   apt: true

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Join us on [slack](https://join.slack.com/t/zaphq/shared_invite/enQtMjkyNTAxNDA3
 
 ## Requirements
 
-* **Node.js version >= 7, npm version >= 4 and [yarn](https://yarnpkg.com/lang/en/docs/install/)**
+* **Node.js version >= 8, npm version >= 5 and [yarn](https://yarnpkg.com/lang/en/docs/install/)**
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
     "install-grpc": "cd app && npm run install-grpc"
   },
   "browserslist": "electron 1.7",
+  "engines": {
+    "node": ">=8.0.0",
+    "npm": ">=5.0.0"
+  },
   "build": {
     "productName": "ZapDesktop",
     "appId": "org.develar.ZapDesktop",


### PR DESCRIPTION
Node 7 was a dev release and is defunct now that 8 is LTS and 9 is the
current dev release. If we wanted to support earlier versions, we should
go all the way back to the prior LTS release series, 6, but I don't see
a reason to do that for new software.

Bump to npm 5 because that is the version that was released with node 8:
https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V8.md#8.0.0

This was prompted by the fact that current versions of yarn have dropped node 7
support.
https://yarnpkg.com/en/