### PR TITLE
Exclude expired requests and funding transactions from 'All'

### DIFF
--- a/app/reducers/activity.js
+++ b/app/reducers/activity.js
@@ -174,12 +174,18 @@ const allActivity = createSelector(
   (searchText, payments, invoices, transactions) => {
     let result = [...payments, ...invoices, ...transactions]
     if (searchText) {
+      // exclude transaction not matching search
       result = result.filter(tx => (
         (tx.tx_hash && tx.tx_hash.includes(searchText)) ||
         (tx.payment_hash && tx.payment_hash.includes(searchText)) ||
         (tx.payment_request && tx.payment_request.includes(searchText))
       ))
     }
+
+    result = result.filter(tx => (
+      // exclude expired transaction
+      !Object.prototype.hasOwnProperty.call(tx, 'expiry') || !invoiceExpired(tx)
+    ))
 
     if (!result.length) { return [] }
 

--- a/app/reducers/activity.js
+++ b/app/reducers/activity.js
@@ -1,4 +1,5 @@
 import { createSelector } from 'reselect'
+import { channelsSelectors } from 'reducers/channels'
 
 // ------------------------------------
 // Initial State
@@ -171,7 +172,8 @@ const allActivity = createSelector(
   paymentsSelector,
   invoicesSelector,
   transactionsSelector,
-  (searchText, payments, invoices, transactions) => {
+  channelsSelectors.fundingTxIdsSelector,
+  (searchText, payments, invoices, transactions, fundingTxIds) => {
     let result = [...payments, ...invoices, ...transactions]
     if (searchText) {
       // exclude transaction not matching search
@@ -184,7 +186,9 @@ const allActivity = createSelector(
 
     result = result.filter(tx => (
       // exclude expired transaction
-      !Object.prototype.hasOwnProperty.call(tx, 'expiry') || !invoiceExpired(tx)
+      (!Object.prototype.hasOwnProperty.call(tx, 'expiry') || !invoiceExpired(tx)) &&
+      // exclude funding transactions
+      (!Object.prototype.hasOwnProperty.call(tx, 'tx_hash') || !fundingTxIds.includes(tx.tx_hash))
     ))
 
     if (!result.length) { return [] }
@@ -193,7 +197,7 @@ const allActivity = createSelector(
   }
 )
 
-const invoiceActivity = createSelector(
+const requestedActivity = createSelector(
   invoicesSelector,
   invoices => groupAll(invoices)
 )
@@ -212,7 +216,7 @@ const pendingActivity = createSelector(
 const FILTERS = {
   ALL_ACTIVITY: allActivity,
   SENT_ACTIVITY: sentActivity,
-  REQUESTED_ACTIVITY: invoiceActivity,
+  REQUESTED_ACTIVITY: requestedActivity,
   PENDING_ACTIVITY: pendingActivity
 }
 

--- a/app/reducers/activity.js
+++ b/app/reducers/activity.js
@@ -172,19 +172,18 @@ const allActivity = createSelector(
   invoicesSelector,
   transactionsSelector,
   (searchText, payments, invoices, transactions) => {
-    const searchedArr = [...payments, ...invoices, ...transactions].filter((tx) => {
-      if ((tx.tx_hash && tx.tx_hash.includes(searchText)) ||
-          (tx.payment_hash && tx.payment_hash.includes(searchText)) ||
-          (tx.payment_request && tx.payment_request.includes(searchText))) {
-        return true
-      }
+    let result = [...payments, ...invoices, ...transactions]
+    if (searchText) {
+      result = result.filter(tx => (
+        (tx.tx_hash && tx.tx_hash.includes(searchText)) ||
+        (tx.payment_hash && tx.payment_hash.includes(searchText)) ||
+        (tx.payment_request && tx.payment_request.includes(searchText))
+      ))
+    }
 
-      return false
-    })
+    if (!result.length) { return [] }
 
-    if (!searchedArr.length) { return [] }
-
-    return groupAll(searchedArr)
+    return groupAll(result)
   }
 )
 

--- a/app/reducers/channels.js
+++ b/app/reducers/channels.js
@@ -448,6 +448,13 @@ channelsSelectors.channelNodes = createSelector(
   }
 )
 
+channelsSelectors.fundingTxIdsSelector = createSelector(
+  channelsSelector,
+  channels => (
+    channels.map(channel => channel.channel_point.split(':')[0])
+  )
+)
+
 const allChannels = createSelector(
   channelsSelectors.activeChannels,
   channelsSelectors.nonActiveChannels,


### PR DESCRIPTION
So this contradicts the naming 'All', but I would argue these two activity types are relatively unhelpful to the user and deserve to be separated out.

"The theory being that channel funding is relevant to the
building of the network, but more of an implementation
detail than a classic user-relevant data-point."