### PR TITLE
Feature/testnet prefix channel balance

### DIFF
--- a/app/components/Contacts/Network.js
+++ b/app/components/Contacts/Network.js
@@ -361,7 +361,7 @@ Network.propTypes = {
   setSelectedChannel: PropTypes.func.isRequired,
   closeChannel: PropTypes.func.isRequired,
 
-  closeChannel: PropTypes.string.isRequired
+  currencyName: PropTypes.string.isRequired
 }
 
 export default Network

--- a/app/components/Contacts/Network.js
+++ b/app/components/Contacts/Network.js
@@ -57,7 +57,9 @@ class Network extends Component {
 
       suggestedNodesProps,
 
-      network
+      network,
+
+      currencyName
     } = this.props
 
     const refreshClicked = () => {
@@ -151,7 +153,7 @@ class Network extends Component {
           <section>
             <h2>My Network</h2>
             <span className={styles.channelAmount}>
-              {btc.satoshisToBtc(balance.channelBalance)}BTC ≈ ${usdAmount
+              {btc.satoshisToBtc(balance.channelBalance)} {currencyName} ≈ ${usdAmount
                 ? usdAmount.toLocaleString()
                 : ''}
             </span>
@@ -357,7 +359,9 @@ Network.propTypes = {
   changeFilter: PropTypes.func.isRequired,
   updateChannelSearchQuery: PropTypes.func.isRequired,
   setSelectedChannel: PropTypes.func.isRequired,
-  closeChannel: PropTypes.func.isRequired
+  closeChannel: PropTypes.func.isRequired,
+
+  closeChannel: PropTypes.string.isRequired
 }
 
 export default Network

--- a/app/routes/app/containers/AppContainer.js
+++ b/app/routes/app/containers/AppContainer.js
@@ -313,6 +313,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     nonActiveFilters: stateProps.nonActiveFilters,
     ticker: stateProps.ticker,
     network: stateProps.info.network,
+    currencyName: stateProps.currencyName,
 
     fetchChannels: dispatchProps.fetchChannels,
     openContactsForm: dispatchProps.openContactsForm,


### PR DESCRIPTION
We had `BTC` hardcoded next to the channel balance in our Network tab. This just replaces it with the dynamic `currencyName` prop