### PR TITLE
Configure defaultremotedelay to match c-lightning, etc.

### DIFF
--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -151,6 +151,7 @@ const startLnd = (alias, autopilot) => {
   const neutrinoArgs = [
     '--bitcoin.active',
     '--bitcoin.testnet',
+    '--bitcoin.defaultremotedelay=432',
     '--bitcoin.node=neutrino',
     '--neutrino.connect=188.166.148.62:18333',
     '--neutrino.addpeer=btcd.jackmallers.com:18333',


### PR DESCRIPTION
Absent this, attempts to open channels with c-lightning nodes fail with:
"to_self_delay X greater than 432"

https://github.com/lightningnetwork/lnd/pull/788
https://github.com/ElementsProject/lightning/issues/1110