### PR TITLE
Generate code coverage reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 coverage
+.coveralls.yml
 
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 [![dependencies Status](https://david-dm.org/LN-Zap/zap-desktop/status.svg)](https://david-dm.org/LN-Zap/zap-desktop)
 [![Build Status](https://travis-ci.org/LN-Zap/zap-desktop.svg?branch=master)](https://travis-ci.org/LN-Zap/zap-desktop)
+[![Coverage Status](https://coveralls.io/repos/github/LN-Zap/zap-desktop/badge.svg?branch=master)](https://coveralls.io/github/LN-Zap/zap-desktop?branch=master)
 [![GitHub license](https://img.shields.io/github/license/LN-Zap/zap-desktop.svg)](LICENSE)
 
 Zap is a free Lightning Network wallet focused on user experience and ease of use, with the overall goal of helping the cryptocurrency community scale Bitcoin and other cryptocurrencies.

--- a/package.json
+++ b/package.json
@@ -31,10 +31,11 @@
     "start-main-dev": "cross-env HOT=1 NODE_ENV=development electron -r babel-register ./app/main.dev",
     "start-renderer-dev": "node --trace-warnings -r babel-register ./node_modules/.bin/webpack-serve --config webpack.config.renderer.dev.js",
     "test": "cross-env NODE_ENV=test BABEL_DISABLE_CACHE=1 node --trace-warnings ./test/runTests.js",
-    "test-ci": "npm run package && npm run test && npm run test-e2e",
-    "test-all": "npm run lint && npm run lint-styles && npm run flow && npm run build && npm run test && npm run test-e2e",
+    "test-ci": "npm run package && npm run test-e2e && npm run test && npm run coveralls",
+    "test-all": "npm run lint && npm run lint-styles && npm run flow && npm run build && npm run test-e2e && npm run test",
     "test-e2e": "cross-env NODE_ENV=test BABEL_DISABLE_CACHE=1 node --trace-warnings ./test/runTests.js e2e",
-    "test-watch": "npm test -- --watch"
+    "coverage": "open coverage/index.html",
+    "coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
   },
   "config": {
     "style_paths": "app/styles/*.scss app/components/**/*.scss"
@@ -124,6 +125,13 @@
   ],
   "homepage": "https://github.com/LN-Zap/zap-desktop#readme",
   "jest": {
+    "collectCoverage": true,
+    "coverageReporters": [
+      "json",
+      "lcov",
+      "text",
+      "html"
+    ],
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/internals/mocks/fileMock.js",
       "\\.(css|less|sass|scss)$": "identity-obj-proxy"
@@ -167,6 +175,7 @@
     "chalk": "^2.4.1",
     "concurrently": "^3.6.0",
     "connect-history-api-fallback": "^1.5.0",
+    "coveralls": "^3.0.2",
     "cross-env": "^5.2.0",
     "cross-spawn": "^6.0.5",
     "csp-html-webpack-plugin": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3076,6 +3076,17 @@ cosmiconfig@^5.0.0, cosmiconfig@^5.0.2:
     js-yaml "^3.9.0"
     parse-json "^4.0.0"
 
+coveralls@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.0.2.tgz#f5a0bcd90ca4e64e088b710fa8dda640aea4884f"
+  dependencies:
+    growl "~> 1.10.0"
+    js-yaml "^3.11.0"
+    lcov-parse "^0.0.10"
+    log-driver "^1.2.7"
+    minimist "^1.2.0"
+    request "^2.85.0"
+
 crc32-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/crc32-stream/-/crc32-stream-2.0.0.tgz#e3cdd3b4df3168dd74e3de3fbbcb7b297fe908f4"
@@ -5293,6 +5304,10 @@ graceful-fs@^4.1.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3,
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
+"growl@~> 1.10.0":
+  version "1.10.5"
+  resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
+
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -7025,6 +7040,10 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
+lcov-parse@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
+
 leb@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/leb/-/leb-0.3.0.tgz#32bee9fad168328d6aea8522d833f4180eed1da3"
@@ -7433,6 +7452,10 @@ lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, l
 lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.5, lodash@^4.5.1:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+
+log-driver@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.7.tgz#63b95021f0702fedfa2c9bb0a24e7797d71871d8"
 
 log-symbols@^1.0.2:
   version "1.0.2"
@@ -10026,7 +10049,7 @@ request@2, request@^2.79.0, request@^2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
-request@^2.45.0, request@^2.83.0:
+request@^2.45.0, request@^2.83.0, request@^2.85.0:
   version "2.87.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
   dependencies:


### PR DESCRIPTION
We have a test suite, so we should have code coverage reports to go with it.

Coverage reports make it easy to see what is and isn't covered by tests and encourages developers to write tests for new and existing code.

This PR:

 - generates test coverage reports whenever tests are run (output to `.coverage` directory)
 - provides the command `yarn coverage` which will open up an html version of the test coverage report (see screenshot below)
 - posts test coverage data to coveralls (eg https://coveralls.io/github/mrfelton/zap-desktop) at the end of every successful build on travis
 - adds a status badge to the project homepage to provide visibility into he current test coverage of the project (I also added a couple of other useful status badges).

![image](https://user-images.githubusercontent.com/200251/37964994-c9a0b1c8-31c3-11e8-983f-11bb77743244.png)
![image](https://user-images.githubusercontent.com/200251/37965189-8538be62-31c4-11e8-992f-137183489b98.png)

