### PR TITLE
feature(external LND node): Connect to external LND node for local development

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -33,10 +33,11 @@ npm run install-grpc
 
 Zap requires `lnd` but does not store `lnd` binaries in the Github repo.
 
-To setup `lnd` for Zap, you have two options:
+To setup `lnd` for Zap, you have three options:
 
 - [Light Client](#light-client)
 - [Full Bitcoin Node](#full-bitcoin-node)
+- [Connect to already running LND](#external-lnd-node)
 
 ### Light Client
 
@@ -46,7 +47,7 @@ This is the default configuration for the Zap wallet. To use the light client yo
 
 #### Lightning Labs Binary
 
-***Note:*** *The Lightning Labs `lightning-app` project is different then [lnd](https://github.com/lightningnetwork/lnd)*
+***Note:*** *The Lightning Labs `lightning-app` project is different than [lnd](https://github.com/lightningnetwork/lnd)*
 
 Download the [lnd binary](https://github.com/lightninglabs/lightning-app/tree/master/apps/desktop/bin) for your appropriate OS and copy it to the [appropriate location](#lnd-location) for your OS.
 
@@ -63,6 +64,23 @@ The `lnd` binary can be found at `$GOPATH/bin`.
 
 Follow the instructions on the [lnd installation](https://github.com/lightningnetwork/lnd/blob/master/docs/INSTALL.md) page.
 
+### External LND Node
+
+If you have set up `lnd` yourself, for example in a docker container, you can
+instruct Zap to connect to this `lnd` node through gRPC by setting the following environment
+variables:
+
+- `LND_HOST_PORT` : Hostname and port of the `lnd` node, for example `localhost:10009`
+- `LND_TLS_CERT` : Path to the `tls.cert` file. Example: `/home/myusername/.lnd/tls.cert`
+- `LND_MACAROON` : Path to the `admin.macaroon` file. Example: `/home/myusername/.lnd/admin.macaroon`
+
+Both paths can be absolute or relative to where you issue your `npm run` command.
+
+Example command:
+
+```bash
+LND_TLS_CERT=/home/myusername/.lnd/tls.cert LND_MACAROON=/home/myusername/.lnd/admin.macaroon LND_HOST_PORT=localhost:10009 npm run dev
+```
 
 ### lnd Location
 

--- a/app/lnd/config/index.js
+++ b/app/lnd/config/index.js
@@ -24,9 +24,13 @@ switch (platform()) {
     break
 }
 
+loc = process.env.LND_TLS_CERT || join(userInfo().homedir, loc)
+macaroonPath = process.env.LND_MACAROON || join(userInfo().homedir, macaroonPath)
+const host = process.env.LND_HOST_PORT || 'localhost:10009'
+
 export default {
   lightningRpc: `${__dirname}/rpc.proto`,
-  lightningHost: 'localhost:10009',
-  cert: join(userInfo().homedir, loc),
-  macaroon: join(userInfo().homedir, macaroonPath)
+  lightningHost: host,
+  cert: loc,
+  macaroon: macaroonPath
 }

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -275,6 +275,15 @@ app.on('ready', async () => {
   menuBuilder.buildMenu()
 
   sendGrpcDisconnected()
+
+  // Check to see if we should use an external LND address
+  if (process.env.LND_HOST_PORT) {
+    // An LND process was found, no need to start our own
+    console.log(`USING EXTERNALLY RUNNING LND AT ADDRESS ${process.env.LND_HOST_PORT}`)
+    startGrpc()
+    return
+  }
+
   // Check to see if an LND process is running
   lookup({ command: 'lnd' }, (err, results) => {
     // There was an error checking for the LND process


### PR DESCRIPTION
If you are running your own LND node somewhere (for example in a local docker container) and you want to connect Zap to this node, you can set the following environment variables:

- `LND_HOST_PORT` : Hostname and port of the `lnd` node, for example `localhost:10009`
- `LND_TLS_CERT` : Path to the `tls.cert` file. Example: `/home/myusername/.lnd/tls.cert`
- `LND_MACAROON` : Path to the `admin.macaroon` file. Example: `/home/myusername/.lnd/admin.macaroon`

Zap will not start its own `lnd` process if it detects a value in the environment variable `LND_HOST_PORT`.