### PR TITLE
fix(channel-details): use currencyName

### DIFF
--- a/app/components/Contacts/Network.js
+++ b/app/components/Contacts/Network.js
@@ -284,7 +284,7 @@ class Network extends Component {
                               currency={ticker.currency}
                               currentTicker={currentTicker}
                             />
-                            <i> {ticker.currency.toUpperCase()}</i>
+                            <i> {currencyName}</i>
                           </p>
                         </section>
                         <section>


### PR DESCRIPTION
We weren't using `currencyName` in the channel details. This fixes that