### PR TITLE
Enable electron security checks on travis/appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: node_js
 env:
   global:
     - DEBUG=electron-builder
-    - ELECTRON_DISABLE_SECURITY_WARNINGS=true
   matrix:
   - TEST=lint-ci
   - TEST=test-ci

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 os: unstable
 
 environment:
-  ELECTRON_DISABLE_SECURITY_WARNINGS: true
   matrix:
     - nodejs_version: 10
     - nodejs_version: 8


### PR DESCRIPTION
Unset the `ELECTRON_DISABLE_SECURITY_WARNINGS` environment variable which was being used to disable the security checks when testing the app on ci. This is no longer needed now that we have a more strict Content Security Policy when the app runs in production mode.

See https://github.com/LN-Zap/zap-desktop/pull/456