### PR TITLE
Remove unneeded call to concurrently

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build-dll": "cross-env NODE_ENV=development node --trace-warnings -r babel-register ./node_modules/webpack/bin/webpack --config webpack.config.renderer.dev.dll.js --colors",
     "build-main": "cross-env NODE_ENV=production node --trace-warnings -r babel-register ./node_modules/webpack/bin/webpack --config webpack.config.main.prod.js --colors",
     "build-renderer": "cross-env NODE_ENV=production node --trace-warnings -r babel-register ./node_modules/webpack/bin/webpack --config webpack.config.renderer.prod.js --colors",
-    "dev": "cross-env START_HOT=1 concurrently \"npm run start-renderer-dev\"",
+    "dev": "cross-env START_HOT=1 npm run start-renderer-dev",
     "flow": "flow",
     "flow-typed": "rimraf flow-typed/npm && flow-typed install --overwrite || true",
     "lint": "cross-env NODE_ENV=development eslint --cache --format=node_modules/eslint-formatter-pretty .",


### PR DESCRIPTION
There is an unneeded call to `concurrently` in the `npm run dev` script.
This causes things that should be output in colour (eg debug messages
when running with DEBUG=*) to not be output in colour which makes
debugging things harder than it should be.

This was in place because previously lnd was being started up externally
in the `npm run dev` script at the same time as starting up the app. But
we now use spawn from within the app to start up lnd.

The call to `concurrently` is no longer needed.

See https://github.com/LN-Zap/zap-desktop/commit/d8c5623e0131d89e1fb889eb5356fd1752bcbf12