### PR TITLE
Fix devtools electron compatibility issues

### DIFF
--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -369,7 +369,7 @@ app.on('ready', async () => {
   // HACK: patch webrequest to fix devtools incompatibility with electron 2.x.
   // See https://github.com/electron/electron/issues/13008#issuecomment-400261941
   session.defaultSession.webRequest.onBeforeRequest({}, (details, callback) => {
-    if (details.url.indexOf('hack') !== -1) {
+    if (details.url.indexOf('7accc8730b0f99b5e7c0702ea89d1fa7c17bfe33') !== -1) {
       callback({
         redirectURL: details.url.replace(
           '7accc8730b0f99b5e7c0702ea89d1fa7c17bfe33',


### PR DESCRIPTION
It looks like there was a typo in the fix for https://github.com/LN-Zap/zap-desktop/pull/491. This PR corrects it.