### PR TITLE
style(husky hooks): drop opt --in from husky hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,3 @@ npm-debug.log.*
 
 # lnd binary
 resources/bin/
-
-# Opt in files
-.opt-in
-.opt-out

--- a/.huskyrc
+++ b/.huskyrc
@@ -1,6 +1,6 @@
 {
   "hooks": {
-    "commit-msg": "opt --in commit-msg --exec 'commitlint -E HUSKY_GIT_PARAMS'",
-    "pre-commit": "opt --in pre-commit --exec 'lint-staged'"
+    "commit-msg": "commitlint --env HUSKY_GIT_PARAMS",
+    "pre-commit": "lint-staged"
   }
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,20 +61,13 @@ git commit -m "feat(close-channel): wire up close channel to UI"
 
 Please make sure to run the tests before you commit your changes. You can run `npm test` which will run the test suite.
 
-### Opt into git hooks
+### Git hooks
 
-There are git hooks set up with this project that are automatically installed when you install dependencies. They're really handy, but are turned off by default (so as to not hinder new contributors). You can opt into these by creating a file called `.opt-in` at the root of the project:
+There are git hooks set up with this project that are automatically installed when you install dependencies. They're really handy, with them in place you will get:
 
-```bash
-echo commit-msg >> .opt-in
-echo pre-commit >> .opt-in
-```
-
-With this in place you will get:
-
-1.  Automatic reformatting of changed files on commit
-1.  Automatic lint of changed files on commit (will not allow commit with files that fail lint)
-1.  Automatic validation of commit message format (will not allow commit with invalid commit message)
+1.  Automatic reformatting of changed files on commit via [prettier][prettier]
+1.  Automatic lint of changed files on commit (will not allow commit with files that fail lint) via [eslint][eslint]
+1.  Automatic validation of commit message format (will not allow commit with invalid commit message) via [commitlint][commitlint]
 
 ### Branch Names
 
@@ -98,6 +91,9 @@ This project has eslint rules and pull requests should pass `npm run lint` befor
 
 Tests should try to be written for every feature/fix and pass `npm run test` before being merged. With the demand for the Lightning Network and Zap rising, rapid development will naturally leave some code untested but we should all try our best.
 
+[commitlint]: http://marionebl.github.io/commitlint/#/
 [convention]: https://conventionalcommits.org/
+[eslint]: https://eslint.org/
 [issues]: https://github.com/LN-Zap/zap-desktop/issues
+[prettier]: https://prettier.io/
 [slack]: https://join.slack.com/t/zaphq/shared_invite/enQtMzgyNDA2NDI2Nzg0LTQwZWQ2ZWEzOWFhMjRiNWZkZWMwYTA4MzA5NzhjMDNhNTM5YzliNDA4MmZkZWZkZTFmODM4ODJkYzU3YmI3ZmI

--- a/package.json
+++ b/package.json
@@ -200,7 +200,6 @@
     "lint-staged": "^7.2.0",
     "minimist": "^1.2.0",
     "node-sass": "^4.9.0",
-    "opt-cli": "^1.6.0",
     "prettier": "^1.13.5",
     "ps-node": "^0.1.6",
     "react-addons-test-utils": "^15.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2811,10 +2811,6 @@ combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.11.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
-
 commander@2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.6.0.tgz#9df7e52fb2a0cb0fb89058ee80c3104225f37e1d"
@@ -7282,10 +7278,6 @@ lodash.camelcase@4.3.0, lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
 
-lodash.clone@4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.5.0.tgz#195870450f5a13192478df4bc3d23d2dea1907b6"
-
 lodash.clonedeep@^4.3.2:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
@@ -7563,10 +7555,6 @@ makeerror@1.0.x:
 mamacro@^0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/mamacro/-/mamacro-0.0.3.tgz#ad2c9576197c9f1abf308d0787865bd975a3f3e4"
-
-manage-path@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/manage-path/-/manage-path-2.0.0.tgz#f4cf8457b926eeee2a83b173501414bc76eb9597"
 
 map-cache@^0.2.2:
   version "0.2.2"
@@ -8386,15 +8374,6 @@ opn@^5.1.0:
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.3.0.tgz#64871565c863875f052cfdf53d3e3cb5adb53b1c"
   dependencies:
     is-wsl "^1.1.0"
-
-opt-cli@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/opt-cli/-/opt-cli-1.6.0.tgz#79d7dc2ccb180c3f05c34b077a34a37618b2a273"
-  dependencies:
-    commander "2.11.0"
-    lodash.clone "4.5.0"
-    manage-path "2.0.0"
-    spawn-command "0.0.2-1"
 
 optimist@^0.6.1, optimist@~0.6.1:
   version "0.6.1"
@@ -10665,7 +10644,7 @@ sparkles@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/sparkles/-/sparkles-1.0.0.tgz#1acbbfb592436d10bbe8f785b7cc6f82815012c3"
 
-spawn-command@0.0.2-1, spawn-command@^0.0.2-1:
+spawn-command@^0.0.2-1:
   version "0.0.2-1"
   resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2-1.tgz#62f5e9466981c1b796dc5929937e11c9c6921bd0"
 


### PR DESCRIPTION
Make the linters run automatically for all users. This helps ensure that all
contributions adhere to our practices.