### PR TITLE
Convert remaining console statements to log or throw, enable no-console linter

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,7 @@
   },
   "extends": [
     "airbnb",
+    "eslint:recommended",
     "plugin:react/recommended",
     "plugin:flowtype/recommended",
     "plugin:import/errors",

--- a/app/lnd/index.js
+++ b/app/lnd/index.js
@@ -4,13 +4,15 @@ import walletUnlocker from './lib/walletUnlocker'
 import subscribe from './subscribe'
 import methods from './methods'
 import walletUnlockerMethods from './walletUnlockerMethods'
+// use mainLog because lndLog is reserved for the lnd binary itself
+import { mainLog } from '../utils/log'
 
 const initLnd = (callback) => {
   const lndConfig = config.lnd()
   const lnd = lightning(lndConfig.lightningRpc, lndConfig.lightningHost)
 
-  const lndSubscribe = mainWindow => subscribe(mainWindow, lnd)
-  const lndMethods = (event, msg, data) => methods(lnd, event, msg, data)
+  const lndSubscribe = mainWindow => subscribe(mainWindow, lnd, mainLog)
+  const lndMethods = (event, msg, data) => methods(lnd, mainLog, event, msg, data)
 
   callback(lndSubscribe, lndMethods)
 }
@@ -19,7 +21,7 @@ const initWalletUnlocker = (callback) => {
   const lndConfig = config.lnd()
 
   const walletUnlockerObj = walletUnlocker(lndConfig.lightningRpc, lndConfig.lightningHost)
-  const walletUnlockerMethodsCallback = (event, msg, data) => walletUnlockerMethods(walletUnlockerObj, event, msg, data)
+  const walletUnlockerMethodsCallback = (event, msg, data) => walletUnlockerMethods(walletUnlockerObj, mainLog, event, msg, data)
 
   callback(walletUnlockerMethodsCallback)
 }

--- a/app/lnd/methods/index.js
+++ b/app/lnd/methods/index.js
@@ -1,4 +1,3 @@
-/* eslint no-console: 0 */ // --> OFF
 // import grpc from 'grpc'
 
 import * as invoicesController from './invoicesController'

--- a/app/lnd/methods/index.js
+++ b/app/lnd/methods/index.js
@@ -18,7 +18,7 @@ import * as networkController from './networkController'
 // TODO - SendPayment
 // TODO - DeleteAllPayments
 
-export default function (lnd, event, msg, data) {
+export default function (lnd, log, event, msg, data) {
   switch (msg) {
     case 'info':
       networkController
@@ -34,14 +34,14 @@ export default function (lnd, event, msg, data) {
       networkController
         .describeGraph(lnd)
         .then(networkData => event.sender.send('receiveDescribeNetwork', networkData))
-        .catch(error => console.log('describeGraph error: ', error))
+        .catch(error => log.error('describeGraph:', error))
       break
     case 'queryRoutes':
       // Data looks like { pubkey: String, amount: Number }
       networkController
         .queryRoutes(lnd, data)
         .then(routes => event.sender.send('receiveQueryRoutes', routes))
-        .catch(error => console.log('queryRoutes error: ', error))
+        .catch(error => log.error('queryRoutes:', error))
       break
     case 'getInvoiceAndQueryRoutes':
       // Data looks like { pubkey: String, amount: Number }
@@ -53,63 +53,63 @@ export default function (lnd, event, msg, data) {
             amount: invoiceData.num_satoshis
           }))
         .then(routes => event.sender.send('receiveInvoiceAndQueryRoutes', routes))
-        .catch(error => console.log('getInvoiceAndQueryRoutes invoice error: ', error))
+        .catch(error => log.error('getInvoiceAndQueryRoutes invoice:', error))
       break
     case 'newaddress':
       // Data looks like { address: '' }
       walletController
         .newAddress(lnd, data.type)
         .then(({ address }) => event.sender.send('receiveAddress', address))
-        .catch(error => console.log('newaddress error: ', error))
+        .catch(error => log.error('newaddress:', error))
       break
     case 'setAlias':
       // Data looks like { new_alias: '' }
       walletController
         .setAlias(lnd, data)
         .then(() => event.sender.send('aliasSet'))
-        .catch(error => console.log('setAlias error: ', error))
+        .catch(error => log.error('setAlias:', error))
       break
     case 'peers':
       // Data looks like { peers: [] }
       peersController
         .listPeers(lnd)
         .then(peersData => event.sender.send('receivePeers', peersData))
-        .catch(error => console.log('peers error: ', error))
+        .catch(error => log.error('peers:', error))
       break
     case 'channels':
       // Data looks like
       // [ { channels: [] }, { total_limbo_balance: 0, pending_open_channels: [], pending_closing_channels: [], pending_force_closing_channels: [] } ]
       Promise.all([channelController.listChannels, channelController.pendingChannels].map(func => func(lnd)))
         .then(channelsData => event.sender.send('receiveChannels', { channels: channelsData[0].channels, pendingChannels: channelsData[1] }))
-        .catch(error => console.log('channels error: ', error))
+        .catch(error => log.error('channels:', error))
       break
     case 'transactions':
       // Data looks like { transactions: [] }
       walletController
         .getTransactions(lnd)
         .then(transactionsData => event.sender.send('receiveTransactions', transactionsData))
-        .catch(error => console.log('transactions error: ', error))
+        .catch(error => log.error('transactions:', error))
       break
     case 'payments':
       // Data looks like { payments: [] }
       paymentsController
         .listPayments(lnd)
         .then(paymentsData => event.sender.send('receivePayments', paymentsData))
-        .catch(error => console.log('payments error: ', error))
+        .catch(error => log.error('payments:', error))
       break
     case 'invoices':
       // Data looks like { invoices: [] }
       invoicesController
         .listInvoices(lnd)
         .then(invoicesData => event.sender.send('receiveInvoices', invoicesData))
-        .catch(error => console.log('invoices error: ', error))
+        .catch(error => log.error('invoices:', error))
       break
     case 'invoice':
       // Data looks like { invoices: [] }
       invoicesController
         .getInvoice(lnd, { pay_req: data.payreq })
         .then(invoiceData => event.sender.send('receiveInvoice', invoiceData))
-        .catch(error => console.log('invoice error: ', error))
+        .catch(error => log.error('invoice:', error))
       break
     case 'balance':
       // Balance looks like [ { balance: '129477456' }, { balance: '243914' } ]
@@ -118,7 +118,7 @@ export default function (lnd, event, msg, data) {
           event.sender.send('receiveBalance', { walletBalance: balance[0].total_balance, channelBalance: balance[1].balance })
           return balance
         })
-        .catch(error => console.log('balance error: ', error))
+        .catch(error => log.error('balance:', error))
       break
     case 'createInvoice':
       // Invoice looks like { r_hash: Buffer, payment_request: '' }
@@ -140,11 +140,11 @@ export default function (lnd, event, msg, data) {
                 })
               ))
             .catch((error) => {
-              console.log('decodedInvoice error: ', error)
+              log.error('decodedInvoice:', error)
               event.sender.send('invoiceFailed', { error: error.toString() })
             }))
         .catch((error) => {
-          console.log('addInvoice error: ', error)
+          log.error('addInvoice:', error)
           event.sender.send('invoiceFailed', { error: error.toString() })
         })
       break
