### PR TITLE
fix(husky hooks): drop opt --in from husky hooks

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,6 +1,6 @@
 {
   "hooks": {
-    "commit-msg": "opt --in commit-msg --exec 'commitlint -E HUSKY_GIT_PARAMS'",
-    "pre-commit": "opt --in pre-commit --exec 'lint-staged'"
+    "commit-msg": "commitlint --env HUSKY_GIT_PARAMS",
+    "pre-commit": "lint-staged"
   }
 }


### PR DESCRIPTION
With opt --in present, the hooks are not run, without it they are.