### PR TITLE
Fix build issues on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,8 @@ os: unstable
 
 environment:
   matrix:
+    - nodejs_version: 10
     - nodejs_version: 8
-    - nodejs_version: 7
 
 cache:
   - "%LOCALAPPDATA%/Yarn"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 os: unstable
 
 environment:
+  ELECTRON_DISABLE_SECURITY_WARNINGS: true
   matrix:
     - nodejs_version: 10
     - nodejs_version: 8


### PR DESCRIPTION
Builds are failing on on AppVeyor. This is due to the fact that those builds are targeting node v7, which is not supported (as per package.json `engines`).

This PR updates the AppVeyor config to get the builds passing again by specifying node v8 and v10 as our build targets.

Additionally, I have updated the travis.yml file to also specify node v8 and v10 for consistency (was previously specifying node v8 and latest - which could result in broken builds when node decide to release a new version of node)

Eg passing tests visible at https://ci.appveyor.com/project/mrfelton/zap-desktop