### PR TITLE
fix(onboarding-password-bug): add more password validation

### DIFF
--- a/app/components/Onboarding/Onboarding.js
+++ b/app/components/Onboarding/Onboarding.js
@@ -124,13 +124,12 @@ const Onboarding = ({
             back={null}
             next={() => {
               // dont allow the user to move on if the confirmation password doesnt match the original password
-              if (newWalletPasswordProps.showCreateWalletPasswordConfirmationError) {
-                return
-              }
               // if the password is less than 8 characters or empty dont allow users to proceed
               if (
                 newWalletPasswordProps.passwordMinCharsError ||
-                !newWalletPasswordProps.createWalletPassword
+                !newWalletPasswordProps.createWalletPassword ||
+                !newWalletPasswordProps.createWalletPasswordConfirmation ||
+                newWalletPasswordProps.showCreateWalletPasswordConfirmationError
               ) {
                 return
               }

--- a/app/reducers/onboarding.js
+++ b/app/reducers/onboarding.js
@@ -340,7 +340,7 @@ onboardingSelectors.passwordMinCharsError = createSelector(
 onboardingSelectors.showCreateWalletPasswordConfirmationError = createSelector(
   createWalletPasswordSelector,
   createWalletPasswordConfirmationSelector,
-  (pass1, pass2) => pass1 !== pass2 && pass2.length >= pass1.length
+  (pass1, pass2) => pass1 !== pass2 && pass2.length > 0
 )
 
 onboardingSelectors.showAezeedPasswordConfirmationError = createSelector(


### PR DESCRIPTION
This PR fixes:

- It was possible to proceed with:
 Password: `1234`
 Confirm Password: `12`

- It was also possible to proceed with filled in Password but Confirm Password empty.

I hope that's the last PR related to #415 :)