### PR TITLE
fix(pay-form): ensure payment form shows on top

### DIFF
--- a/app/components/Form/Form.scss
+++ b/app/components/Form/Form.scss
@@ -3,7 +3,7 @@
 .container {
   position: absolute;
   top: 0;
-  z-index: 10;
+  z-index: 20;
   height: 100vh;
   width: 100%;
   background: $spaceblue;

--- a/app/routes/app/components/App.js
+++ b/app/routes/app/components/App.js
@@ -85,7 +85,6 @@ class App extends Component {
 
         <ContactModal {...contactModalProps} />
 
-        <Form formType={form.formType} formProps={formProps} closeForm={closeForm} />
         <ChannelForm {...channelFormProps} />
 
         <ReceiveModal {...receiveModalProps} />
@@ -101,6 +100,8 @@ class App extends Component {
             :
             <Network {...networkTabProps} />
         }
+
+        <Form formType={form.formType} formProps={formProps} closeForm={closeForm} />
       </div>
     )
   }


### PR DESCRIPTION
This fixes an issue where the payment form - initiated from an external request payment link - would display under the connect dialog if that was already open. This change ensures that the payment form always displays on the top most layer.

Fix #284