### PR TITLE
fix(onboarding-empty-pass): add empty password validation

### DIFF
--- a/app/components/Onboarding/Onboarding.js
+++ b/app/components/Onboarding/Onboarding.js
@@ -127,8 +127,11 @@ const Onboarding = ({
               if (newWalletPasswordProps.showCreateWalletPasswordConfirmationError) {
                 return
               }
-              // if the password is less than 8 characters dont allow users to proceed
-              if (newWalletPasswordProps.passwordMinCharsError) {
+              // if the password is less than 8 characters or empty dont allow users to proceed
+              if (
+                newWalletPasswordProps.passwordMinCharsError ||
+                !newWalletPasswordProps.createWalletPassword
+              ) {
                 return
               }
 


### PR DESCRIPTION
Concerning issue #415. Now users can't proceed when password is empty.