### PR TITLE
Update electron and electron builder to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "cross-spawn": "^6.0.5",
     "csp-html-webpack-plugin": "^2.3.0",
     "css-loader": "^0.28.11",
-    "electron-builder": "^20.15.3",
+    "electron-builder": "^20.16.4",
     "electron-devtools-installer": "^2.2.4",
     "enzyme": "^2.9.1",
     "enzyme-to-json": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
     "copy-to-clipboard": "^3.0.8",
     "debug-logger": "^0.4.1",
     "devtron": "^1.4.0",
-    "electron": "2.0.2",
+    "electron": "^2.0.3",
     "electron-debug": "^2.0.0",
     "electron-store": "^2.0.0",
     "font-awesome": "^4.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3991,9 +3991,9 @@ electron-to-chromium@^1.3.47:
   version "1.3.48"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.48.tgz#d3b0d8593814044e092ece2108fc3ac9aea4b900"
 
-electron@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.2.tgz#b77e05f83419cc5ec921a2d21f35b55e4bfc3d68"
+electron@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.3.tgz#8e591e820cae2ccdb0c3fd74c6d07834913fc133"
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -525,7 +525,7 @@ ajv@^6.0.1:
     json-schema-traverse "^0.3.0"
     uri-js "^3.0.2"
 
-ajv@^6.1.0, ajv@^6.4.0:
+ajv@^6.1.0, ajv@^6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.1.tgz#88ebc1263c7133937d108b80c5572e64e1d9322d"
   dependencies:
@@ -615,13 +615,9 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-app-builder-bin@1.9.11:
-  version "1.9.11"
-  resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-1.9.11.tgz#bf04d4cdfc0a8ed83acedc5f9ab16be73b5a3a57"
-
-app-builder-bin@1.9.5:
-  version "1.9.5"
-  resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-1.9.5.tgz#f4e2b26e26578c9a48cea85da44f0bc1a7582fc0"
+app-builder-bin@1.9.16:
+  version "1.9.16"
+  resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-1.9.16.tgz#c9e8bc837bfc5452b5396bc6959ed81cfff5fb6a"
 
 app-root-path@^2.0.1:
   version "2.0.1"
@@ -2242,47 +2238,28 @@ buffers@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/buffers/-/buffers-0.1.1.tgz#b24579c3bed4d6d396aeee6d9a8ae7f5482ab7bb"
 
-builder-util-runtime@4.2.1, builder-util-runtime@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-4.2.1.tgz#0caa358f1331d70680010141ca591952b69b35bc"
+builder-util-runtime@4.2.2, builder-util-runtime@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-4.2.2.tgz#655e47dd7f701d682463114dbce5decc6d3c182f"
   dependencies:
     bluebird-lst "^1.0.5"
     debug "^3.1.0"
-    fs-extra-p "^4.6.0"
+    fs-extra-p "^4.6.1"
     sax "^1.2.4"
 
-builder-util@5.11.1:
-  version "5.11.1"
-  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-5.11.1.tgz#e1540935bc0efcb3948ae364a2f71e08d7bc82e0"
+builder-util@5.11.9, builder-util@^5.11.5:
+  version "5.11.9"
+  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-5.11.9.tgz#97e246230254218a086a81d5406d7ebbc9618b88"
   dependencies:
     "7zip-bin" "~4.0.2"
-    app-builder-bin "1.9.5"
+    app-builder-bin "1.9.16"
     bluebird-lst "^1.0.5"
-    builder-util-runtime "^4.2.1"
+    builder-util-runtime "^4.2.2"
     chalk "^2.4.1"
     debug "^3.1.0"
-    fs-extra-p "^4.6.0"
+    fs-extra-p "^4.6.1"
     is-ci "^1.1.0"
-    js-yaml "^3.11.0"
-    lazy-val "^1.0.3"
-    semver "^5.5.0"
-    source-map-support "^0.5.6"
-    stat-mode "^0.2.2"
-    temp-file "^3.1.2"
-
-builder-util@5.11.4, builder-util@^5.11.0, builder-util@^5.11.2:
-  version "5.11.4"
-  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-5.11.4.tgz#24d72aa567ecfeacca72b0740b4ddbffaaef617c"
-  dependencies:
-    "7zip-bin" "~4.0.2"
-    app-builder-bin "1.9.11"
-    bluebird-lst "^1.0.5"
-    builder-util-runtime "^4.2.1"
-    chalk "^2.4.1"
-    debug "^3.1.0"
-    fs-extra-p "^4.6.0"
-    is-ci "^1.1.0"
-    js-yaml "^3.11.0"
+    js-yaml "^3.12.0"
     lazy-val "^1.0.3"
     semver "^5.5.0"
     source-map-support "^0.5.6"
