### PR TITLE
Drop ineffectual nodeintegration electron setting

### DIFF
--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -82,7 +82,6 @@ app.on('ready', async () => {
   mainWindow = new BrowserWindow({
     show: false,
     frame: false,
-    nodeIntegration: false,
     icon: icon
   })
 


### PR DESCRIPTION
The actual nodeintegration setting is nested under webPreferences:
https://github.com/electron/electron/blob/master/docs/api/browser-window.md#new-browserwindowoptions

If you set it there, Zap doesn't run, because process is no longer available in
app.html. Use of process in app.html is a barrier to other security settings -
sandbox and contextIsolation.
https://github.com/electron/electron/blob/master/docs/tutorial/security.md#checklist