### PR TITLE
Feature(z-index-vars): Use function to apply z-index so they can easi…

### DIFF
--- a/app/app.global.scss
+++ b/app/app.global.scss
@@ -196,5 +196,5 @@ body {
 }
 
 .ReactModal__Overlay.ReactModal__Overlay--after-open {
-  z-index: 50;
+  z-index: z("react-modal","open");
 }

--- a/app/components/Contacts/ContactsForm.scss
+++ b/app/components/Contacts/ContactsForm.scss
@@ -11,7 +11,7 @@
   bottom: auto;
   background: $white;
   outline: none;
-  z-index: -2;
+  z-index: z("contact-form","modal");
   border: 1px solid $darkgrey;
   
   header {

--- a/app/components/Form/Form.scss
+++ b/app/components/Form/Form.scss
@@ -7,13 +7,13 @@
   width: 100%;
   height: 100vh;
   background: $white;
-  z-index: 0;
+  z-index: z("form","outter-cont");
   opacity: 0;
   transition: all 0.5s;
 
   &.open {
     opacity: 1;
-    z-index: 20;
+    z-index: z("form","outter-cont-open");
   }
 }
 

--- a/app/components/GlobalError/GlobalError.scss
+++ b/app/components/GlobalError/GlobalError.scss
@@ -2,7 +2,7 @@
 
 .container {
   position: absolute;
-  z-index: 1001;
+  z-index: z("global-error","container");
   background: $red;
   color: $white;
   width: 100%;

--- a/app/components/LoadingBolt/LoadingBolt.scss
+++ b/app/components/LoadingBolt/LoadingBolt.scss
@@ -1,7 +1,7 @@
 @import '../../variables.scss';
 
 .container {
-  z-index: 1000;
+  z-index: z("loading-bolt","container");
   position: absolute;
   top: 0;
   left: 0;

--- a/app/components/ModalRoot/ModalRoot.scss
+++ b/app/components/ModalRoot/ModalRoot.scss
@@ -6,7 +6,7 @@
   left: 0;
   width: 100%;
   height: 100%;
-  z-index: 10;
+  z-index: z("modal-root","container");
   background: #fff;
 }
 

--- a/app/components/Network/CanvasNetworkGraph.scss
+++ b/app/components/Network/CanvasNetworkGraph.scss
@@ -32,7 +32,7 @@
 .loader {
   position: absolute;
   top: 0;
-  z-index: 10;
+  z-index: z("canvas-network","loader");
   width: 50px;
   height: 50px;
   border: 15px solid;
@@ -104,7 +104,7 @@
   border-radius: 50%;
   position: absolute;
   top: 0;
-  z-index: 9;
+  z-index: z("canvas-network","loader-before");
 }
 
 .circular {

--- a/app/routes/activity/components/Activity.scss
+++ b/app/routes/activity/components/Activity.scss
@@ -79,7 +79,7 @@
 				display: block;
 				position: absolute;
 				bottom: -100px;
-				z-index: 10;
+				z-index: z("activity","activities-active");
 
 				li {
 					margin: 5px 0;

--- a/app/routes/contacts/components/Contacts.scss
+++ b/app/routes/contacts/components/Contacts.scss
@@ -123,7 +123,7 @@
       display: block;
       position: absolute;
       bottom: -100px;
-      z-index: 10;
+      z-index: z("contacts","filters-active");
 
       li {
         margin: 5px 0;

--- a/app/tooltip.scss
+++ b/app/tooltip.scss
@@ -9,7 +9,7 @@
   will-change: transform;
   visibility: hidden;
   opacity: 0;
-  z-index: 900005;
+  z-index: z("tooltip","after");
   pointer-events: none;
   transition: 0.2s ease;
   transition-delay: 0ms;
@@ -24,7 +24,7 @@
   position: absolute;
   background: transparent;
   border: 6px solid transparent;
-  z-index: 900006;
+  z-index: z("tooltip","before");
 }
 [data-hint]:after {
   content: attr(data-hint);

--- a/app/variables.scss
+++ b/app/variables.scss
@@ -16,3 +16,67 @@ $red: #FF556A;
 $blue: #007bb6;
 $orange: #FF8A65;
 $curve: cubic-bezier(0.650, 0.000, 0.450, 1.000);
+
+$z-layers: (
+  "activity": (
+    "activities-active":      10,
+  ),
+  "contact-form": (
+    "modal":                 -10,
+  ),
+  "contacts": (
+    "filters-active":         10
+  ),
+  "canvas-network": (
+    "loader":                 20,
+    "loader-before":          10
+  ),
+  "form": (
+    "outter-cont":             0,
+    "outter-cont-open":       30  // Needs to be higher than canvas-network loader
+  ),
+  "global-error": (
+    "container":             100,
+  ),
+  "loading-bolt":  (
+    "container":              90,
+  ),
+  "modal-root": (
+    "container":              10,
+  ),
+  "react-modal": (
+    "open":                   50
+  ),
+  "tooltip": (
+    "after":                 998,
+    "before":                999
+  )
+);
+
+// Functions for pulling z-index values from $z-layers map
+@function z($layer...) {
+  @if not map-has-nested-keys($z-layers, $layer) {
+    @warn "No layer found for `#{$layer}` in $z-layers map. Property omitted.";
+  }
+
+  @return map-deep-get($z-layers, $layer);
+}
+
+@function map-has-nested-keys($map, $keys) {
+  @each $key in $keys {
+    @if not map-has-key($map, $key) {
+      @return false;
+    }
+    $map: map-get($map, $key);
+  }
+
+  @return true;
+}
+
+@function map-deep-get($map, $keys) {
+  @each $key in $keys {
+    $map: map-get($map, $key);
+  }
+
+  @return $map;
+}


### PR DESCRIPTION
…ly be tracked as vars.

Following up on comments from #183, this update uses a function to apply the z-index in each .scss file. The function needs to iterate over a map of z-index values, so all of the z-indexes end up in a single list and can be tracked more easily. 

There are a couple ways of doing this, [a few discussed here](https://www.sitepoint.com/better-solution-managing-z-index-sass/). This approach seemed the best since it allows for scaling with nesting values - where the top level is the component name.

Possible improvements:
- Using _zindex.scss partial to track z-index so that the variables.scss file doesn't get overcrowded. A drawback to this would be having to import the partial into all files that use z-index.
- Use a more descriptive name for the z function? I saw the it used that way a few places and just decided to keep it.