### PR TITLE
Fix/dynamic explorer links

### DIFF
--- a/app/components/Activity/ActivityModal.js
+++ b/app/components/Activity/ActivityModal.js
@@ -51,6 +51,8 @@ ActivityModal.propTypes = {
   currentTicker: PropTypes.object.isRequired,
   toggleCurrencyProps: PropTypes.object.isRequired,
 
+  isTestnet: PropTypes.bool.isRequired,
+
   modalType: PropTypes.string,
   modalProps: PropTypes.object.isRequired,
   hideActivityModal: PropTypes.func.isRequired

--- a/app/components/Activity/ActivityModal.js
+++ b/app/components/Activity/ActivityModal.js
@@ -14,6 +14,7 @@ const ActivityModal = ({
   modalProps,
   ticker,
   currentTicker,
+  isTestnet,
 
   hideActivityModal,
   toggleCurrencyProps
@@ -36,6 +37,7 @@ const ActivityModal = ({
       </div>
       <SpecificModal
         {...modalProps}
+        isTestnet={isTestnet}
         ticker={ticker}
         currentTicker={currentTicker}
         toggleCurrencyProps={toggleCurrencyProps}

--- a/app/components/Activity/TransactionModal.js
+++ b/app/components/Activity/TransactionModal.js
@@ -19,6 +19,7 @@ const TransactionModal = ({
   transaction,
   ticker,
   currentTicker,
+  isTestnet,
 
   toggleCurrencyProps: {
     setActivityModalCurrencyFilters,
@@ -37,7 +38,7 @@ const TransactionModal = ({
       <section className={styles.details}>
         <div>
           <Isvg src={link} />
-          <span className={styles.link} onClick={() => blockExplorer.showTransaction(transaction.tx_hash)}>On-Chain</span>
+          <span className={styles.link} onClick={() => blockExplorer.showTransaction(isTestnet, transaction.tx_hash)}>On-Chain</span>
         </div>
         <div>
           <Value value={transaction.total_fees} currency={ticker.currency} currentTicker={currentTicker} />
@@ -75,7 +76,7 @@ const TransactionModal = ({
     </div>
 
     <footer className={styles.footer}>
-      <p onClick={() => blockExplorer.showTransaction(transaction.tx_hash)}>{transaction.tx_hash}</p>
+      <p onClick={() => blockExplorer.showTransaction(isTestnet, transaction.tx_hash)}>{transaction.tx_hash}</p>
     </footer>
   </div>
 )

--- a/app/components/Activity/TransactionModal.js
+++ b/app/components/Activity/TransactionModal.js
@@ -86,7 +86,9 @@ TransactionModal.propTypes = {
   ticker: PropTypes.object.isRequired,
   currentTicker: PropTypes.object.isRequired,
 
-  toggleCurrencyProps: PropTypes.object.isRequired
+  toggleCurrencyProps: PropTypes.object.isRequired,
+
+  isTestnet: PropTypes.bool.isRequired
 }
 
 export default TransactionModal

--- a/app/components/Contacts/Network.js
+++ b/app/components/Contacts/Network.js
@@ -316,6 +316,8 @@ Network.propTypes = {
   ticker: PropTypes.object.isRequired,
   suggestedNodesProps: PropTypes.object.isRequired,
 
+  isTestnet: PropTypes.bool.isRequired,
+
   fetchChannels: PropTypes.func.isRequired,
   openContactsForm: PropTypes.func.isRequired,
   toggleFilterPulldown: PropTypes.func.isRequired,

--- a/app/components/Contacts/Network.js
+++ b/app/components/Contacts/Network.js
@@ -51,7 +51,9 @@ class Network extends Component {
 
       closeChannel,
 
-      suggestedNodesProps
+      suggestedNodesProps,
+
+      isTestnet
     } = this.props
 
     const refreshClicked = () => {
@@ -224,7 +226,7 @@ class Network extends Component {
                       <span>{displayNodeName(channel)}</span>
                       {
                         selectedChannel === channel &&
-                        <span onClick={() => blockExplorer.showTransaction(channel.channel_point.split(':')[0])}>
+                        <span onClick={() => blockExplorer.showTransaction(isTestnet, channel.channel_point.split(':')[0])}>
                           <FaExternalLink />
                         </span>
                       }

--- a/app/components/ModalRoot/ModalRoot.js
+++ b/app/components/ModalRoot/ModalRoot.js
@@ -14,7 +14,7 @@ const MODAL_COMPONENTS = {
 }
 
 const ModalRoot = ({
-  modalType, modalProps, hideModal, currentTicker, currency
+  modalType, modalProps, hideModal, currentTicker, currency, isTestnet
 }) => {
   if (!modalType) { return null }
 
@@ -31,6 +31,7 @@ const ModalRoot = ({
           hideModal={hideModal}
           currentTicker={currentTicker}
           currency={currency}
+          isTestnet={isTestnet}
         />
       </div>
     </div>

--- a/app/components/ModalRoot/ModalRoot.js
+++ b/app/components/ModalRoot/ModalRoot.js
@@ -43,7 +43,8 @@ ModalRoot.propTypes = {
   modalProps: PropTypes.object,
   hideModal: PropTypes.func.isRequired,
   currentTicker: PropTypes.object.isRequired,
-  currency: PropTypes.string.isRequired
+  currency: PropTypes.string.isRequired,
+  isTestnet: PropTypes.bool.isRequired
 }
 
 export default ModalRoot

--- a/app/components/ModalRoot/SuccessfulSendCoins.js
+++ b/app/components/ModalRoot/SuccessfulSendCoins.js
@@ -35,7 +35,8 @@ SuccessfulSendCoins.propTypes = {
   txid: PropTypes.string.isRequired,
   hideModal: PropTypes.func.isRequired,
   currentTicker: PropTypes.object.isRequired,
-  currency: PropTypes.string.isRequired
+  currency: PropTypes.string.isRequired,
+  isTestnet: PropTypes.bool.isRequired
 }
 
 export default SuccessfulSendCoins

--- a/app/components/ModalRoot/SuccessfulSendCoins.js
+++ b/app/components/ModalRoot/SuccessfulSendCoins.js
@@ -5,7 +5,7 @@ import { btc, blockExplorer } from 'utils'
 import styles from './SuccessfulSendCoins.scss'
 
 const SuccessfulSendCoins = ({
-  amount, addr, txid, hideModal, currentTicker, currency
+  amount, addr, txid, hideModal, currentTicker, currency, isTestnet
 }) => {
   const calculatedAmount = currency === 'usd' ? btc.satoshisToUsd(amount, currentTicker.price_usd) : btc.satoshisToBtc(amount)
 
@@ -14,7 +14,7 @@ const SuccessfulSendCoins = ({
       <AnimatedCheckmark />
       <h1>
         You&nbsp;
-        <span className={styles.link} onClick={() => blockExplorer.showTransaction(txid)}>sent</span>&nbsp;
+        <span className={styles.link} onClick={() => blockExplorer.showTransaction(isTestnet, txid)}>sent</span>&nbsp;
         <span className={styles.amount}>{calculatedAmount} {currency.toUpperCase()}</span>&nbsp;
         to&nbsp;
         <span className={styles.addr}>{addr}</span>

--- a/app/components/Wallet/Wallet.js
+++ b/app/components/Wallet/Wallet.js
@@ -26,7 +26,8 @@ const Wallet = ({
   currentCurrencyFilters,
   currencyName,
   setCurrency,
-  setWalletCurrencyFilters
+  setWalletCurrencyFilters,
+  isTestnet
 }) => {
   const usdAmount = btc.satoshisToUsd((parseInt(balance.walletBalance, 10) + parseInt(balance.channelBalance, 10)), currentTicker.price_usd)
 
@@ -112,7 +113,7 @@ const Wallet = ({
                     {
                       // TODO(jimmymow): remove this
                       // eslint-disable-next-line
-                    }Successfully <span className={styles.txLink} onClick={() => blockExplorer.showTransaction(successTransactionScreen.txid)}>sent</span> transaction
+                    }Successfully <span className={styles.txLink} onClick={() => blockExplorer.showTransaction(isTestnet, successTransactionScreen.txid)}>sent</span> transaction
                   </section>
                 </span>
             }

--- a/app/components/Wallet/Wallet.js
+++ b/app/components/Wallet/Wallet.js
@@ -134,6 +134,7 @@ Wallet.propTypes = {
   openReceiveModal: PropTypes.func.isRequired,
   showPayLoadingScreen: PropTypes.bool.isRequired,
   showSuccessPayScreen: PropTypes.bool.isRequired,
+  isTestnet: PropTypes.bool.isRequired,
   successTransactionScreen: PropTypes.object.isRequired,
   currentCurrencyFilters: PropTypes.array.isRequired,
   currencyName: PropTypes.string.isRequired,

--- a/app/routes/activity/containers/ActivityContainer.js
+++ b/app/routes/activity/containers/ActivityContainer.js
@@ -93,6 +93,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     successTransactionScreen: stateProps.transaction.successTransactionScreen,
     currentCurrencyFilters: stateProps.currentCurrencyFilters,
     currencyName: stateProps.currencyName,
+    isTestnet: stateProps.info.data.testnet,
 
     setCurrency: dispatchProps.setCurrency,
     setWalletCurrencyFilters: dispatchProps.setWalletCurrencyFilters,

--- a/app/routes/app/components/App.js
+++ b/app/routes/app/components/App.js
@@ -116,6 +116,7 @@ App.propTypes = {
   formProps: PropTypes.object.isRequired,
   closeForm: PropTypes.func.isRequired,
   error: PropTypes.object.isRequired,
+  info: PropTypes.object.isRequired,
   currentTicker: PropTypes.object,
   contactModalProps: PropTypes.object,
   contactsFormProps: PropTypes.object,

--- a/app/routes/app/components/App.js
+++ b/app/routes/app/components/App.js
@@ -52,6 +52,7 @@ class App extends Component {
       ticker,
       currentTicker,
       form,
+      info: { data },
 
       formProps,
       closeForm,
@@ -81,6 +82,7 @@ class App extends Component {
           hideModal={hideModal}
           currentTicker={currentTicker}
           currency={ticker.currency}
+          isTestnet={data.testnet}
         />
 
         <ContactModal {...contactModalProps} />

--- a/app/routes/app/containers/AppContainer.js
+++ b/app/routes/app/containers/AppContainer.js
@@ -305,6 +305,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     nodes: stateProps.network.nodes,
     nonActiveFilters: stateProps.nonActiveFilters,
     ticker: stateProps.ticker,
+    isTestnet: stateProps.info.data.testnet,
 
     fetchChannels: dispatchProps.fetchChannels,
     openContactsForm: dispatchProps.openContactsForm,
@@ -361,6 +362,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     modalProps: stateProps.activity.modal.modalProps,
     ticker: stateProps.ticker,
     currentTicker: stateProps.currentTicker,
+    isTestnet: stateProps.info.data.testnet,
 
     hideActivityModal: dispatchProps.hideActivityModal,
 

--- a/app/utils/blockExplorer.js
+++ b/app/utils/blockExplorer.js
@@ -3,11 +3,13 @@ import { shell } from 'electron'
 const testnetUrl = 'https://testnet.smartbit.com.au'
 const mainnetUrl = 'https://smartbit.com.au'
 
-const showTransaction = txid =>
-  shell.openExternal(`${testnetUrl}/tx/${txid}`)
+const showTransaction = (isTestnet, txid) => {
+  console.log('isTestnet: ', isTestnet)
+  console.log('txid: ', txid)
+  isTestnet ? shell.openExternal(`${testnetUrl}/tx/${txid}`) : shell.openExternal(`${mainnetUrl}/tx/${txid}`)
+}
 
-const showBlock = blockHash =>
-  shell.openExternal(`${testnetUrl}/block/${blockHash}`)
+const showBlock = (isTestnet, blockHash) => isTestnet ? shell.openExternal(`${testnetUrl}/block/${blockHash}`) : shell.openExternal(`${mainnetUrl}/block/${blockHash}`)
 
 const showChannelClosing = channel =>
   showTransaction(channel.closing_txid)

--- a/app/utils/blockExplorer.js
+++ b/app/utils/blockExplorer.js
@@ -3,13 +3,11 @@ import { shell } from 'electron'
 const testnetUrl = 'https://testnet.smartbit.com.au'
 const mainnetUrl = 'https://smartbit.com.au'
 
-const showTransaction = (isTestnet, txid) => {
-  console.log('isTestnet: ', isTestnet)
-  console.log('txid: ', txid)
-  isTestnet ? shell.openExternal(`${testnetUrl}/tx/${txid}`) : shell.openExternal(`${mainnetUrl}/tx/${txid}`)
-}
+const showTransaction = (isTestnet, txid) =>
+  (isTestnet ? shell.openExternal(`${testnetUrl}/tx/${txid}`) : shell.openExternal(`${mainnetUrl}/tx/${txid}`))
 
-const showBlock = (isTestnet, blockHash) => isTestnet ? shell.openExternal(`${testnetUrl}/block/${blockHash}`) : shell.openExternal(`${mainnetUrl}/block/${blockHash}`)
+const showBlock = (isTestnet, blockHash) =>
+  (isTestnet ? shell.openExternal(`${testnetUrl}/block/${blockHash}`) : shell.openExternal(`${mainnetUrl}/block/${blockHash}`))
 
 const showChannelClosing = channel =>
   showTransaction(channel.closing_txid)


### PR DESCRIPTION
With mainnet coming up we didn't wanna have hard-coded testnet links. This adds the `isTestnet` param to the showTransaction and showBlock util functions and passes the nodes testnet info when used