### PR TITLE
Enable our eslint plugins, which are currently inactive

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -33,7 +33,7 @@ app/node_modules
 
 # flow-typed
 flow-typed/npm/*
-!flow-typed/npm/module_vx.x.x.js
+flow-typed/module_vx.x.x.js
 
 # App packaged
 release

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,10 @@
     "sourceType": "module",
     "allowImportExportEverywhere": true
   },
-  "extends": "airbnb",
+  "extends": [
+    "airbnb",
+    "plugin:react/recommended"
+  ],
   "env": {
     "browser": true,
     "node": true

--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,8 @@
   },
   "extends": [
     "airbnb",
-    "plugin:react/recommended"
+    "plugin:react/recommended",
+    "plugin:flowtype/recommended"
   ],
   "env": {
     "browser": true,

--- a/.eslintrc
+++ b/.eslintrc
@@ -34,7 +34,8 @@
     "react/require-default-props": 0,
     "max-len": ["error", 150],
     "import/no-extraneous-dependencies": 0,
-    "no-new": 0
+    "no-new": 0,
+    "compat/compat": "error"
   },
   "plugins": [
     "flowtype",

--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,8 @@
     "plugin:react/recommended",
     "plugin:flowtype/recommended",
     "plugin:import/errors",
-    "plugin:import/warnings"
+    "plugin:import/warnings",
+    "plugin:jsx-a11y/strict"
   ],
   "env": {
     "browser": true,

--- a/.eslintrc
+++ b/.eslintrc
@@ -36,7 +36,9 @@
     "max-len": ["error", 150],
     "import/no-extraneous-dependencies": 0,
     "no-new": 0,
-    "compat/compat": "error"
+    "compat/compat": "error",
+    "flowtype-errors/show-errors": "error",
+    "flowtype-errors/enforce-min-coverage": ["error", 20]
   },
   "plugins": [
     "flowtype",

--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,8 @@
     "plugin:flowtype/recommended",
     "plugin:import/errors",
     "plugin:import/warnings",
-    "plugin:jsx-a11y/strict"
+    "plugin:jsx-a11y/strict",
+    "plugin:promise/recommended"
   ],
   "env": {
     "browser": true,

--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,9 @@
   "extends": [
     "airbnb",
     "plugin:react/recommended",
-    "plugin:flowtype/recommended"
+    "plugin:flowtype/recommended",
+    "plugin:import/errors",
+    "plugin:import/warnings"
   ],
   "env": {
     "browser": true,
@@ -51,7 +53,7 @@
   "settings": {
     "import/resolver": {
       "node": {
-        "paths": ["app", "app/node_modules"]
+        "moduleDirectory": ["app", "app/node_modules", "node_modules"]
       },
       "webpack": {
         "config": "webpack.config.eslint.js"

--- a/app/lnd/lib/lightning.js
+++ b/app/lnd/lib/lightning.js
@@ -3,10 +3,12 @@ import path from 'path'
 import grpc from 'grpc'
 import config from '../config'
 
-module.exports = (rpcpath, host) => {
+const lightning = (rpcpath, host) => {
   const lndCert = fs.readFileSync(config.cert)
   const credentials = grpc.credentials.createSsl(lndCert)
   const rpc = grpc.load(path.join(__dirname, 'rpc.proto'))
 
   return new rpc.lnrpc.Lightning(host, credentials)
 }
+
+export default { lightning }

--- a/app/notifications/index.js
+++ b/app/notifications/index.js
@@ -1,8 +1,8 @@
-export default {
-  showNotification: (title, body, onClick) => {
-    new Notification(title, {
-      body,
-      onClick
-    })
-  }
+export const showNotification = (title, body, onClick) => {
+  new Notification(title, {
+    body,
+    onClick
+  })
 }
+
+export default { showNotification }

--- a/app/routes.js
+++ b/app/routes.js
@@ -6,7 +6,7 @@ import Activity from './routes/activity'
 import Contacts from './routes/contacts'
 import Network from './routes/network'
 
-export default () => (
+const routes = () => (
   <App>
     <Switch>
       <Route path='/contacts' component={Contacts} />
@@ -15,3 +15,5 @@ export default () => (
     </Switch>
   </App>
 )
+
+export default routes

--- a/app/routes/contacts/components/Contacts.js
+++ b/app/routes/contacts/components/Contacts.js
@@ -148,23 +148,21 @@ class Contacts extends Component {
 
         <ul className={`${styles.friends} ${filterPulldown && styles.fade}`}>
           {
-            loadingChannelPubkeys.map(pubkey => <LoadingContact pubkey={pubkey} isClosing={false} />)
+            loadingChannelPubkeys.map(pubkey => <LoadingContact pubkey={pubkey} isClosing={false} key={pubkey} />)
           }
 
           {
             currentChannels.length > 0 && currentChannels.map((channel, index) => {
               if (closingChannelIds.includes(channel.chan_id)) {
-                return <LoadingContact pubkey={channel.remote_pubkey} isClosing />
+                return <LoadingContact pubkey={channel.remote_pubkey} isClosing key={index} />
               } else if (Object.prototype.hasOwnProperty.call(channel, 'blocks_till_open')) {
                 return <PendingContact channel={channel} key={index} />
               } else if (Object.prototype.hasOwnProperty.call(channel, 'closing_txid')) {
                 return <ClosingContact channel={channel} key={index} />
-              } else if (channel.active) {
-                return <OnlineContact channel={channel} key={index} openContactModal={openContactModal} />
               } else if (!channel.active) {
                 return <OfflineContact channel={channel} key={index} openContactModal={openContactModal} />
               }
-              return <span />
+              return <OnlineContact channel={channel} key={index} openContactModal={openContactModal} />
             })
           }
         </ul>

--- a/app/store/configureStore.dev.js
+++ b/app/store/configureStore.dev.js
@@ -8,7 +8,7 @@ import ipc from '../reducers/ipc'
 
 const history = createHashHistory()
 
-const configureStore = (initialState?: counterStateType) => {
+const configureStore = (initialState) => {
   // Redux Configuration
   const middleware = []
   const enhancers = []

--- a/app/utils/index.js
+++ b/app/utils/index.js
@@ -1,11 +1,4 @@
-import btc from './btc'
-import usd from './usd'
-import bech32 from './bech32'
-import blockExplorer from './blockExplorer'
-
-export default {
-  btc,
-  usd,
-  bech32,
-  blockExplorer
-}
+export btc from './btc'
+export usd from './usd'
+export bech32 from './bech32'
+export blockExplorer from './blockExplorer'

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -5,9 +5,5 @@
   "plugins": [
     "jest"
   ],
-  "rules": {
-    "jest/no-disabled-tests": "warn",
-    "jest/no-focused-tests": "error",
-    "jest/no-identical-title": "error"
-  }
+  "extends": ["plugin:jest/recommended"]
 }


### PR DESCRIPTION
This enables the following extensions:

    "plugin:react/recommended",
    "plugin:flowtype/recommended",
    "plugin:import/errors",
    "plugin:import/warnings",
    "plugin:jsx-a11y/strict",
    "plugin:promise/recommended"

And rules:

    "compat/compat": "error",
    "flowtype-errors/show-errors": "error",
    "flowtype-errors/enforce-min-coverage": ["error", 20]