### PR TITLE
Move PayForm amount error message below the field

### DIFF
--- a/app/components/Form/PayForm.js
+++ b/app/components/Form/PayForm.js
@@ -49,11 +49,6 @@ class PayForm extends Component {
         {showPayLoadingScreen && <LoadingBolt />}
 
         <section className={`${styles.amountContainer} ${isLn ? styles.ln : ''} ${showErrors.amount && styles.error}`}>
-          <section className={`${styles.amountError} ${showErrors.amount && styles.active}`}>
-            {showErrors.amount &&
-              <span>{errors.amount}</span>
-            }
-          </section>
           <label htmlFor='amount'>
             <CurrencyIcon currency={currency} crypto={crypto} />
           </label>
@@ -74,6 +69,11 @@ class PayForm extends Component {
             id='amount'
             readOnly={isLn}
           />
+        </section>
+        <section className={`${styles.errorMessage} ${showErrors.amount && styles.active}`}>
+          {showErrors.amount &&
+            <span>{errors.amount}</span>
+          }
         </section>
         <div className={styles.inputContainer}>
           <div className={styles.info}>
@@ -103,7 +103,7 @@ class PayForm extends Component {
               id='paymentRequest'
             />
           </section>
-          <section className={`${styles.payInputError} ${showErrors.payInput && styles.active}`}>
+          <section className={`${styles.errorMessage} ${showErrors.payInput && styles.active}`}>
             {showErrors.payInput &&
               <span>{errors.payInput}</span>
             }

--- a/app/components/Form/PayForm.scss
+++ b/app/components/Form/PayForm.scss
@@ -14,8 +14,6 @@
   color: $main;
   display: flex;
   justify-content: center;
-  min-height: 120px;
-  margin-bottom: 20px;
   min-height: 175px;
   border-bottom: 1px solid transparent;
 
@@ -24,22 +22,9 @@
   }
 
   &.error {
-    border-color: $red; 
+    border-color: $red;
   }
 
-  .amountError {
-    position: absolute;
-    top: 0;
-    right: 0;
-    opacity: 0;
-    color: $red;
-    transition: all 0.25s ease;
-
-    &.active {
-      opacity: 1;
-    }
-  }
-  
   label, input[type=number], input[type=text] {
     color: inherit;
     display: inline-block;
@@ -61,7 +46,7 @@
       }
     }
   }
-  
+
   input[type=number], input[type=text] {
     width: 100px;
     font-size: 180px;
@@ -136,7 +121,7 @@
   }
 }
 
-.payInputError {
+.errorMessage {
   margin: 10px 0;
   min-height: 20px;
   color: $red;


### PR DESCRIPTION
This is consistent with the other field and avoids overlap formatting issues.

Fixes #174