### PR TITLE
Improve feedback to users during sync process

### DIFF
--- a/app/components/Onboarding/Syncing.js
+++ b/app/components/Onboarding/Syncing.js
@@ -16,8 +16,7 @@ class Syncing extends Component {
   }
 
   render() {
-    const { syncPercentage, address } = this.props
-
+    const { syncPercentage, address, blockHeight, lndBlockHeight } = this.props
     const copyClicked = () => {
       copy(address)
       showNotification('Noice', 'Successfully copied to clipboard')
@@ -66,14 +65,21 @@ class Syncing extends Component {
             <div className={styles.progressBar}>
               <div
                 className={styles.progress}
-                style={{ width: Number.isNaN(syncPercentage) ? 0 : `${syncPercentage}%` }}
+                style={{ width: syncPercentage ? `${syncPercentage}%` : 0 }}
               />
             </div>
             <h4>
-              {Number.isNaN(parseInt(syncPercentage, 10)) || syncPercentage.toString().length === 0
-                ? ''
-                : `${syncPercentage}%`}
+              {typeof syncPercentage === 'undefined' && 'Preparing...'}
+              {Boolean(syncPercentage >= 0 && syncPercentage < 99) && `${syncPercentage}%`}
+              {Boolean(syncPercentage >= 99) && 'Finalizing...'}
             </h4>
+            {Boolean(syncPercentage >= 0 && syncPercentage < 99) && (
+              <span className={styles.progressCounter}>
+                {Boolean(!blockHeight || !lndBlockHeight) && 'starting...'}
+                {Boolean(blockHeight && lndBlockHeight) &&
+                  `${lndBlockHeight.toLocaleString()} of ${blockHeight.toLocaleString()}`}
+              </span>
+            )}
           </section>
         </div>
       </div>
@@ -85,7 +91,9 @@ Syncing.propTypes = {
   fetchBlockHeight: PropTypes.func.isRequired,
   newAddress: PropTypes.func.isRequired,
   address: PropTypes.string.isRequired,
-  syncPercentage: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired
+  syncPercentage: PropTypes.number,
+  blockHeight: PropTypes.number,
+  lndBlockHeight: PropTypes.number
 }
 
 export default Syncing

--- a/app/components/Onboarding/Syncing.js
+++ b/app/components/Onboarding/Syncing.js
@@ -9,9 +9,13 @@ import styles from './Syncing.scss'
 
 class Syncing extends Component {
   componentWillMount() {
-    const { fetchBlockHeight, newAddress } = this.props
+    const { fetchBlockHeight, blockHeight, newAddress } = this.props
 
-    fetchBlockHeight()
+    // If we don't already know the target block height, fetch it now.
+    if (!blockHeight) {
+      fetchBlockHeight()
+    }
+
     newAddress('np2wkh')
   }
 

--- a/app/components/Onboarding/Syncing.scss
+++ b/app/components/Onboarding/Syncing.scss
@@ -94,6 +94,12 @@
     color: $gold;
     margin-top: 10px;
   }
+
+  .progressCounter {
+    color: $gold;
+    font-size: 12px;
+    margin-top: 10px;
+  }
 }
 
 .spinner {

--- a/app/containers/Root.js
+++ b/app/containers/Root.js
@@ -82,8 +82,9 @@ const mapStateToProps = state => ({
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const syncingProps = {
     fetchBlockHeight: dispatchProps.fetchBlockHeight,
+    blockHeight: stateProps.lnd.blockHeight,
+    lndBlockHeight: stateProps.lnd.lndBlockHeight,
     newAddress: dispatchProps.newAddress,
-
     syncPercentage: stateProps.syncPercentage,
     address: stateProps.address.address
   }
@@ -214,7 +215,7 @@ const Root = ({
   }
 
   // If we are syncing show the syncing screen
-  if (lnd.syncing) {
+  if (lnd.grpcStarted && lnd.syncing) {
     return <Syncing {...syncingProps} />
   }
 

--- a/app/lnd/lib/neutrino.js
+++ b/app/lnd/lib/neutrino.js
@@ -10,6 +10,14 @@ class Neutrino extends EventEmitter {
     this.alias = alias
     this.autopilot = autopilot
     this.process = null
+    this.state = {
+      grpcProxyStarted: false,
+      walletOpened: false,
+      chainSyncStarted: false,
+      chainSyncFinished: false,
+      currentBlockHeight: null,
+      targetBlockHeight: null
+    }
   }
 
   start() {
@@ -52,37 +60,58 @@ class Neutrino extends EventEmitter {
       }
 
       // gRPC started.
-      if (line.includes('gRPC proxy started') && line.includes('password')) {
-        this.emit('grpc-proxy-started')
+      if (!this.state.grpcProxyStarted) {
+        if (line.includes('gRPC proxy started') && line.includes('password')) {
+          this.state.grpcProxyStarted = true
+          this.emit('grpc-proxy-started')
+        }
       }
 
       // Wallet opened.
-      if (line.includes('gRPC proxy started') && !line.includes('password')) {
-        this.emit('wallet-opened')
+      if (!this.state.walletOpened) {
+        if (line.includes('gRPC proxy started') && !line.includes('password')) {
+          this.state.walletOpened = true
+          this.emit('wallet-opened')
+        }
       }
 
       // LND syncing has started.
-      if (line.includes('Waiting for chain backend to finish sync')) {
-        this.emit('chain-sync-started')
+      if (!this.state.chainSyncStarted) {
+        if (line.includes('Syncing to block height')) {
+          const height = line.match(/Syncing to block height (\d+)/)[1]
+          this.state.chainSyncStarted = true
+          this.state.targetBlockHeight = height
+          this.emit('chain-sync-started')
+          this.emit('got-final-block-height', height)
+        }
       }
 
       // LND syncing has completed.
-      if (line.includes('Chain backend is fully synced')) {
-        this.emit('chain-sync-finished')
+      if (!this.state.chainSyncFinished) {
+        if (line.includes('Chain backend is fully synced')) {
+          this.state.chainSyncFinished = true
+          this.emit('chain-sync-finished')
+        }
       }
 
       // Pass current block height progress to front end for loading state UX
-      if (line.includes('Rescanned through block')) {
-        const height = line.match(/Rescanned through block.+\(height (\d*)/)[1]
-        this.emit('got-block-height', height)
-      } else if (line.includes('Caught up to height')) {
-        const height = line.match(/Caught up to height (\d*)/)[1]
-        this.emit('got-block-height', height)
-      } else if (line.includes('in the last')) {
-        const height = line.match(/Processed \d* blocks? in the last.+\(height (\d*)/)[1]
-        this.emit('got-block-height', height)
+      if (this.state.chainSyncStarted) {
+        if (line.includes('Downloading headers for blocks')) {
+          const height = line.match(/Downloading headers for blocks (\d+) to \d+/)[1]
+          this.emit('got-current-block-height', height)
+        } else if (line.includes('Rescanned through block')) {
+          const height = line.match(/Rescanned through block.+\(height (\d+)/)[1]
+          this.emit('got-current-block-height', height)
+        } else if (line.includes('Caught up to height')) {
+          const height = line.match(/Caught up to height (\d+)/)[1]
+          this.emit('got-current-block-height', height)
+        } else if (line.includes('in the last')) {
+          const height = line.match(/Processed \d* blocks? in the last.+\(height (\d+)/)[1]
+          this.emit('got-current-block-height', height)
+        }
       }
     })
+
     return this.process
   }
 

--- a/app/lnd/lib/neutrino.js
+++ b/app/lnd/lib/neutrino.js
@@ -61,14 +61,26 @@ class Neutrino extends EventEmitter {
         this.emit('wallet-opened')
       }
 
-      // LND is all caught up to the blockchain.
+      // LND syncing has started.
+      if (line.includes('Waiting for chain backend to finish sync')) {
+        this.emit('chain-sync-started')
+      }
+
+      // LND syncing has completed.
       if (line.includes('Chain backend is fully synced')) {
-        this.emit('fully-synced')
+        this.emit('chain-sync-finished')
       }
 
       // Pass current block height progress to front end for loading state UX
-      if (line.includes('Caught up to height') || line.includes('Catching up block hashes')) {
-        this.emit('got-block-height', line)
+      if (line.includes('Rescanned through block')) {
+        const height = line.match(/Rescanned through block.+\(height (\d*)/)[1]
+        this.emit('got-block-height', height)
+      } else if (line.includes('Caught up to height')) {
+        const height = line.match(/Caught up to height (\d*)/)[1]
+        this.emit('got-block-height', height)
+      } else if (line.includes('in the last')) {
+        const height = line.match(/Processed \d* blocks? in the last.+\(height (\d*)/)[1]
+        this.emit('got-block-height', height)
       }
     })
     return this.process

--- a/app/reducers/ipc.js
+++ b/app/reducers/ipc.js
@@ -1,5 +1,5 @@
 import createIpc from 'redux-electron-ipc'
-import { lndSyncing, lndSynced, lndStdout, grpcDisconnected, grpcConnected } from './lnd'
+import { lndSyncing, lndSynced, lndBlockHeight, grpcDisconnected, grpcConnected } from './lnd'
 import { receiveInfo } from './info'
 import { receiveAddress } from './address'
 import { receiveCryptocurrency } from './ticker'
@@ -53,7 +53,7 @@ import {
 const ipc = createIpc({
   lndSyncing,
   lndSynced,
-  lndStdout,
+  lndBlockHeight,
   grpcDisconnected,
   grpcConnected,
 

--- a/app/reducers/ipc.js
+++ b/app/reducers/ipc.js
@@ -1,5 +1,12 @@
 import createIpc from 'redux-electron-ipc'
-import { lndSyncing, lndSynced, lndBlockHeight, grpcDisconnected, grpcConnected } from './lnd'
+import {
+  lndSyncing,
+  lndSynced,
+  lndBlockHeightTarget,
+  lndBlockHeight,
+  grpcDisconnected,
+  grpcConnected
+} from './lnd'
 import { receiveInfo } from './info'
 import { receiveAddress } from './address'
 import { receiveCryptocurrency } from './ticker'
@@ -53,6 +60,7 @@ import {
 const ipc = createIpc({
   lndSyncing,
   lndSynced,
+  lndBlockHeightTarget,
   lndBlockHeight,
   grpcDisconnected,
   grpcConnected,

--- a/app/reducers/lnd.js
+++ b/app/reducers/lnd.js
@@ -52,6 +52,10 @@ export const lndBlockHeight = (event, height) => dispatch => {
   dispatch({ type: RECEIVE_BLOCK, lndBlockHeight: height })
 }
 
+export const lndBlockHeightTarget = (event, height) => dispatch => {
+  dispatch({ type: RECEIVE_BLOCK_HEIGHT, blockHeight: height })
+}
+
 export function getBlockHeight() {
   return {
     type: GET_BLOCK_HEIGHT

--- a/app/zap.js
+++ b/app/zap.js
@@ -170,7 +170,11 @@ class ZapController {
       this.sendMessage('lndSynced')
     })
 
-    this.neutrino.on('got-block-height', height => {
+    this.neutrino.on('got-final-block-height', height => {
+      this.sendMessage('lndBlockHeightTarget', Number(height))
+    })
+
+    this.neutrino.on('got-current-block-height', height => {
       this.sendMessage('lndBlockHeight', Number(height))
     })
 

--- a/app/zap.js
+++ b/app/zap.js
@@ -158,16 +158,20 @@ class ZapController {
     this.neutrino.on('wallet-opened', () => {
       mainLog.info('Wallet opened')
       this.startGrpc()
+    })
+
+    this.neutrino.on('chain-sync-started', () => {
+      mainLog.info('Neutrino sync started')
       this.sendMessage('lndSyncing')
     })
 
-    this.neutrino.on('fully-synced', () => {
-      mainLog.info('Neutrino fully synced')
+    this.neutrino.on('chain-sync-finished', () => {
+      mainLog.info('Neutrino sync finished')
       this.sendMessage('lndSynced')
     })
 
-    this.neutrino.on('got-block-height', line => {
-      this.sendMessage('lndStdout', line)
+    this.neutrino.on('got-block-height', height => {
+      this.sendMessage('lndBlockHeight', Number(height))
     })
 
     this.neutrino.start()


### PR DESCRIPTION
This patch fixes some issues with the sync process. The parsing of lnd log entries where we calculate the current sync progress has been moved from the renderer back to the main process and updated to improve it's accuracy.

We now call dispatch a call to `fetchInfo` as soon as the gRPC connection has been established so that we get the node info as early as possible, and we defer showing the syncing screen until we are sure that a grpc connection has been established and syncing is in progress.

These enable us to provide better feedback to the user and prevent further race conditions that I have observed.

As a bonus, we show the user some more information about the current sync progress.

<img width="946" alt="screenshot 2018-07-04 02 15 12" src="https://user-images.githubusercontent.com/200251/42251796-5a7c3c16-7f31-11e8-8ce2-c97ce3bf373d.png">
