### PR TITLE
docs(slack-link): replace the expired slack link with a link that does…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,4 +93,4 @@ This project has eslint rules and pull requests should pass `npm run lint` befor
 Tests should try to be written for every feature/fix and pass `npm run test` before being merged. With the demand for the Lightning Network and Zap rising, rapid development will naturally leave some code untested but we should all try our best.
 
 [issues]: https://github.com/LN-Zap/zap-desktop/issues
-[slack]: https://join.slack.com/t/zaphq/shared_invite/enQtMzMxMzIzNDU0NTY3LTgyM2QwYzAyZTA5OTAyMjEwMTQxZmZmZmZkNWUzMTU2MmMyNmMxNjY4Y2VjY2FiYTRkMTkwMTRlMTE4YjM2MWY
+[slack]: https://join.slack.com/t/zaphq/shared_invite/enQtMzgyNDA2NDI2Nzg0LTQwZWQ2ZWEzOWFhMjRiNWZkZWMwYTA4MzA5NzhjMDNhNTM5YzliNDA4MmZkZWZkZTFmODM4ODJkYzU3YmI3ZmI

--- a/README.md
+++ b/README.md
@@ -135,4 +135,4 @@ This project is open source under the MIT license, which means you have full acc
 
 [issues]: https://github.com/LN-Zap/zap-desktop/issues
 [releases]: https://github.com/LN-Zap/zap-desktop/releases
-[slack]: https://join.slack.com/t/zaphq/shared_invite/enQtMzMxMzIzNDU0NTY3LTgyM2QwYzAyZTA5OTAyMjEwMTQxZmZmZmZkNWUzMTU2MmMyNmMxNjY4Y2VjY2FiYTRkMTkwMTRlMTE4YjM2MWY
+[slack]: https://join.slack.com/t/zaphq/shared_invite/enQtMzgyNDA2NDI2Nzg0LTQwZWQ2ZWEzOWFhMjRiNWZkZWMwYTA4MzA5NzhjMDNhNTM5YzliNDA4MmZkZWZkZTFmODM4ODJkYzU3YmI3ZmI


### PR DESCRIPTION
… not expire

I finally figured out how to get a slack invite that does not expire. I have updated the slack invite on `zap.jackmallers.com` and now with this PR our readme will be updated with an active slack invite as well.