### PR TITLE
Make LND errors visible to users via a message box

### DIFF
--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -10,7 +10,7 @@
  *
  *
  */
-import { app, BrowserWindow, ipcMain } from 'electron'
+import { app, BrowserWindow, ipcMain, dialog } from 'electron'
 import path from 'path'
 import fs from 'fs'
 import { spawn } from 'child_process'
@@ -159,7 +159,13 @@ const startLnd = (alias, autopilot) => {
   ]
 
   const neutrino = spawn(lndConfig.lndPath, neutrinoArgs)
-    .on('error', error => console.log(`lnd error: ${error}`))
+    .on('error', (error) => {
+      console.log(`lnd error: ${error}`)
+      dialog.showMessageBox({
+        type: 'error',
+        message: `lnd error: ${error}`
+      })
+    })
     .on('close', code => console.log(`lnd shutting down ${code}`))
 
   // Listen for when neutrino prints out data

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -166,7 +166,10 @@ const startLnd = (alias, autopilot) => {
         message: `lnd error: ${error}`
       })
     })
-    .on('close', code => console.log(`lnd shutting down ${code}`))
+    .on('close', (code) => {
+      console.log(`lnd shutting down ${code}`)
+      app.quit()
+    })
 
   // Listen for when neutrino prints out data
   neutrino.stdout.on('data', (data) => {


### PR DESCRIPTION
This ensures the user can see the error, and that Zap will not be running if LND quits.