### PR TITLE
fix(log): fix the uncaught exception by calling info on log not lnd

### DIFF
--- a/app/lnd/subscribe/transactions.js
+++ b/app/lnd/subscribe/transactions.js
@@ -1,7 +1,7 @@
 export default function subscribeToTransactions(mainWindow, lnd, log) {
   const call = lnd.subscribeTransactions({})
   call.on('data', transaction => {
-    lnd.log.info('TRANSACTION:', transaction)
+    log.info('TRANSACTION:', transaction)
     mainWindow.send('newTransaction', { transaction })
   })
   call.on('end', () => log.info('end'))


### PR DESCRIPTION
Subscribe transaction on `data` was throwing a `Uncaught Exception error` because our `log.info` was being called on the `LND` object

<img width="422" alt="screen shot 2018-06-21 at 1 47 46 pm" src="https://user-images.githubusercontent.com/4040039/41739487-d11a1eb4-755a-11e8-8f62-54d9b060f926.png">
