### PR TITLE
Remove redundant install steps

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -21,12 +21,11 @@ git clone https://github.com/LN-Zap/zap-desktop.git
 
 ### Installing Dependencies
 
-Install all the dependencies with yarn + install grpc:
+Install all the dependencies with yarn:
 
 ```bash
 cd zap-desktop
 yarn
-npm run install-grpc
 ```
 
 ## Lightning Network Daemon (lnd)

--- a/app/package.json
+++ b/app/package.json
@@ -10,8 +10,7 @@
     "url": "https://github.com/LN-Zap/zap-desktop"
   },
   "scripts": {
-    "postinstall": "npm rebuild --runtime=electron --target=1.8.4 --disturl=https://atom.io/download/atom-shell --build-from-source",
-    "install-grpc": "cd node_modules/grpc && git submodule update --init && npm run electron-build -- --target=1.8.4"
+    "postinstall": "npm rebuild --runtime=electron --target=1.8.4 --disturl=https://atom.io/download/atom-shell --build-from-source"
   },
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "test-ci": "npm run package && npm run test && npm run test-e2e",
     "test-all": "npm run lint && npm run lint-styles && npm run flow && npm run build && npm run test && npm run test-e2e",
     "test-e2e": "cross-env NODE_ENV=test BABEL_DISABLE_CACHE=1 node --trace-warnings ./test/runTests.js e2e",
-    "test-watch": "npm test -- --watch",
-    "install-grpc": "cd app && npm run install-grpc"
+    "test-watch": "npm test -- --watch"
   },
   "browserslist": "electron 1.8",
   "engines": {


### PR DESCRIPTION
Remove the `install-grpc` installation step as it is redundant.

See #420