### PR TITLE
fix(network-loading-css): Increase z-index on Form modal

### DIFF
--- a/app/components/Form/Form.scss
+++ b/app/components/Form/Form.scss
@@ -13,7 +13,7 @@
 
   &.open {
     opacity: 1;
-    z-index: 10;
+    z-index: 20;
   }
 }
 


### PR DESCRIPTION
Fix for Issue [#180](https://github.com/LN-Zap/zap-desktop/issues/180).

When the Network tab is first opened the loader appears and has a z-index of 10. If the Pay or Request button is clicked, the form modal opens and the loader from the Network tab is still somewhat visible. This is because the form modal also has a z-index of 10.

This minor fix ups the z-index of the form modal from 10 to 20.

Generally I've done increments of 10 (0-100) or 100 (0-1000) for z-index, to keep the scale manageable. I noticed there were a few other 10s so I keep the increase to a 10 increment.

Awesome project, hope I can help out along the way!