### PR TITLE
Update docs to suggest building before running tests

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -88,6 +88,7 @@ chmod +x lnd
 To test that everything has been installed correctly:
 
 ```bash
+npm run build
 npm run test
 ```
 


### PR DESCRIPTION
I tried running "npm run test" as suggested at the end of these instructions and got a bunch of errors saying "The main process is not built yet. Build it by running "npm run build-main" so just making a note of that in the docs