### PR TITLE
enhance(peer-form): auto fill host if pasted pubkey contains host inf…

### DIFF
--- a/app/components/Peers/PeerForm.js
+++ b/app/components/Peers/PeerForm.js
@@ -10,6 +10,18 @@ const PeerForm = ({ form, setForm, connect }) => {
     connect({ pubkey, host })
   }
 
+  const pubkeyChanged = (pubkey) => {
+    const pubkeyHost = pubkey.match(/(.+)@(.+)/)
+    setForm(Array.isArray(pubkeyHost) ?
+      {
+        pubkey: pubkeyHost[1],
+        host: pubkeyHost[2]
+      }
+      :
+      { pubkey }
+    )
+  }
+
   return (
     <div>
       <ReactModal
@@ -35,7 +47,7 @@ const PeerForm = ({ form, setForm, connect }) => {
               size=''
               placeholder='Public key'
               value={form.pubkey}
-              onChange={event => setForm({ pubkey: event.target.value })}
+              onChange={event => pubkeyChanged(event.target.value)}
               id='pubkey'
             />
           </section>


### PR DESCRIPTION
PeerForm: Auto fill host if pasted pubkey contains host information

If pasted pubkey is in the form of \<pubkey\>@\<host\> the string will be splitted and the pubkey and host will be set accordingly.
This simplifies adding new peers since most pages use the format \<pubkey\>@\<host\> to publish their lightning node information.
  