### PR TITLE
Update list of supported cipher suites for compatibility with lnd 0.4.0

### DIFF
--- a/app/lnd/lib/lightning.js
+++ b/app/lnd/lib/lightning.js
@@ -3,6 +3,21 @@ import path from 'path'
 import grpc from 'grpc'
 import config from '../config'
 
+// Default is ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384
+// https://github.com/grpc/grpc/blob/master/doc/environment_variables.md
+//
+// Current LND cipher suites here:
+// https://github.com/lightningnetwork/lnd/blob/master/lnd.go#L80
+//
+// We order the suites by priority, based on the recommendations provided by SSL Labs here:
+// https://github.com/ssllabs/research/wiki/SSL-and-TLS-Deployment-Best-Practices#23-use-secure-cipher-suites
+process.env.GRPC_SSL_CIPHER_SUITES = process.env.GRPC_SSL_CIPHER_SUITES || [
+  'ECDHE-ECDSA-AES128-GCM-SHA256',
+  'ECDHE-ECDSA-AES256-GCM-SHA384',
+  'ECDHE-ECDSA-AES128-CBC-SHA256',
+  'ECDHE-ECDSA-CHACHA20-POLY1305'
+].join(':')
+
 const lightning = (rpcpath, host) => {
   const lndCert = fs.readFileSync(config.cert)
   const credentials = grpc.credentials.createSsl(lndCert)


### PR DESCRIPTION
Update the list of supported cipher suites to use with openssl to
include those supported by lnd, which are defined as:

tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305

See https://github.com/lightningnetwork/lnd/blob/master/lnd.go#L80-L85

Fix #324