### PR TITLE
fix: Don't catch api/index errors

### DIFF
--- a/app/api/index.js
+++ b/app/api/index.js
@@ -5,9 +5,7 @@ export function requestTicker(id) {
   return axios({
     method: 'get',
     url: BASE_URL
-  })
-    .then(response => response.data)
-    .catch(error => error)
+  }).then(response => response.data)
 }
 
 export function requestTickers(ids) {
@@ -23,9 +21,7 @@ export function requestBlockHeight() {
   return axios({
     method: 'get',
     url: BASE_URL
-  })
-    .then(response => response.data)
-    .catch(error => error)
+  }).then(response => response.data)
 }
 
 export function requestSuggestedNodes() {
@@ -33,7 +29,5 @@ export function requestSuggestedNodes() {
   return axios({
     method: 'get',
     url: BASE_URL
-  })
-    .then(response => response.data)
-    .catch(error => error)
+  }).then(response => response.data)
 }


### PR DESCRIPTION
If we catch these errors and resolve to the error itself, then `await` for that
function resolves to the error value rather than throws. Because no api currently
handles the associated errors, it is better to be noisy about these errors, by
throwing rather than returning the error object.