### PR TITLE
Do not bundle moment locale data data that we don't use

### DIFF
--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -3,6 +3,7 @@
  */
 
 import path from 'path'
+import { IgnorePlugin } from 'webpack'
 import { dependencies as externals } from './app/package.json'
 
 export default {
@@ -37,6 +38,8 @@ export default {
     extensions: ['.js', '.jsx', '.json'],
     modules: [path.join(__dirname, 'app'), 'node_modules']
   },
+
+  plugins: [new IgnorePlugin(/^\.\/locale$/, /moment$/)],
 
   optimization: {
     namedModules: true


### PR DESCRIPTION
More work to reduce the size of our bundle - this helps speed up the initial load time of the app.

We aren't using moment locales, yet they are being bundled with our app and causing significant bloat.

Removing these shaves an additional 136.63k of our final renderer.prod.js bundle size, bringing it down from 1.12mb to just under 1mb.

More info:
 - https://github.com/jmblog/how-to-optimize-momentjs-with-webpack
 - https://medium.com/@michalozogan/how-to-split-moment-js-locales-to-chunks-with-webpack-de9e25caccea

**before:**
<img width="1398" alt="2-react-icons" src="https://user-images.githubusercontent.com/200251/41797553-c0e242f4-766a-11e8-8432-26b696f7a966.png">

**after:**
<img width="1396" alt="3-moment-locale" src="https://user-images.githubusercontent.com/200251/41797564-c61057ca-766a-11e8-9e10-d70d4da3d262.png">