@@ -3595,16 +3572,16 @@ dir-glob@^2.0.0:
     arrify "^1.0.1"
     path-type "^3.0.0"
 
-dmg-builder@4.10.1:
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-4.10.1.tgz#5603daa1f93e23b6b3572549f188a62e16eb1ffb"
+dmg-builder@4.10.2:
+  version "4.10.2"
+  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-4.10.2.tgz#eeaf14bb6d980fd1733b23595b96b6e0633d9fd0"
   dependencies:
     bluebird-lst "^1.0.5"
-    builder-util "^5.11.0"
-    electron-builder-lib "~20.14.6"
-    fs-extra-p "^4.6.0"
+    builder-util "^5.11.5"
+    electron-builder-lib "~20.16.0"
+    fs-extra-p "^4.6.1"
     iconv-lite "^0.4.23"
-    js-yaml "^3.11.0"
+    js-yaml "^3.12.0"
     parse-color "^1.0.0"
     sanitize-filename "^1.6.1"
 
@@ -3720,9 +3697,9 @@ dotenv-expand@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-4.2.0.tgz#def1f1ca5d6059d24a766e587942c21106ce1275"
 
-dotenv@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-5.0.1.tgz#a5317459bd3d79ab88cff6e44057a6a3fbb1fcef"
+dotenv@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.0.0.tgz#24e37c041741c5f4b25324958ebbc34bca965935"
 
 duplexer2@0.0.2:
   version "0.0.2"
@@ -3777,84 +3754,54 @@ ejs@~2.5.6:
   version "2.5.6"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.6.tgz#479636bfa3fe3b1debd52087f0acb204b4f19c88"
 
-electron-builder-lib@20.15.3:
-  version "20.15.3"
-  resolved "https://registry.yarnpkg.com/electron-builder-lib/-/electron-builder-lib-20.15.3.tgz#bac8e4630b7994617398e2405b5c3c4e71b37cc0"
+electron-builder-lib@20.16.4, electron-builder-lib@~20.16.0:
+  version "20.16.4"
+  resolved "https://registry.yarnpkg.com/electron-builder-lib/-/electron-builder-lib-20.16.4.tgz#b5e89688e730f56566a4bb513bf8e1ba38912d37"
   dependencies:
     "7zip-bin" "~4.0.2"
-    app-builder-bin "1.9.11"
+    app-builder-bin "1.9.16"
     async-exit-hook "^2.0.1"
     bluebird-lst "^1.0.5"
-    builder-util "5.11.4"
-    builder-util-runtime "4.2.1"
+    builder-util "5.11.9"
+    builder-util-runtime "4.2.2"
     chromium-pickle-js "^0.2.0"
     debug "^3.1.0"
     ejs "^2.6.1"
     electron-osx-sign "0.4.10"
-    electron-publish "20.15.0"
-    fs-extra-p "^4.6.0"
-    hosted-git-info "^2.6.0"
+    electron-publish "20.16.0"
+    fs-extra-p "^4.6.1"
+    hosted-git-info "^2.6.1"
     is-ci "^1.1.0"
     isbinaryfile "^3.0.2"
-    js-yaml "^3.11.0"
+    js-yaml "^3.12.0"
     lazy-val "^1.0.3"
     minimatch "^3.0.4"
     normalize-package-data "^2.4.0"
     plist "^3.0.1"
-    read-config-file "3.0.1"
+    read-config-file "3.0.2"
     sanitize-filename "^1.6.1"
     semver "^5.5.0"
-    stream-json "^0.6.1"
+    stream-json "^1.0.2"
     temp-file "^3.1.2"
 
