### PR TITLE
fix(passwords): convert password to Buffer

### DIFF
--- a/app/lnd/methods/walletController.js
+++ b/app/lnd/methods/walletController.js
@@ -112,7 +112,7 @@ export function genSeed(walletUnlocker) {
  */
 export function unlockWallet(walletUnlocker, { wallet_password }) {
   return new Promise((resolve, reject) => {
-    walletUnlocker.unlockWallet({ wallet_password }, (err, data) => {
+    walletUnlocker.unlockWallet({ wallet_password: Buffer.from(wallet_password) }, (err, data) => {
       if (err) { reject(err) }
 
       resolve(data)
@@ -128,7 +128,7 @@ export function unlockWallet(walletUnlocker, { wallet_password }) {
 export function initWallet(walletUnlocker, { wallet_password, cipher_seed_mnemonic, aezeed_passphrase }) {
   return new Promise((resolve, reject) => {
     walletUnlocker.initWallet({
-      wallet_password,
+      wallet_password: Buffer.from(wallet_password),
       cipher_seed_mnemonic,
       aezeed_passphrase: Buffer.from(aezeed_passphrase, 'hex'),
       recovery_window: 250


### PR DESCRIPTION
The wallet password is defined as `bytes` in the rpc.proto spec and we are
passing it as a string, resulting in an incorrect password being set on a
new wallet and an inability to unlock an existing wallet.

Convert the wallet password to a Buffer before passing to `initWallet` and
`unlockWallet`, which is the default data type used to represent bytes in
the node grpc client. This is sures that the password is passed correctly
to lnd.

Fix #400