### PR TITLE
fix(filter-over-modal): Add z-index to open ReactModal Overlay

### DIFF
--- a/app/app.global.scss
+++ b/app/app.global.scss
@@ -192,5 +192,9 @@ body {
   stroke: #88D4A2;
   stroke-width: 15;
   stroke-dasharray: 100;
-  animation: dash 2.5s infinite linear;  
+  animation: dash 2.5s infinite linear;
+}
+
+.ReactModal__Overlay.ReactModal__Overlay--after-open {
+  z-index: 50;
 }


### PR DESCRIPTION
This is related to Issue #193.

I was looking at a better way to track z-indexes as was mentioned in [this comment](https://github.com/LN-Zap/zap-desktop/pull/183#issuecomment-357128547), and came across the bug.

After checking the react-modal issues, their accepted fix was manually adding a z-index to the modal overlay class, see [this react issue](https://github.com/reactjs/react-modal/issues/390). 

Increasing the z-index keeps the modal at the forefront and blocks clicking on the filter dropdown until the modal is closed. I added the update to app.global.scss so that the z-index would be applied to the modal across the app. Doing so seems to fix the issue in all locations where <ReactModal> is used.

Separately, I found some better ways of documenting/tracking the z-index usage via variables. Will hopefully have a PR for that later this week.