### PR TITLE
Remove lodash dependency

### DIFF
--- a/app/components/Contacts/ContactModal.js
+++ b/app/components/Contacts/ContactModal.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import find from 'lodash/find'
 import ReactModal from 'react-modal'
 import FaCircle from 'react-icons/lib/fa/circle'
 import MdClose from 'react-icons/lib/md/close'
@@ -47,7 +46,7 @@ const ContactModal = ({
   }
 
   // the remote node for the channel
-  const node = find(channelNodes, { pub_key: channel.remote_pubkey })
+  const node = channelNodes.find(node => node.pub_key === channel.remote_pubkey)
 
   return (
     <ReactModal

--- a/app/components/Contacts/Network.js
+++ b/app/components/Contacts/Network.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import find from 'lodash/find'
 import Isvg from 'react-inlinesvg'
 import FaExternalLink from 'react-icons/lib/fa/external-link'
 import FaCircle from 'react-icons/lib/fa/circle'
@@ -108,7 +107,7 @@ class Network extends Component {
     }
 
     const displayNodeName = displayedChannel => {
-      const node = find(nodes, n => displayedChannel.remote_pubkey === n.pub_key)
+      const node = nodes.find(n => displayedChannel.remote_pubkey === n.pub_key)
 
       if (node && node.alias.length) {
         return node.alias
@@ -213,7 +212,7 @@ class Network extends Component {
             {loadingChannelPubkeys.length &&
               loadingChannelPubkeys.map(loadingPubkey => {
                 // TODO(jimmymow): refactor this out. same logic is in displayNodeName above
-                const node = find(nodes, n => loadingPubkey === n.pub_key)
+                const node = nodes.find(n => loadingPubkey === n.pub_key)
                 const nodeDisplay = () => {
                   if (node && node.alias.length) {
                     return node.alias

--- a/app/components/Form/Pay.js
+++ b/app/components/Form/Pay.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import find from 'lodash/find'
 
 import Isvg from 'react-inlinesvg'
 import paperPlane from 'icons/paper_plane.svg'
@@ -59,7 +58,7 @@ class Pay extends Component {
     } = this.props
 
     const displayNodeName = pubkey => {
-      const node = find(nodes, n => n.pub_key === pubkey)
+      const node = nodes.find(n => n.pub_key === pubkey)
 
       if (node && node.alias.length) {
         return node.alias

--- a/app/lnd/methods/channelController.js
+++ b/app/lnd/methods/channelController.js
@@ -1,10 +1,9 @@
-import find from 'lodash/find'
 import { listPeers, connectPeer } from './peersController'
 import pushopenchannel from '../push/openchannel'
 
 function ensurePeerConnected(lnd, pubkey, host) {
   return listPeers(lnd).then(({ peers }) => {
-    const peer = find(peers, { pub_key: pubkey })
+    const peer = peers.find(candidatePeer => candidatePeer.pub_key === pubkey)
     if (peer) {
       return peer
     }

--- a/app/reducers/channels.js
+++ b/app/reducers/channels.js
@@ -1,6 +1,5 @@
 import { createSelector } from 'reselect'
 import { ipcRenderer } from 'electron'
-import filter from 'lodash/filter'
 import { btc } from 'utils'
 import { showNotification } from 'notifications'
 import { requestSuggestedNodes } from '../api'
@@ -483,7 +482,7 @@ channelsSelectors.channelNodes = createSelector(
   (channels, nodes) => {
     const chanPubkeys = channels.map(channel => channel.remote_pubkey)
 
-    return filter(nodes, node => chanPubkeys.includes(node.pub_key))
+    return nodes.filter(node => chanPubkeys.includes(node.pub_key))
   }
 )
 

--- a/app/reducers/contactsform.js
+++ b/app/reducers/contactsform.js
@@ -1,6 +1,4 @@
 import { createSelector } from 'reselect'
-import filter from 'lodash/filter'
-import isEmpty from 'lodash/isEmpty'
 
 import { tickerSelectors } from './ticker'
 import { btc } from '../utils'
@@ -234,10 +232,9 @@ contactFormSelectors.filteredNetworkNodes = createSelector(
     const query = searchQuery.includes('@') ? searchQuery.split('@')[0] : searchQuery
 
     // list of the nodes
-    const list = filter(
-      nodes,
-      node => node.alias.includes(query) || node.pub_key.includes(query)
-    ).sort(contactableFirst)
+    const list = nodes
+      .filter(node => node.alias.includes(query) || node.pub_key.includes(query))
+      .sort(contactableFirst)
 
     // if we don't limit the nodes returned then we take a huge performance hit
     // rendering thousands of nodes potentially, so we just render 20 for the time being
@@ -270,7 +267,7 @@ contactFormSelectors.manualFormIsValid = createSelector(manualSearchQuerySelecto
   }
   return {
     errors,
-    isValid: isEmpty(errors)
+    isValid: Object.keys(errors).length === 0
   }
 })
 

--- a/app/reducers/payform.js
+++ b/app/reducers/payform.js
@@ -1,8 +1,6 @@
 import { createSelector } from 'reselect'
 import bitcoin from 'bitcoinjs-lib'
 
-import isEmpty from 'lodash/isEmpty'
-
 import { setFormType } from './form'
 import { tickerSelectors } from './ticker'
 import { infoSelectors } from './info'
@@ -267,9 +265,9 @@ payFormSelectors.payFormIsValid = createSelector(
 
     return {
       errors,
-      amountIsValid: isEmpty(errors.amount),
-      payInputIsValid: isEmpty(errors.payInput),
-      isValid: isEmpty(errors)
+      amountIsValid: !errors.amount,
+      payInputIsValid: !errors.payInput,
+      isValid: Object.keys(errors).length === 0
     }
   }
 )

--- a/app/routes/activity/components/components/Payment/Payment.js
+++ b/app/routes/activity/components/components/Payment/Payment.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import find from 'lodash/find'
 import Moment from 'react-moment'
 import { btc } from 'utils'
 
@@ -9,7 +8,7 @@ import styles from '../Activity.scss'
 
 const Payment = ({ payment, ticker, currentTicker, showActivityModal, nodes, currencyName }) => {
   const displayNodeName = pubkey => {
-    const node = find(nodes, n => pubkey === n.pub_key)
+    const node = nodes.find(n => pubkey === n.pub_key)
 
     if (node && node.alias.length) {
       return node.alias

--- a/package.json
+++ b/package.json
@@ -229,7 +229,6 @@
     "electron-store": "^2.0.0",
     "font-awesome": "^4.7.0",
     "history": "^4.6.3",
-    "lodash": "^4.17.10",
     "moment": "^2.22.2",
     "prop-types": "^15.5.10",
     "qrcode.react": "0.8.0",


### PR DESCRIPTION
We only use 3 functions from lodash - `find`, `filter` and `isEmpty` - all of which can be done easily with straight ES6.

This PR removes lodash.

Shaves a nominal 34.57k of final renderer.prod.js bundle size.

**before:**
<img width="1396" alt="3-moment-locale" src="https://user-images.githubusercontent.com/200251/41797962-40cca300-766c-11e8-99ac-26819d4df8fd.png">

**after:**
<img width="1397" alt="4-lodash" src="https://user-images.githubusercontent.com/200251/41797965-466062d4-766c-11e8-9a1f-4f67bfa277e9.png">
