### PR TITLE
Show the connected peers at the top of the Add Channel list by default

### DIFF
--- a/app/routes/app/components/App.js
+++ b/app/routes/app/components/App.js
@@ -24,7 +24,8 @@ class App extends Component {
       newAddress,
       fetchChannels,
       fetchBalance,
-      fetchDescribeNetwork
+      fetchDescribeNetwork,
+      fetchPeers
     } = this.props
 
     // fetch price ticker
@@ -39,6 +40,7 @@ class App extends Component {
     fetchBalance()
     // fetch LN network from nides POV
     fetchDescribeNetwork()
+    fetchPeers()
   }
 
   render() {
@@ -118,6 +120,7 @@ App.propTypes = {
   fetchChannels: PropTypes.func.isRequired,
   fetchBalance: PropTypes.func.isRequired,
   fetchDescribeNetwork: PropTypes.func.isRequired,
+  fetchPeers: PropTypes.func.isRequired,
 
   children: PropTypes.object.isRequired
 }

--- a/app/routes/app/containers/AppContainer.js
+++ b/app/routes/app/containers/AppContainer.js
@@ -23,6 +23,8 @@ import { createInvoice, fetchInvoice } from 'reducers/invoice'
 
 import { fetchBlockHeight, lndSelectors } from 'reducers/lnd'
 
+import { fetchPeers } from 'reducers/peers'
+
 import {
   fetchChannels,
   openChannel,
@@ -89,6 +91,7 @@ const mapDispatchToProps = {
 
   fetchBalance,
 
+  fetchPeers,
   fetchChannels,
   openChannel,
   closeChannel,


### PR DESCRIPTION
These we have an active connection with so are most likely to result in successful channel opening