### PR TITLE
Ensure webpack build output is in colour

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.1",
   "description": "desktop application for the lightning network",
   "scripts": {
-    "build": "concurrently \"npm run build-main\" \"npm run build-renderer\"",
+    "build": "concurrently --raw \"npm run build-main\" \"npm run build-renderer\"",
     "build-dll": "cross-env NODE_ENV=development node --trace-warnings -r babel-register ./node_modules/webpack/bin/webpack --config webpack.config.renderer.dev.dll.js --colors",
     "build-main": "cross-env NODE_ENV=production node --trace-warnings -r babel-register ./node_modules/webpack/bin/webpack --config webpack.config.main.prod.js --colors",
     "build-renderer": "cross-env NODE_ENV=production node --trace-warnings -r babel-register ./node_modules/webpack/bin/webpack --config webpack.config.renderer.prod.js --colors",
@@ -24,7 +24,7 @@
     "package-all": "npm run build && build -mwl",
     "package-linux": "npm run build && build --linux",
     "package-win": "npm run build && build --win",
-    "postinstall": "concurrently \"npm run flow-typed\" \"npm run build-dll\" \"electron-builder install-app-deps\" \"node node_modules/fbjs-scripts/node/check-dev-engines.js package.json\"",
+    "postinstall": "concurrently --raw \"npm run flow-typed\" \"npm run build-dll\" \"electron-builder install-app-deps\" \"node node_modules/fbjs-scripts/node/check-dev-engines.js package.json\"",
     "prestart": "npm run build",
     "start": "cross-env NODE_ENV=production electron ./app/",
     "start-main-dev": "cross-env HOT=1 NODE_ENV=development electron -r babel-register ./app/main.dev",


### PR DESCRIPTION
pass the `--raw` flag to concurrently so that we see the raw output of our processes, rather than a version which has been mangled by concurrently. This ensures that the webpack build output is in colour more legible.

To test: run `npm run build`:

**before:**
<img width="1113" alt="screenshot 2018-06-20 17 57 49" src="https://user-images.githubusercontent.com/200251/41670217-fd70c762-74b3-11e8-9bf9-848c907e718a.png">

**after:**
<img width="1102" alt="screenshot 2018-06-20 17 58 33" src="https://user-images.githubusercontent.com/200251/41670223-02e9a024-74b4-11e8-9136-394116df7c39.png">
