### PR TITLE
fix(waiting_close_channels): account for waiting_close_channels

### DIFF
--- a/app/components/Contacts/Network.js
+++ b/app/components/Contacts/Network.js
@@ -130,6 +130,11 @@ class Network extends Component {
         return 'closing'
       }
 
+      // if the channel is in waiting_close_channels phase
+      if (Object.prototype.hasOwnProperty.call(statusChannel, 'waiting_close_channels')) {
+        return 'closing'
+      }
+
       // if we are in the process of closing this channel
       if (closingChannelIds.includes(statusChannel.chan_id)) {
         return 'closing'

--- a/app/reducers/channels.js
+++ b/app/reducers/channels.js
@@ -404,6 +404,8 @@ const channelsSelector = state => state.channels.channels
 const pendingOpenChannelsSelector = state => state.channels.pendingChannels.pending_open_channels
 const pendingClosedChannelsSelector = state =>
   state.channels.pendingChannels.pending_closing_channels
+const pendingWaitingCloseChannelsSelector = state =>
+  state.channels.pendingChannels.waiting_close_channels
 const pendingForceClosedChannelsSelector = state =>
   state.channels.pendingChannels.pending_force_closing_channels
 const waitingCloseChannelsSelector = state => state.channels.pendingChannels.waiting_close_channels
@@ -457,9 +459,11 @@ channelsSelectors.pendingOpenChannelPubkeys = createSelector(
 channelsSelectors.closingPendingChannels = createSelector(
   pendingClosedChannelsSelector,
   pendingForceClosedChannelsSelector,
-  (pendingClosedChannels, pendingForcedClosedChannels) => [
+  pendingWaitingCloseChannelsSelector,
+  (pendingClosedChannels, pendingForcedClosedChannels, pendingWaitingCloseChannels) => [
     ...pendingClosedChannels,
-    ...pendingForcedClosedChannels
+    ...pendingForcedClosedChannels,
+    ...pendingWaitingCloseChannels
   ]
 )
 


### PR DESCRIPTION
`waiting_close_channels` is a fairly new property of the `pendingChannels` object returned by `LND`. any channels that were returned in this list were:

1) displayed as `offline`
2) not included in the `Closing` filter in the channels list

This PR just accounts for `waiting_close_channels` and fixes both issues above