### PR TITLE
Do not bundle moment-timezone that we don't use 

### DIFF
--- a/app/components/Activity/InvoiceModal.js
+++ b/app/components/Activity/InvoiceModal.js
@@ -2,7 +2,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import Moment from 'react-moment'
-import 'moment-timezone'
 
 import QRCode from 'qrcode.react'
 import copy from 'copy-to-clipboard'

--- a/app/components/Activity/PaymentModal.js
+++ b/app/components/Activity/PaymentModal.js
@@ -2,7 +2,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import Moment from 'react-moment'
-import 'moment-timezone'
 
 import FaAngleDown from 'react-icons/lib/fa/angle-down'
 

--- a/app/components/Activity/TransactionModal.js
+++ b/app/components/Activity/TransactionModal.js
@@ -2,7 +2,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import Moment from 'react-moment'
-import 'moment-timezone'
 
 import FaAngleDown from 'react-icons/lib/fa/angle-down'
 

--- a/app/routes/activity/components/components/Invoice/Invoice.js
+++ b/app/routes/activity/components/components/Invoice/Invoice.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Moment from 'react-moment'
-import 'moment-timezone'
 import { btc } from 'utils'
 
 import Isvg from 'react-inlinesvg'

--- a/app/routes/activity/components/components/Payment/Payment.js
+++ b/app/routes/activity/components/components/Payment/Payment.js
@@ -2,7 +2,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import find from 'lodash/find'
 import Moment from 'react-moment'
-import 'moment-timezone'
 import { btc } from 'utils'
 
 import Value from 'components/Value'

--- a/app/routes/activity/components/components/Transaction/Transaction.js
+++ b/app/routes/activity/components/components/Transaction/Transaction.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Moment from 'react-moment'
-import 'moment-timezone'
 import { btc } from 'utils'
 
 import Value from 'components/Value'

--- a/package.json
+++ b/package.json
@@ -236,7 +236,7 @@
     "font-awesome": "^4.7.0",
     "history": "^4.6.3",
     "lodash": "^4.17.10",
-    "moment-timezone": "^0.5.13",
+    "moment": "^2.22.2",
     "prop-types": "^15.5.10",
     "qrcode.react": "0.8.0",
     "react": "^15.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8059,15 +8059,9 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkd
   dependencies:
     minimist "0.0.8"
 
-moment-timezone@^0.5.13:
-  version "0.5.13"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.13.tgz#99ce5c7d827262eb0f1f702044177f60745d7b90"
-  dependencies:
-    moment ">= 2.9.0"
-
-"moment@>= 2.9.0":
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
+moment@^2.22.2:
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
We don't use `moment-timezone` at all. This can be replaced with `moment` for a smaller memory footprint.

This PR removes `moment-timezone`

Shaves another 176.88k of final renderer.prod.js bundle size.

**before:**
<img width="1397" alt="4-lodash" src="https://user-images.githubusercontent.com/200251/41800114-6138747c-7674-11e8-9ce2-22c12b833ce6.png">

**after:**
<img width="1399" alt="5-moment-timezone" src="https://user-images.githubusercontent.com/200251/41800123-6603a422-7674-11e8-9560-8d1531387226.png">
