### PR TITLE
Move LND settings Zap uses into the local lnd.conf

### DIFF
--- a/app/lnd/config/index.js
+++ b/app/lnd/config/index.js
@@ -60,6 +60,7 @@ if (process.env.NODE_ENV === 'development') {
 export default {
   lnd: () => ({
     lndPath,
+    configPath: join(appRootPath, 'resources', 'lnd.conf'),
     lightningRpc: join(appRootPath, 'resources', 'rpc.proto'),
     lightningHost: store.get('host') || 'localhost:10009',
     cert: store.get('cert') || join(userInfo().homedir, loc),

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -155,12 +155,7 @@ const startLnd = (alias, autopilot) => {
   mainLog.debug(' > macaroon:', lndConfig.macaroon)
 
   const neutrinoArgs = [
-    '--bitcoin.active',
-    '--bitcoin.testnet',
-    '--bitcoin.node=neutrino',
-    '--neutrino.connect=188.166.148.62',
-    '--neutrino.connect=127.0.0.1:18333',
-    '--debuglevel=debug',
+    `--configfile=${lndConfig.configPath}`,
     `${autopilot ? '--autopilot.active' : ''}`,
     `${alias ? `--alias=${alias}` : ''}`
   ]

--- a/resources/lnd.conf
+++ b/resources/lnd.conf
@@ -1,0 +1,309 @@
+; Imported from https://github.com/lightningnetwork/lnd/blob/v0.4.2-beta/sample-lnd.conf
+[Application Options]
+
+; The directory that lnd stores all wallet, chain, and channel related data
+; within The default is ~/.lnd/data on POSIX OSes, $LOCALAPPDATA/Lnd/data on
+; Windows, ~/Library/Application Support/Lnd/data on Mac OS, and $home/lnd/data
+; on Plan9.  Environment variables are expanded so they may be used.  NOTE:
+; Windows environment variables are typically %VARIABLE%, but they must be
+; accessed with $VARIABLE here.  Also, ~ is expanded to $LOCALAPPDATA on Windows.
+; datadir=~/.lnd/data
+
+; The directory that logs are stored in. The logs are auto-rotated by default.
+; Rotated logs are compressed in place.
+; logdir=~/.lnd/logs
+
+; Number of logfiles that the log rotation should keep. Setting it to 0 disables deletion of old log files.
+; maxlogfiles=3
+;
+; Max log file size in MB before it is rotated.
+; maxlogfilesize=10
+
+; Path to TLS certificate for lnd's RPC and REST services.
+; tlscertpath=~/.lnd/tls.cert
+
+; Path to TLS private key for lnd's RPC and REST services.
+; tlskeypath=~/.lnd/tls.key
+
+; Disable macaroon authentication. Macaroons are used are bearer credentials to
+; authenticate all RPC access. If one wishes to opt out of macaroons, uncomment
+; the line below.
+; no-macaroons=true
+
+; Path to write the admin macaroon for lnd's RPC and REST services if it
+; doesn't exist. This can be set if one wishes to store the admin macaroon in a
+; distinct location. By default, it is stored within lnd's main home directory.
+; Applications that are able to read this file, gains admin macaroon access
+; adminmacaroonpath=~/.lnd/admin.macaroon
+
+; Path to write the read-only macaroon for lnd's RPC and REST services if it
+; doesn't exist. This can be set if one wishes to store the read-only macaroon
+; in a distinct location. The read only macaroon allows users which can read
+; the file to access RPC's which don't modify the state of the daemon.
+; readonlymacaroonpath=~/.lnd/readonly.macaroon
+
+
+; Specify the interfaces to listen on for p2p connections.  One listen
+; address per line.
+; All ipv4 on port 9735:
+;   listen=0.0.0.0:9735
+; On all ipv4 interfaces on port 9735 and ipv6 localhost port 9736:
+;   listen=0.0.0.0:9735
+;   listen=[::1]:9736
+
+; Disable listening for incoming p2p connections.  This will override all
+; listeners.
+; nolisten=1
+
+; Specify the interfaces to listen on for gRPC connections.  One listen
+; address per line.
+; Only ipv4 localhost on port 10009:
+;   rpclisten=localhost:10009
+; On ipv4 localhost port 10009 and ipv6 port 10010:
+;   rpclisten=localhost:10009
+;   rpclisten=[::1]:10010
+
+; Specify the interfaces to listen on for REST connections.  One listen
+; address per line.
+; All ipv4 interfaces on port 8080:
+;   restlisten=0.0.0.0:8080
+; On ipv4 localhost port 80 and 443:
+;   restlisten=localhost:80
+;   restlisten=localhost:443
+
+
+; Adding an external IP will advertise your node to the network. This signals
+; that your node is available to accept incoming channels. If you don't wish to
+; advertise your node, this value doesn't need to be set. Unless specified
+; (with host:port notation), the default port (9735) will be added to the
+; address.
+; externalip=
+
+
+; Debug logging level.
+; Valid levels are {trace, debug, info, warn, error, critical}
+; You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set
+; log level for individual subsystems.  Use btcd --debuglevel=show to list
+; available subsystems.
+; debuglevel=info
+
+; Write CPU profile to the specified file.
+; cpuprofile=
+
+; Enable HTTP profiling on given port -- NOTE port must be between 1024 and
+; 65536. The profile can be access at: http://localhost:<PORT>/debug/pprof/.
+; profile=
+
+; The maximum number of incoming pending channels permitted per peer.
+; maxpendingchannels=1
+
+; If true, then automatic network bootstrapping will not be attempted. This
+; means that your node won't attempt to automatically seek out peers on the
+; network.
+; nobootstrap=1
+
+; If set, your wallet will be encrypted with the default passphrase. This isn't
+; recommend, as if an attacker gains access to your wallet file, they'll be able
+; to decrypt it. This value is ONLY to be used in testing environments.
+; noencryptwallet=1
+
+; The alias your node will use, which can be up to 32 UTF-8 characters in
+; length.
+; alias=My Lightning ☇
+
+; The color of the node in hex format, used to customize node appearance in
+; intelligence services.
+; color=#3399FF
+
+
+[Bitcoin]
+
+; If the Bitcoin chain should be active. Atm, only a single chain can be
+; active.
+bitcoin.active=1
+
+; Use Bitcoin's test network.
+; bitcoin.testnet=1
+;
+; Use Bitcoin's simulation test network
+bitcoin.simnet=1
+
+; Use Bitcoin's regression test network
+; bitcoin.regtest=false
+
+; Use the btcd back-end
+bitcoin.node=btcd
+
+; Use the bitcoind back-end
+; bitcoin.node=bitcoind
+
+; Use the neutrino (light client) back-end
+; bitcoin.node=neutrino
+
+; The default number of confirmations a channel must have before it's considered
+; open. We'll require any incoming channel requests to wait this many
+; confirmations before we consider the channel active.
+; bitcoin.defaultchanconfs=3
+
+
+[Btcd]
+
+; The host that your local btcd daemon is listening on. By default, this
+; setting is assumed to be localhost with the default port for the current
+; network.
+; btcd.rpchost=localhost
+
+; Username for RPC connections to btcd. By default, lnd will attempt to
+; automatically obtain the credentials, so this likely won't need to be set
+; (other than for simnet mode).
+; btcd.rpcuser=kek
+
+; Password for RPC connections to btcd. By default, lnd will attempt to
+; automatically obtain the credentials, so this likely won't need to be set
+; (other than for simnet mode).
+; btcd.rpcpass=kek
+
+; File containing the daemon's certificate file. This only needs to be set if
+; the node isn't on the same host as lnd.
+; btcd.rpccert=~/.btcd/rpc.cert
+
+; The raw bytes of the daemon's PEM-encoded certificate chain which will be used
+; to authenticate the RPC connection. This only needs to be set if the btcd
+; node is on a remote host.
+; btcd.rawrpccert=
+
+
+[Bitcoind]
+
+; The host that your local bitcoind daemon is listening on. By default, this
+; setting is assumed to be localhost with the default port for the current
+; network.
+; bitcoind.rpchost=localhost
+
+; Username for RPC connections to bitcoind. By default, lnd will attempt to
+; automatically obtain the credentials, so this likely won't need to be set
+; (other than for a remote bitcoind instance).
+; bitcoind.rpcuser=kek
+
+; Password for RPC connections to bitcoind. By default, lnd will attempt to
+; automatically obtain the credentials, so this likely won't need to be set
+; (other than for a remote bitcoind instance).
+; bitcoind.rpcpass=kek
+
+; ZMQ socket which sends rawblock and (optionally) rawtx notifications from
+; bitcoind. By default, lnd will attempt to automatically obtain this
+; information, so this likely won't need to be set (other than for a remote
+; bitcoind instance).
+; bitcoind.zmqpath=tcp://127.0.0.1:28332
+
+
+[neutrino]
+
+; Connect only to the specified peers at startup. This creates a persistent
+; connection to a target peer. This is recommended as there aren't many
+; neutrino compliant full nodes on the test network yet.
+; neutrino.connect=
+
+; Add a peer to connect with at startup.
+; neutrino.addpeer=
+
+
+[Litecoin]
+
+; If the Litecoin chain should be active. Atm, only a single chain can be
+; active.
+; litecoin.active=1
+
+; Use Litecoin's test network.
+; litecoin.testnet=1
+
+; Use the ltcd back-end
+litecoin.node=ltcd
+
+; Use the litecoind back-end
+; litecoin.node=litecoind
+
+
+[Ltcd]
+
+; The host that your local ltcd daemon is listening on. By default, this
+; setting is assumed to be localhost with the default port for the current
+; network.
+; ltcd.rpchost=localhost
+
+; Username for RPC connections to ltcd. By default, lnd will attempt to
+; automatically obtain the credentials, so this likely won't need to be set
+; (other than for simnet mode).
+; ltcd.rpcuser=kek
+
+; Password for RPC connections to ltcd. By default, lnd will attempt to
+; automatically obtain the credentials, so this likely won't need to be set
+; (other than for simnet mode).
+; ltcd.rpcpass=kek
+
+; File containing the daemon's certificate file. This only needs to be set if
+; the node isn't on the same host as lnd.
+; ltcd.rpccert=~/.ltcd/rpc.cert
+
+; The raw bytes of the daemon's PEM-encoded certificate chain which will be used
+; to authenticate the RPC connection. This only needs to be set if the ltcd
+; node is on a remote host.
+; ltcd.rawrpccert=
+
+
+[Litecoind]
+
+; The host that your local litecoind daemon is listening on. By default, this
+; setting is assumed to be localhost with the default port for the current
+; network.
+; litecoind.rpchost=localhost
+
+; Username for RPC connections to litecoind. By default, lnd will attempt to
+; automatically obtain the credentials, so this likely won't need to be set
+; (other than for a remote litecoind instance).
+; litecoind.rpcuser=kek
+
+; Password for RPC connections to litecoind. By default, lnd will attempt to
+; automatically obtain the credentials, so this likely won't need to be set
+; (other than for a remote litecoind instance).
+; litecoind.rpcpass=kek
+
+; ZMQ socket which sends rawblock and (optionally) rawtx notifications from
+; litecoind. By default, lnd will attempt to automatically obtain this
+; information, so this likely won't need to be set (other than for a remote
+; litecoind instance).
+; litecoind.zmqpath=tcp://127.0.0.1:28332
+
+
+[autopilot]
+
+; If the autopilot agent should be active or not. The autopilot agent will
+; attempt to automatically open up channels to put your node in an advantageous
+; position within the network graph.
+; autopilot.active=1
+
+; The maximum number of channels that should be created.
+; autopilot.maxchannels=5
+
+; The fraction of total funds that should be committed to automatic channel
+; establishment. For example 0.6 means that 60% of the total funds available
+; within the wallet should be used to automatically establish channels. The total
+; amount of attempted channels will still respect the maxchannels param.
+; autopilot.allocation=0.6
+
+[tor]
+; The port that Tor's exposed SOCKS5 proxy is listening on. Using Tor allows
+; outbound-only connections (listening will be disabled) -- NOTE port must be
+; between 1024 and 65535
+; tor.socks=9050
+
+; The DNS server as IP:PORT that Tor will use for SRV queries - NOTE must have
+; TCP resolution enabled. The current active DNS sever for Testnet listening is
+; nodes.lightning.directory
+; tor.dns=nodes.lightning.directory
+
+; Enable Tor stream isolation by randomizing user credentials for each
+; connection. With this mode active, each connection will use a new circuit.
+; This means that multiple applications (other than lnd) using Tor won't be mixed
+; in with lnd's traffic.
+; tor.streamisolation=1

--- a/resources/lnd.conf
+++ b/resources/lnd.conf
@@ -1,4 +1,6 @@
 ; Imported from https://github.com/lightningnetwork/lnd/blob/v0.4.2-beta/sample-lnd.conf
+; updated to include default Zap settings
+
 [Application Options]
 
 ; The directory that lnd stores all wallet, chain, and channel related data
@@ -85,7 +87,7 @@
 ; You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set
 ; log level for individual subsystems.  Use btcd --debuglevel=show to list
 ; available subsystems.
-; debuglevel=info
+debuglevel=debug
 
 ; Write CPU profile to the specified file.
 ; cpuprofile=
@@ -123,22 +125,22 @@
 bitcoin.active=1
 
 ; Use Bitcoin's test network.
-; bitcoin.testnet=1
-;
+bitcoin.testnet=1
+
 ; Use Bitcoin's simulation test network
-bitcoin.simnet=1
+; bitcoin.simnet=1
 
 ; Use Bitcoin's regression test network
 ; bitcoin.regtest=false
 
 ; Use the btcd back-end
-bitcoin.node=btcd
+; bitcoin.node=btcd
 
 ; Use the bitcoind back-end
 ; bitcoin.node=bitcoind
 
 ; Use the neutrino (light client) back-end
-; bitcoin.node=neutrino
+bitcoin.node=neutrino
 
 ; The default number of confirmations a channel must have before it's considered
 ; open. We'll require any incoming channel requests to wait this many
@@ -207,6 +209,8 @@ bitcoin.node=btcd
 ; Add a peer to connect with at startup.
 ; neutrino.addpeer=
 
+neutrino.connect=188.166.148.62
+neutrino.connect=127.0.0.1:18333
 
 [Litecoin]
 


### PR DESCRIPTION
This enables easy access to all lnd settings for development, and is a step
toward relying on an external configuration file that will be accessible to
users for whom the code is not.