### PR TITLE
build: do not build grpc-node from source

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/LN-Zap/zap-desktop"
   },
   "scripts": {
-    "postinstall": "npm rebuild --runtime=electron --target=2.0.2 --disturl=https://atom.io/download/atom-shell --build-from-source"
+    "postinstall": "npm rebuild --runtime=electron --target=2.0.2 --disturl=https://atom.io/download/electron"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
grpc-node provides node bindings that are specifically targeted towards
electrum. Make use of these rather than force compiling grpc on install.

See https://github.com/LN-Zap/zap-desktop/issues/420