### PR TITLE
fix(p2pkh): generate np2wkh instead of p2pkh

### DIFF
--- a/app/reducers/transaction.js
+++ b/app/reducers/transaction.js
@@ -115,7 +115,7 @@ export const newTransaction = (event, { transaction }) => dispatch => {
   showNotification(notifTitle, notifBody)
 
   // Generate a new address
-  dispatch(newAddress('p2pkh'))
+  dispatch(newAddress('np2wkh'))
 }
 
 // ------------------------------------


### PR DESCRIPTION
We shouldn't be generating `p2pkh` addresses. We were when a new transaction was received. This switches to generating a `np2wkh` address