-electron-builder-lib@~20.14.6:
-  version "20.14.7"
-  resolved "https://registry.yarnpkg.com/electron-builder-lib/-/electron-builder-lib-20.14.7.tgz#db91977dd13b0a288e1da5629183807a9847de21"
-  dependencies:
-    "7zip-bin" "~4.0.2"
-    app-builder-bin "1.9.5"
-    async-exit-hook "^2.0.1"
-    bluebird-lst "^1.0.5"
-    builder-util "5.11.1"
-    builder-util-runtime "4.2.1"
-    chromium-pickle-js "^0.2.0"
-    debug "^3.1.0"
-    ejs "^2.6.1"
-    electron-osx-sign "0.4.10"
-    electron-publish "20.14.6"
-    fs-extra-p "^4.6.0"
-    hosted-git-info "^2.6.0"
-    is-ci "^1.1.0"
-    isbinaryfile "^3.0.2"
-    js-yaml "^3.11.0"
-    lazy-val "^1.0.3"
-    minimatch "^3.0.4"
-    normalize-package-data "^2.4.0"
-    plist "^3.0.1"
-    read-config-file "3.0.1"
-    sanitize-filename "^1.6.1"
-    semver "^5.5.0"
-    stream-json "^0.6.1"
-    temp-file "^3.1.2"
-
-electron-builder@^20.15.3:
-  version "20.15.3"
-  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-20.15.3.tgz#691e6e03392438fbc23b3cef1e9b78562a9e5c64"
+electron-builder@^20.16.4:
+  version "20.16.4"
+  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-20.16.4.tgz#c5908384e3b3e0d26cd7371997f9cbd8970ecc19"
   dependencies:
     bluebird-lst "^1.0.5"
-    builder-util "5.11.4"
-    builder-util-runtime "4.2.1"
+    builder-util "5.11.9"
+    builder-util-runtime "4.2.2"
     chalk "^2.4.1"
-    dmg-builder "4.10.1"
-    electron-builder-lib "20.15.3"
+    dmg-builder "4.10.2"
+    electron-builder-lib "20.16.4"
     electron-download-tf "4.3.4"
-    fs-extra-p "^4.6.0"
+    fs-extra-p "^4.6.1"
     is-ci "^1.1.0"
     lazy-val "^1.0.3"
-    read-config-file "3.0.1"
+    read-config-file "3.0.2"
     sanitize-filename "^1.6.1"
     update-notifier "^2.5.0"
-    yargs "^11.0.0"
+    yargs "^12.0.0"
 
 electron-chromedriver@~1.8.0:
   version "1.8.0"
@@ -3949,27 +3896,15 @@ electron-osx-sign@0.4.10:
     minimist "^1.2.0"
     plist "^2.1.0"
 
-electron-publish@20.14.6:
-  version "20.14.6"
-  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-20.14.6.tgz#ced15b0c08fdaef2fb25beba9f55f20d1c19e215"
+electron-publish@20.16.0:
+  version "20.16.0"
+  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-20.16.0.tgz#6fbda71181af650315f11ad85af1027df3f30a09"
   dependencies:
     bluebird-lst "^1.0.5"
-    builder-util "^5.11.0"
-    builder-util-runtime "^4.2.1"
+    builder-util "^5.11.5"
+    builder-util-runtime "^4.2.2"
     chalk "^2.4.1"
-    fs-extra-p "^4.6.0"
-    lazy-val "^1.0.3"
-    mime "^2.3.1"
-
-electron-publish@20.15.0:
-  version "20.15.0"
-  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-20.15.0.tgz#4dd96b2ce82b8856342a6d60dda571669a390d2d"
-  dependencies:
-    bluebird-lst "^1.0.5"
-    builder-util "^5.11.2"
-    builder-util-runtime "^4.2.1"
-    chalk "^2.4.1"
-    fs-extra-p "^4.6.0"
+    fs-extra-p "^4.6.1"
     lazy-val "^1.0.3"
     mime "^2.3.1"
 
@@ -5001,6 +4936,13 @@ fs-extra-p@^4.6.0:
     bluebird-lst "^1.0.5"
     fs-extra "^6.0.0"
 
+fs-extra-p@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/fs-extra-p/-/fs-extra-p-4.6.1.tgz#6156e0cc98097f415fcd17029578fc41c78b5092"
+  dependencies:
+    bluebird-lst "^1.0.5"
+    fs-extra "^6.0.1"
+
 fs-extra@^0.30.0:
   version "0.30.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.30.0.tgz#f233ffcc08d4da7d432daa449776989db1df93f0"
