### PR TITLE
Fix lndLogGetLevel to apply the most-recent log level when none is detected

### DIFF
--- a/app/utils/log.js
+++ b/app/utils/log.js
@@ -52,6 +52,7 @@ const logConfig = name => ({
 export const mainLog = debugLogger.config(logConfig('main'))('zap')
 export const lndLog = debugLogger.config(logConfig('lnd '))('zap')
 
+let lndLogLevel = null // stored most recent log level for continuity
 export const lndLogGetLevel = (msg) => {
   // Define a mapping between log level prefixes and log level names.
   const levelMap = {
@@ -63,16 +64,18 @@ export const lndLogGetLevel = (msg) => {
     CRT: 'critical'
   }
 
-  // We set the default level to trace.
-  // The only log lines that don't include a level prefix are a part of trace entries
-  let level = 'trace'
-
   // Parse the log line to determine its level.
+  let level
   Object.entries(levelMap).forEach(([key, value]) => {
     if (msg.includes(`[${key}]`)) {
       level = value
     }
   })
-
-  return level
+  if (level) {
+    lndLogLevel = level
+    return level
+  }
+  // We set the default level to trace.
+  // The only log lines that don't include a level prefix are a part of trace entries
+  return lndLogLevel || 'trace'
 }


### PR DESCRIPTION
In some cases, multi-line log output was output at its value for the first line,
but in the trace log in following lines. For example, in this output:
```
  zap:lnd  [DBG]  2018-06-17 18:30:35.051 [DBG] CRTR: New channel update applied: (*channeldb.ChannelEdgePolicy)(0xc420e74310)({ +0ms
  zap:lnd  [DBG]   SigBytes: ([]uint8) (len=71 cap=71) { +0ms
  zap:lnd  [DBG]   }, +0ms
  zap:lnd  [DBG]   sig: (*btcec.Signature)(<nil>), +0ms
  zap:lnd  [DBG]   ChannelID: (uint64) 1423834572626526208, +0ms
  zap:lnd  [DBG]   LastUpdate: (time.Time) 2018-06-17 18:30:26 -0500 CDT, +0ms
  zap:lnd  [DBG]   Flags: (lnwire.ChanUpdateFlag) 1, +0ms
  zap:lnd  [DBG]   TimeLockDelta: (uint16) 6, +0ms
  zap:lnd  [DBG]   MinHTLC: (lnwire.MilliSatoshi) 1000 mSAT, +0ms
  zap:lnd  [DBG]   FeeBaseMSat: (lnwire.MilliSatoshi) 1 mSAT, +0ms
  zap:lnd  [DBG]   FeeProportionalMillionths: (lnwire.MilliSatoshi) 10 mSAT, +0ms
  zap:lnd  [DBG]   Node: (*channeldb.LightningNode)(<nil>), +0ms
  zap:lnd  [DBG]   db: (*channeldb.DB)(<nil>) +1ms
  zap:lnd  [DBG]  }) +0ms
  zap:lnd  [DBG]   +0ms
```

Previously the first line would be marked `DBG`, while the others were marked `TRC`.