### PR TITLE
Add missing rimraf dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,6 +205,7 @@
     "react-addons-test-utils": "^15.6.0",
     "react-test-renderer": "^15.6.1",
     "redux-logger": "^3.0.6",
+    "rimraf": "^2.6.2",
     "sass-loader": "^7.0.3",
     "spectron": "^3.8.0",
     "style-loader": "^0.21.0",


### PR DESCRIPTION
It looks like we were a little hasty in #492 as rimraf is used directly within package.json in the `flow-typed` script and so it needs to remain as a dev dependency.

See https://github.com/LN-Zap/zap-desktop/pull/492