### PR TITLE
fix(devtools): patch webrequest to fix devtools

### DIFF
--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -10,7 +10,7 @@
  *
  *
  */
-import { app, BrowserWindow, ipcMain, dialog } from 'electron'
+import { app, BrowserWindow, ipcMain, dialog, session } from 'electron'
 import path from 'path'
 import fs from 'fs'
 import split2 from 'split2'
@@ -341,6 +341,21 @@ app.on('ready', async () => {
       mainLog.info('CONNECTING TO CUSTOM LND INSTANCE')
       startGrpc()
       mainWindow.webContents.send('successfullyCreatedWallet')
+    }
+  })
+
+  // HACK: patch webrequest to fix devtools incompatibility with electron 2.x.
+  // See https://github.com/electron/electron/issues/13008#issuecomment-400261941
+  session.defaultSession.webRequest.onBeforeRequest({}, (details, callback) => {
+    if (details.url.indexOf('hack') !== -1) {
+      callback({
+        redirectURL: details.url.replace(
+          '7accc8730b0f99b5e7c0702ea89d1fa7c17bfe33',
+          '57c9d07b416b5a2ea23d28247300e4af36329bdc'
+        )
+      })
+    } else {
+      callback({ cancel: false })
     }
   })
 })


### PR DESCRIPTION
Fix an incompatibility between electron 2.x and devtools by patching the electron webRequest handler.

See https://github.com/electron/electron/issues/13008#issuecomment-400261941

Fix #490