@@ -5034,7 +4976,7 @@ fs-extra@^5.0.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^6.0.0:
+fs-extra@^6.0.0, fs-extra@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-6.0.1.tgz#8abc128f7946e310135ddc93b98bddb410e7a34b"
   dependencies:
@@ -5611,9 +5553,13 @@ home-path@^1.0.1:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/home-path/-/home-path-1.0.5.tgz#788b29815b12d53bacf575648476e6f9041d133f"
 
-hosted-git-info@^2.1.4, hosted-git-info@^2.6.0:
+hosted-git-info@^2.1.4:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.6.0.tgz#23235b29ab230c576aab0d4f13fc046b0b038222"
+
+hosted-git-info@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.6.1.tgz#6e4cee78b01bb849dcf93527708c69fdbee410df"
 
 hpack.js@^2.1.6:
   version "2.1.6"
@@ -6782,7 +6728,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.11.0:
+js-yaml@^3.12.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
   dependencies:
@@ -8596,10 +8542,6 @@ parse5@^3.0.2:
   dependencies:
     "@types/node" "^6.0.46"
 
-parser-toolkit@>=0.0.3:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/parser-toolkit/-/parser-toolkit-0.0.5.tgz#ec4b61729c86318b56ea971bfba6b3c672d62c01"
-
 parseurl@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.1.tgz#c8ab8c9223ba34888aa64a297b28853bec18da56"
@@ -9536,17 +9478,17 @@ react@^15.6.1:
     object-assign "^4.1.0"
     prop-types "^15.5.10"
 
-read-config-file@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/read-config-file/-/read-config-file-3.0.1.tgz#307ed2e162fa54306d0ae6d41e9cdc829720d2a9"
+read-config-file@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/read-config-file/-/read-config-file-3.0.2.tgz#3866666a8772d350cfbfe9a4b26187df34883c56"
   dependencies:
-    ajv "^6.4.0"
+    ajv "^6.5.1"
     ajv-keywords "^3.2.0"
     bluebird-lst "^1.0.5"
-    dotenv "^5.0.1"
+    dotenv "^6.0.0"
     dotenv-expand "^4.2.0"
-    fs-extra-p "^4.6.0"
-    js-yaml "^3.11.0"
+    fs-extra-p "^4.6.1"
+    js-yaml "^3.12.0"
     json5 "^1.0.1"
     lazy-val "^1.0.3"
 
@@ -10809,6 +10751,10 @@ stream-browserify@^2.0.1:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
 
+stream-chain@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/stream-chain/-/stream-chain-2.0.2.tgz#d99b560ad8b26879325fa5ed5f28bd62a3bab6f9"
+
 stream-each@^1.1.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/stream-each/-/stream-each-1.2.2.tgz#8e8c463f91da8991778765873fe4d960d8f616bd"
@@ -10836,11 +10782,11 @@ stream-http@^2.7.2:
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
 
-stream-json@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/stream-json/-/stream-json-0.6.1.tgz#c9413e7f42ba8eac4883be712220455f64dcea67"
+stream-json@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/stream-json/-/stream-json-1.0.2.tgz#5421e21892eded43a2bab809cf4d8f65c6ecdadd"
   dependencies:
-    parser-toolkit ">=0.0.3"
+    stream-chain "^2.0.2"
 
 stream-shift@^1.0.0:
   version "1.0.0"
@@ -12295,7 +12241,7 @@ y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
 
-y18n@^4.0.0:
+"y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
 
@@ -12365,6 +12311,23 @@ yargs@^11.1.0:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
+
+yargs@^12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.0.tgz#8274480fd7332c77888bc33b6594340d31ed40d3"
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1 || ^4.0.0"
+    yargs-parser "^10.0.0"
 
 yargs@^4.2.0:
   version "4.8.1"


### PR DESCRIPTION
Electron v2.0.3 was released a few days ago which fixes a number of minor bugs which are likely to affect us. There is also one fix which is marked as a security fix

See https://github.com/electron/electron/releases/tag/v2.0.3

Also, update electron-builder which has had quite a few nice updates since the version we had installed.

Have tested with `npm run dev`, `npm start`, and via a package built with `npm run package` and everything appears to work as expected.