@@ -154,13 +154,14 @@ export default function (lnd, event, msg, data) {
       paymentsController
         .sendPaymentSync(lnd, data)
         .then((payment) => {
+          log.info('payment:', payment)
           const { payment_route } = payment
-          console.log('payinvoice success: ', payment_route)
+          log.error('payinvoice success:', payment_route)
           event.sender.send('paymentSuccessful', Object.assign(data, { payment_route }))
           return payment
         })
         .catch(({ error }) => {
-          console.log('error: ', error)
+          log.error('error: ', error)
           event.sender.send('paymentFailed', { error: error.toString() })
         })
       break
@@ -171,7 +172,7 @@ export default function (lnd, event, msg, data) {
         .sendCoins(lnd, data)
         .then(({ txid }) => event.sender.send('transactionSuccessful', { amount: data.amount, addr: data.addr, txid }))
         .catch((error) => {
-          console.log('error: ', error)
+          log.error('error: ', error)
           event.sender.send('transactionError', { error: error.toString() })
         })
       break
@@ -181,11 +182,11 @@ export default function (lnd, event, msg, data) {
       channelController
         .openChannel(lnd, event, data)
         .then((channel) => {
-          console.log('CHANNEL: ', channel)
+          log.error('CHANNEL: ', channel)
           event.sender.send('channelSuccessful', { channel })
           return channel
         })
-        .catch(error => console.log('openChannel error: ', error))
+        .catch(error => log.error('openChannel:', error))
       break
     case 'closeChannel':
       // Response is empty. Streaming updates on channel status and updates
@@ -193,11 +194,11 @@ export default function (lnd, event, msg, data) {
       channelController
         .closeChannel(lnd, event, data)
         .then((result) => {
-          console.log('CLOSE CHANNEL: ', result)
+          log.error('CLOSE CHANNEL: ', result)
           event.sender.send('closeChannelSuccessful')
           return result
         })
-        .catch(error => console.log('closeChannel error: ', error))
+        .catch(error => log.error('closeChannel:', error))
       break
     case 'connectPeer':
       // Returns a peer_id. Pass the pubkey, host and peer_id so we can add a new peer to the list
@@ -206,13 +207,13 @@ export default function (lnd, event, msg, data) {
         .connectPeer(lnd, data)
         .then((peer) => {
           const { peer_id } = peer
-          console.log('peer_id: ', peer_id)
+          log.error('peer_id: ', peer_id)
           event.sender.send('connectSuccess', { pub_key: data.pubkey, address: data.host, peer_id })
           return peer
         })
         .catch((error) => {
           event.sender.send('connectFailure', { error: error.toString() })
-          console.log('connectPeer error: ', error)
+          log.error('connectPeer:', error)
         })
       break
     case 'disconnectPeer':
@@ -221,11 +222,11 @@ export default function (lnd, event, msg, data) {
       peersController
         .disconnectPeer(lnd, data)
         .then(() => {
-          console.log('pubkey: ', data.pubkey)
+          log.error('pubkey: ', data.pubkey)
           event.sender.send('disconnectSuccess', { pubkey: data.pubkey })
           return null
         })
-        .catch(error => console.log('disconnectPeer error: ', error))
+        .catch(error => log.error('disconnectPeer:', error))
       break
     case 'connectAndOpen':
       // Connects to a peer if we aren't connected already and then attempt to open a channel
@@ -233,13 +234,13 @@ export default function (lnd, event, msg, data) {
       channelController
         .connectAndOpen(lnd, event, data)
         .then((channelData) => {
-          console.log('connectAndOpen data: ', channelData)
+          log.error('connectAndOpen data: ', channelData)
           // event.sender.send('connectSuccess', { pub_key: data.pubkey, address: data.host, peer_id })
           return channelData
         })
         .catch((error) => {
           // event.sender.send('connectFailure', { error: error.toString() })
-          console.log('connectAndOpen error: ', error)
+          log.error('connectAndOpen:', error)
         })
       break
     default:

--- a/app/lnd/methods/paymentsController.js
+++ b/app/lnd/methods/paymentsController.js
@@ -9,17 +9,14 @@ export function sendPaymentSync(lnd, { paymentRequest }) {
     lnd.sendPaymentSync({ payment_request: paymentRequest }, (error, data) => {
       if (error) {
         reject({ error })
-        return
+      } else if (!data || !data.payment_route) {
+        reject({ error: data.payment_error })
+      } else {
+        resolve(data)
       }
-
-      if (!data || !data.payment_route) { reject({ error: data.payment_error }) }
-
-      console.log('data: ', data)
-      resolve(data)
     })
   })
 }
-
 
 /**
  * Synchronous non-streaming version of SendPayment

--- a/app/lnd/subscribe/index.js
+++ b/app/lnd/subscribe/index.js
@@ -2,8 +2,8 @@ import subscribeToTransactions from './transactions'
 import subscribeToInvoices from './invoices'
 import subscribeToChannelGraph from './channelgraph'
 
-export default (mainWindow, lnd) => {
-  subscribeToTransactions(mainWindow, lnd)
-  subscribeToInvoices(mainWindow, lnd)
+export default (mainWindow, lnd, log) => {
+  subscribeToTransactions(mainWindow, lnd, log)
+  subscribeToInvoices(mainWindow, lnd, log)
   subscribeToChannelGraph(mainWindow, lnd)
 }

--- a/app/lnd/subscribe/invoices.js
+++ b/app/lnd/subscribe/invoices.js
@@ -1,8 +1,8 @@
-export default function subscribeToInvoices(mainWindow, lnd) {
+export default function subscribeToInvoices(mainWindow, lnd, log) {
   const call = lnd.subscribeInvoices({})
 
   call.on('data', invoice => mainWindow.send('invoiceUpdate', { invoice }))
-  call.on('end', () => console.log('end'))
-  call.on('error', error => console.log('error: ', error))
-  call.on('status', status => console.log('status: ', status))
+  call.on('end', () => log.info('end'))
+  call.on('error', error => log.error(error))
+  call.on('status', status => log.info('status:', status))
 }

--- a/app/lnd/subscribe/transactions.js
+++ b/app/lnd/subscribe/transactions.js
@@ -1,10 +1,10 @@
-export default function subscribeToTransactions(mainWindow, lnd) {
+export default function subscribeToTransactions(mainWindow, lnd, log) {
   const call = lnd.subscribeTransactions({})
   call.on('data', (transaction) => {
-    console.log('TRANSACTION: ', transaction)
+    lnd.log.info('TRANSACTION:', transaction)
     mainWindow.send('newTransaction', { transaction })
   })
-  call.on('end', () => console.log('end'))
-  call.on('error', error => console.log('error: ', error))
-  call.on('status', status => console.log('TRANSACTION STATUS: ', status))
+  call.on('end', () => log.info('end'))
+  call.on('error', error => log.error('error: ', error))
+  call.on('status', status => log.info('TRANSACTION STATUS: ', status))
 }

--- a/app/lnd/walletUnlockerMethods/index.js
+++ b/app/lnd/walletUnlockerMethods/index.js
@@ -2,7 +2,7 @@
 
 import * as walletController from '../methods/walletController'
 
-export default function (walletUnlocker, event, msg, data) {
+export default function (walletUnlocker, log, event, msg, data) {
   switch (msg) {
     case 'genSeed':
       walletController.genSeed(walletUnlocker)
@@ -17,7 +17,7 @@ export default function (walletUnlocker, event, msg, data) {
     case 'initWallet':
       walletController.initWallet(walletUnlocker, data)
         .then(() => event.sender.send('successfullyCreatedWallet'))
-        .catch(error => console.log('initWallet error: ', error))
+        .catch(error => log.error('initWallet:', error))
       break
     default:
   }

--- a/app/lnd/walletUnlockerMethods/index.js
+++ b/app/lnd/walletUnlockerMethods/index.js
@@ -1,5 +1,3 @@
-/* eslint no-console: 0 */ // --> OFF
-
 import * as walletController from '../methods/walletController'
 
 export default function (walletUnlocker, log, event, msg, data) {

--- a/internals/scripts/CheckNodeEnv.js
+++ b/internals/scripts/CheckNodeEnv.js
@@ -7,7 +7,6 @@ export default function CheckNodeEnv(expectedEnv: string) {
   }
 
   if (process.env.NODE_ENV !== expectedEnv) {
-    console.log(chalk.whiteBright.bgRed.bold(`"process.env.NODE_ENV" must be "${expectedEnv}" to use this webpack config`))
-    process.exit(2)
+    throw new Error(chalk.whiteBright.bgRed.bold(`"process.env.NODE_ENV" must be "${expectedEnv}" to use this webpack config`))
   }
 }

--- a/test/e2e/e2e.spec.js
+++ b/test/e2e/e2e.spec.js
@@ -30,12 +30,6 @@ describe('main window', function spec() {
   it('should haven\'t any logs in console of main window', async () => {
     const { client } = this.app
     const logs = await client.getRenderProcessLogs()
-    // Print renderer process logs
-    logs.forEach((log) => {
-      console.log(log.message)
-      console.log(log.source)
-      console.log(log.level)
-    })
     expect(logs).toHaveLength(0)
   })
 })

--- a/webpack.config.renderer.dev.js
+++ b/webpack.config.renderer.dev.js
@@ -10,12 +10,12 @@
 import path from 'path'
 import fs from 'fs'
 import webpack from 'webpack'
-import chalk from 'chalk'
 import merge from 'webpack-merge'
 import { spawn, execSync } from 'child_process'
 import ExtractTextPlugin from 'extract-text-webpack-plugin'
 import baseConfig from './webpack.config.base'
 import CheckNodeEnv from './internals/scripts/CheckNodeEnv'
+import { mainLog } from './app/utils/log'
 
 CheckNodeEnv('development')
 
@@ -28,7 +28,7 @@ const manifest = path.resolve(dll, 'renderer.json')
  * Warn if the DLL is not built
  */
 if (!(fs.existsSync(dll) && fs.existsSync(manifest))) {
-  console.log(chalk.black.bgYellow.bold('The DLL files are missing. Sit back while we build them for you with "npm run build-dll"'))
+  mainLog.info('The DLL files are missing. Sit back while we build them for you with "npm run build-dll"')
   execSync('npm run build-dll')
 }
 
@@ -264,14 +264,13 @@ export default merge.smart(baseConfig, {
     },
     before() {
       if (process.env.START_HOT) {
-        console.log('Starting Main Process...')
         spawn(
           'npm',
           ['run', 'start-main-dev'],
           { shell: true, env: process.env, stdio: 'inherit' }
         )
           .on('close', code => process.exit(code))
-          .on('error', spawnError => console.error(spawnError))
+          .on('error', spawnError => mainLog.error(spawnError))
       }
     }
   },


### PR DESCRIPTION
This follow up on #436 by converting remaining `console.log` statements to use the log or throw, and enabling the `no-console` linter to prevent addition in the future.

As a bonus, this allows us to enable the full `eslint:recommended` set, which is a good baseline.
https://eslint.org/docs/rules/