### PR TITLE
fix(channels): correct property for waiting_close_channels object

### DIFF
--- a/app/components/Contacts/Network.js
+++ b/app/components/Contacts/Network.js
@@ -130,7 +130,7 @@ class Network extends Component {
       }
 
       // if the channel is in waiting_close_channels phase
-      if (Object.prototype.hasOwnProperty.call(statusChannel, 'waiting_close_channels')) {
+      if (Object.prototype.hasOwnProperty.call(statusChannel, 'limbo_balance')) {
         return 'closing'
       }
 


### PR DESCRIPTION
We were looking for the wrong property on the channel object here which was resulting in closing channels being displayed as offline. We want to be looking for `limbo_balance`. 