### PR TITLE
fix: ensure onboarding completes after syncing

### DIFF
--- a/app/zap.js
+++ b/app/zap.js
@@ -45,7 +45,7 @@ class ZapController {
     this._registerIpcListeners()
 
     // Show the window as soon as the application has finished loading.
-    this.mainWindow.webContents.on('did-finish-load', async () => {
+    this.mainWindow.webContents.on('did-finish-load', () => {
       this.mainWindow.show()
       this.mainWindow.focus()
       mainLog.timeEnd('Time until app is visible')
@@ -155,9 +155,9 @@ class ZapController {
       this.startWalletUnlocker()
     })
 
-    this.neutrino.on('wallet-opened', async () => {
+    this.neutrino.on('wallet-opened', () => {
       mainLog.info('Wallet opened')
-      await this.startGrpc()
+      this.startGrpc()
       this.sendMessage('lndSyncing')
     })
 
@@ -177,7 +177,7 @@ class ZapController {
    * Add IPC event listeners...
    */
   _registerIpcListeners() {
-    ipcMain.on('startLnd', async (event, options = {}) => {
+    ipcMain.on('startLnd', (event, options = {}) => {
       // Trim any user supplied strings.
       const cleanOptions = Object.keys(options).reduce((previous, current) => {
         previous[current] =
@@ -203,7 +203,7 @@ class ZapController {
         mainLog.debug(' > host:', cleanOptions.host)
         mainLog.debug(' > cert:', cleanOptions.cert)
         mainLog.debug(' > macaroon:', cleanOptions.macaroon)
-        await this.startGrpc()
+        this.startGrpc()
           .then(() => this.sendMessage('successfullyCreatedWallet'))
           .catch(e => {
             const errors = {}


### PR DESCRIPTION
Fix a race condition that could cause the app to think that it is still syncing even after it has completed and as a result being stuck reporting 100% syncing during the onboarding process.

`startGrpc` can take some time to fully establish and verify that the connection is set up as we wait for a successful result from a call to `getInfo`.

Previously, we would send the `lndSyncing` message to the app only after `startGrpc` was complete. However, if the syncing process had actually completed before `startGrpc` then we would first notify that syncing had completed, only to then notify that it had started after it had already completed.

In this fix, we notify the app of `lndSyncing` immediately after the wallet has been unlocked.