### PR TITLE
enhance(mainnet conf): add an lnd.conf entry for bitcoin.mainnet

### DIFF
--- a/resources/lnd.conf
+++ b/resources/lnd.conf
@@ -124,6 +124,9 @@ debuglevel=debug
 ; active.
 bitcoin.active=1
 
+; Use Bitcoin's main network.
+; bitcoin.mainnet=1
+
 ; Use Bitcoin's test network.
 bitcoin.testnet=1
 


### PR DESCRIPTION
Commented out as testnet is still our default.