### PR TITLE
lint: Remove redundant eslint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,8 +23,6 @@
     "node": true
   },
   "rules": {
-    "comma-dangle": ["error", "never"],
-    "semi": ["error", "never"],
     "prettier/prettier": "error",
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "react/no-did-mount-set-state": 0,

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint-styles": "npm run lint-styles-base -- app/*.scss app/components/*.scss",
     "lint-styles-fix-base": "npm run lint-styles-base -- --fix",
     "lint-styles-fix": "npm run lint-styles-fix-base -- app/*.scss app/components/*.scss",
+    "lint-check": "eslint --print-config .eslintrc.js | eslint-config-prettier-check",
     "lint-ci": "npm run lint && npm run lint-styles && npm run flow",
     "package": "npm run build && build --publish never",
     "package-all": "npm run build && build -mwl",


### PR DESCRIPTION
Indentified via eslint-config-prettier's check script. Prettier applies standards that directly enforce these.