### PR TITLE
Fix devtools startup error messages

### DIFF
--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -287,6 +287,12 @@ app.on('ready', async () => {
     mainWindow.loadURL(`file://${__dirname}/dist/index.html`)
   }
 
+  if (process.env.NODE_ENV === 'development' || process.env.DEBUG_PROD === 'true') {
+    mainWindow.webContents.once('dom-ready', () => {
+      mainWindow.openDevTools()
+    })
+  }
+
   // @TODO: Use 'ready-to-show' event
   //        https://github.com/electron/electron/blob/master/docs/api/browser-window.md#using-ready-to-show-event
   mainWindow.webContents.on('did-finish-load', () => {

--- a/app/menu.js
+++ b/app/menu.js
@@ -9,10 +9,6 @@ export default class MenuBuilder {
   }
 
   buildMenu() {
-    if (process.env.NODE_ENV === 'development' || process.env.DEBUG_PROD === 'true') {
-      this.setupDevelopmentEnvironment()
-    }
-
     let template
 
     if (process.platform === 'darwin') {
@@ -56,10 +52,6 @@ export default class MenuBuilder {
         selectionMenu.popup(this.mainWindow)
       }
     })
-  }
-
-  setupDevelopmentEnvironment() {
-    this.mainWindow.openDevTools()
   }
 
   buildDarwinTemplate() {


### PR DESCRIPTION
Wait until the `dom-ready` event has fired before opening up the devtools window. This prevents the following error message showing up multiple times when the app starts in dev mode:

> Extension server error: Operation failed: : has no execution context

See https://github.com/electron/electron/issues/12438

Fix #499