### PR TITLE
More reliable lnd log parsing

### DIFF
--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -13,6 +13,7 @@
 import { app, BrowserWindow, ipcMain, dialog } from 'electron'
 import path from 'path'
 import fs from 'fs'
+import split2 from 'split2'
 import { spawn } from 'child_process'
 import { lookup } from 'ps-node'
 import Store from 'electron-store'
@@ -172,10 +173,7 @@ const startLnd = (alias, autopilot) => {
     })
 
   // Listen for when neutrino prints out data
-  neutrino.stdout.on('data', (data) => {
-    // Data stored in variable line, log line to the console
-    const line = data.toString('utf8')
-
+  neutrino.stdout.pipe(split2()).on('data', (line) => {
     if (process.env.NODE_ENV === 'development') {
       console.log(line)
     }

--- a/package.json
+++ b/package.json
@@ -239,6 +239,7 @@
     "reselect": "^3.0.1",
     "satoshi-bitcoin": "^1.0.4",
     "source-map-support": "^0.5.6",
+    "split2": "^2.2.0",
     "xtend": "^4.0.1"
   },
   "main": "webpack.config.base.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10301,6 +10301,12 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
+split2@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/split2/-/split2-2.2.0.tgz#186b2575bcf83e85b7d18465756238ee4ee42493"
+  dependencies:
+    through2 "^2.0.2"
+
 split@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/split/-/split-1.0.0.tgz#c4395ce683abcd254bc28fe1dabb6e5c27dcffae"
@@ -10798,7 +10804,7 @@ throttleit@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/throttleit/-/throttleit-0.0.2.tgz#cfedf88e60c00dd9697b61fdd2a8343a9b680eaf"
 
-through2@^2.0.0:
+through2@^2.0.0, through2@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
   dependencies:


### PR DESCRIPTION
Pipe lnd stdout tream through `split2` in order to ensure that each data
event contains a single line of log output.

Fix #432