### PR TITLE
Size the PayForm amount input to hold at least 2 chars

### DIFF
--- a/app/components/Form/PayForm.js
+++ b/app/components/Form/PayForm.js
@@ -66,7 +66,7 @@ class PayForm extends Component {
               isLn ?
                 { width: '75%', fontSize: '85px' }
                 :
-                { width: `${amount.length > 1 ? (amount.length * 20) - 5 : 25}%`, fontSize: `${190 - (amount.length ** 2)}px` }
+                { width: `${amount.length > 1 ? (amount.length * 20) - 5 : 35}%`, fontSize: `${190 - (amount.length ** 2)}px` }
             }
             value={currentAmount}
             onChange={event => setPayAmount(event.target.value)}


### PR DESCRIPTION
Because the "." of "0." is not propagated via the JS, so not in the size of
the amount string.