### PR TITLE
Bump to Electron 1.7.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
 node_js:
   - node
   - 8
+  - 7
 
 cache:
   apt: true

--- a/app/package.json
+++ b/app/package.json
@@ -10,8 +10,8 @@
     "url": "https://github.com/LN-Zap/zap-desktop"
   },
   "scripts": {
-    "postinstall": "npm rebuild --runtime=electron --target=1.6.16 --disturl=https://atom.io/download/atom-shell --build-from-source",
-    "install-grpc": "cd node_modules/grpc && git submodule update --init && npm run electron-build -- --target=1.6.16"
+    "postinstall": "npm rebuild --runtime=electron --target=1.7.12 --disturl=https://atom.io/download/atom-shell --build-from-source",
+    "install-grpc": "cd node_modules/grpc && git submodule update --init && npm run electron-build -- --target=1.7.12"
   },
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,10 +32,15 @@
     "test-watch": "npm test -- --watch",
     "install-grpc": "cd app && npm run install-grpc"
   },
-  "browserslist": "electron 1.6",
+  "browserslist": "electron 1.7",
   "engines": {
-    "node": ">=8.0.0",
-    "npm": ">=5.0.0"
+    "node": ">=7.9.0",
+    "npm": ">=4.2.0"
+  },
+  "devEngines": {
+    "node": ">=7.9.x",
+    "npm": ">=4.2.x",
+    "yarn": ">=0.21.3"
   },
   "build": {
     "productName": "Zap",
@@ -208,7 +213,7 @@
     "d3-selection": "^1.2.0",
     "d3-zoom": "^1.7.1",
     "devtron": "^1.4.0",
-    "electron": "1.6.16",
+    "electron": "1.7.12",
     "electron-debug": "^1.2.0",
     "font-awesome": "^4.7.0",
     "history": "^4.6.3",
@@ -233,11 +238,6 @@
     "satoshi-bitcoin": "^1.0.4",
     "source-map-support": "^0.4.15",
     "xtend": "^4.0.1"
-  },
-  "devEngines": {
-    "node": ">=7.x",
-    "npm": ">=4.x",
-    "yarn": ">=0.21.3"
   },
   "main": "webpack.config.base.js",
   "directories": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3226,9 +3226,9 @@ electron-to-chromium@^1.3.30:
   dependencies:
     electron-releases "^2.1.0"
 
-electron@1.6.16:
-  version "1.6.16"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.6.16.tgz#f37a8f49cc2625059c99eb266dee4dffe0917b63"
+electron@1.7.12:
+  version "1.7.12"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.12.tgz#dcc61a2c1b0c3df25f68b3425379a01abd01190e"
   dependencies:
     "@types/node" "^7.0.18"
     electron-download "^3.0.1"


### PR DESCRIPTION
It turns out Electron 1.7 is based on Node 7.9.0 [1] I moved the engines /
devEngines limits for node and npm down to the associated versions. The theory
is we should lift them when we adopt Electron 1.8, which is in beta now and
based on Node 8.2.1 [2]

[1] https://github.com/electron/electron/releases/tag/v1.7.0
[2] https://github.com/electron/electron/releases/tag/v1.8.1