### PR TITLE
fix(grpc): update grpc to v1.12.3

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -15,7 +15,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "grpc": "1.12.1",
+    "grpc": "^1.12.3",
     "ps-node": "^0.1.6",
     "react-icons": "^2.2.5"
   }

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -171,9 +171,9 @@ glob@^7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-grpc@1.12.1:
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.12.1.tgz#bf2ef184695836582d7b0f04a0120032460fdac7"
+grpc@^1.12.3:
+  version "1.12.3"
+  resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.12.3.tgz#b38bf05f26477d42f8285794c0b1f8b8c0b6dec3"
   dependencies:
     lodash "^4.17.5"
     nan "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,9 @@
       {
         "from": "resources/bin/${platform}",
         "to": "bin",
-        "filter": [ "lnd*" ]
+        "filter": [
+          "lnd*"
+        ]
       }
     ]
   },


### PR DESCRIPTION
Update grpc to v1.12.3 in order to fix issues build issues due to the fact
that 1.12.1 doesn't contain node-pre-gyp as a bundled dependency.

See https://github.com/grpc/grpc-node/issues/365

This may be linked to the issue reported in #420 whose build logs (https://bpaste.net/show/d9de030db9ca) show the warning

> warning "grpc@1.12.1" is missing a bundled dependency "node-pre-gyp". This should be reported to the package maintainer.