### PR TITLE
fix(grpc): handle gRPC startup issues

### DIFF
--- a/app/lnd/index.js
+++ b/app/lnd/index.js
@@ -7,24 +7,27 @@ import walletUnlockerMethods from './walletUnlockerMethods'
 // use mainLog because lndLog is reserved for the lnd binary itself
 import { mainLog } from '../utils/log'
 
-const initLnd = callback => {
+const initLnd = () => {
   const lndConfig = config.lnd()
   const lnd = lightning(lndConfig.lightningRpc, lndConfig.lightningHost)
 
   const lndSubscribe = mainWindow => subscribe(mainWindow, lnd, mainLog)
   const lndMethods = (event, msg, data) => methods(lnd, mainLog, event, msg, data)
 
-  callback(lndSubscribe, lndMethods)
+  return {
+    lndSubscribe,
+    lndMethods
+  }
 }
 
-const initWalletUnlocker = callback => {
+const initWalletUnlocker = () => {
   const lndConfig = config.lnd()
 
   const walletUnlockerObj = walletUnlocker(lndConfig.lightningRpc, lndConfig.lightningHost)
   const walletUnlockerMethodsCallback = (event, msg, data) =>
     walletUnlockerMethods(walletUnlockerObj, mainLog, event, msg, data)
 
-  callback(walletUnlockerMethodsCallback)
+  return walletUnlockerMethodsCallback
 }
 
 export default {

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -109,7 +109,10 @@ const sendGrpcConnected = () => {
 
 // Create and subscribe the grpc object
 const startGrpc = () => {
-  lnd.initLnd((lndSubscribe, lndMethods) => {
+  mainLog.info('Starting gRPC...')
+  try {
+    const { lndSubscribe, lndMethods } = lnd.initLnd()
+
     // Subscribe to bi-directional streams
     lndSubscribe(mainWindow)
 
@@ -119,19 +122,34 @@ const startGrpc = () => {
     })
 
     sendGrpcConnected()
-  })
+  } catch (error) {
+    dialog.showMessageBox({
+      type: 'error',
+      message: `Unable to connect to lnd. Please check your lnd node and try again: ${error}`
+    })
+    app.quit()
+  }
 }
 
 // Create and subscribe the grpc object
 const startWalletUnlocker = () => {
-  lnd.initWalletUnlocker(walletUnlockerMethods => {
+  mainLog.info('Starting wallet unlocker...')
+  try {
+    const walletUnlockerMethods = lnd.initWalletUnlocker()
+
     // Listen for all gRPC restful methods
     ipcMain.on('walletUnlocker', (event, { msg, data }) => {
       walletUnlockerMethods(event, msg, data)
     })
-  })
 
-  mainWindow.webContents.send('walletUnlockerStarted')
+    mainWindow.webContents.send('walletUnlockerStarted')
+  } catch (error) {
+    dialog.showMessageBox({
+      type: 'error',
+      message: `Unable to start lnd wallet unlocker. Please check your lnd node and try again: ${error}`
+    })
+    app.quit()
+  }
 }
 
 // Send the front end event letting them know LND is synced to the blockchain


### PR DESCRIPTION
If there is a problem initializing the lnd gRPC connection, show an error message to the user and quit the app.

This is an extraction of some of the changes from https://github.com/LN-Zap/zap-desktop/pull/479