### PR TITLE
Bump to grpc 1.10.0

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -15,7 +15,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "grpc": "1.7.1",
+    "grpc": "1.10.0",
     "ps-node": "^0.1.6",
     "react-icons": "^2.2.5"
   }

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -28,10 +28,6 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
-arguejs@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/arguejs/-/arguejs-0.2.3.tgz#b6f939f5fe0e3cd1f3f93e2aa9262424bf312af7"
-
 asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
@@ -297,11 +293,10 @@ graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
-grpc@1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.7.1.tgz#a1eecd074e78ffe5bb3bb64dcc7417d14fdb5cc4"
+grpc@1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.10.0.tgz#a3bab7f7e6b37727c5a6eb8427fc58775823edce"
   dependencies:
-    arguejs "^0.2.3"
     lodash "^4.15.0"
     nan "^2.0.0"
     node-pre-gyp "^0.6.39"


### PR DESCRIPTION
The impetus is to improve error reporting for GRPC connection errors,
which was introduced in 1.8.4. Security and other fixes are included
as well.
https://github.com/grpc/grpc-node/releases/tag/v1.8.4

Here's an example of the new `emitStatusIfDone` error reporting:
<img width="433" alt="screen shot 2018-03-10 at 1 27 28 pm" src="https://user-images.githubusercontent.com/5470/37246928-4908df5e-2467-11e8-8080-be0d6aa55bce.png">

This error is commonly reported so additional info could be helpful: #236 #141 #234 #254 #207 #247 #324