### PR TITLE
Fix/activity header selection and hitbox area

### DIFF
--- a/app/routes/activity/components/Activity.scss
+++ b/app/routes/activity/components/Activity.scss
@@ -45,6 +45,7 @@
 	  .filters {
 	  	display: flex;
 	  	flex-direction: row;
+			user-select: none;
 
 	  	li {
 	  		position: relative;

--- a/app/routes/activity/components/Activity.scss
+++ b/app/routes/activity/components/Activity.scss
@@ -49,11 +49,9 @@
 
 	  	li {
 	  		position: relative;
-	  		margin: 0 15px;
 	  		opacity: 0.5;
 	  		font-size: 14px;
 	  		cursor: pointer;
-	  		padding: 20px 0;
 
 	  		&.activeFilter {
 	  			opacity: 1;
@@ -62,10 +60,19 @@
 	  		&:nth-child(1) {
 	  			margin-left: 0;
 	  		}
+
+				span {
+					display: block;
+					position: relative;
+					margin: 0 15px;
+					padding: 20px 0;
+				}
 	  	}
 
 	  	.activeBorder {
-				width: 100%;
+				left: 15px;
+				right: 15px;
+				width: auto;
 				height: 1px;
 				background: white;
 				position: absolute;


### PR DESCRIPTION
Fixes:
- activity header selection (disabled with css)
- activity header hitbox size (what used to be margin is now clickable, graphics unchanged)