### PR TITLE
Fetch block height from multiple block explorers incase one is unavailable

### DIFF
--- a/app/api/index.js
+++ b/app/api/index.js
@@ -29,11 +29,33 @@ export function requestTickers(ids) {
 }
 
 export function requestBlockHeight() {
-  const BASE_URL = `${scheme}testnet-api.smartbit.com.au/v1/blockchain/blocks?limit=1`
-  return axios({
-    method: 'get',
-    url: BASE_URL
-  }).then(response => response.data)
+  const sources = [
+    {
+      baseUrl: `${scheme}testnet-api.smartbit.com.au/v1/blockchain/blocks?limit=1`,
+      path: 'blocks[0].height'
+    },
+    {
+      baseUrl: `${scheme}tchain.api.btc.com/v3/block/latest`,
+      path: 'data.height'
+    },
+    {
+      baseUrl: `${scheme}api.blockcypher.com/v1/btc/test3`,
+      path: 'height'
+    }
+  ]
+  const fetchData = (baseUrl, path) => {
+    return axios({
+      method: 'get',
+      timeout: 5000,
+      url: baseUrl
+    })
+      .then(response => path.split('.').reduce((a, b) => a[b], response.data))
+      .catch(() => null)
+  }
+
+  const promises = []
+  sources.forEach(source => promises.push(fetchData(source.baseUrl, source.path)))
+  return Promise.race(promises)
 }
 
 export function requestSuggestedNodes() {

--- a/app/reducers/lnd.js
+++ b/app/reducers/lnd.js
@@ -84,8 +84,8 @@ export function receiveBlockHeight(blockHeight) {
 // Fetch current block height
 export const fetchBlockHeight = () => async dispatch => {
   dispatch(getBlockHeight())
-  const blockData = await requestBlockHeight()
-  dispatch(receiveBlockHeight(blockData.blocks[0].height))
+  const blockHeight = await requestBlockHeight()
+  dispatch(receiveBlockHeight(blockHeight))
 }
 
 // ------------------------------------

--- a/webpack.config.renderer.dev.js
+++ b/webpack.config.renderer.dev.js
@@ -298,6 +298,16 @@ export default merge.smart(baseConfig, {
         target: 'https://testnet-api.smartbit.com.au',
         pathRewrite: { '^/proxy/testnet-api.smartbit.com.au': '' },
         changeOrigin: true
+      },
+      '/proxy/tchain.api.btc.com': {
+        target: 'https://tchain.api.btc.com',
+        pathRewrite: { '^/proxy/tchain.api.btc.com': '' },
+        changeOrigin: true
+      },
+      '/proxy/api.blockcypher.com': {
+        target: 'https://api.blockcypher.com',
+        pathRewrite: { '^/proxy/api.blockcypher.com': '' },
+        changeOrigin: true
       }
     },
     historyApiFallback: {

--- a/webpack.config.renderer.prod.js
+++ b/webpack.config.renderer.prod.js
@@ -159,7 +159,9 @@ export default merge.smart(baseConfig, {
         "'self'",
         'https://api.coinmarketcap.com',
         'https://zap.jackmallers.com',
-        'https://testnet-api.smartbit.com.au'
+        'https://testnet-api.smartbit.com.au',
+        'https://tchain.api.btc.com',
+        'https://api.blockcypher.com'
       ],
       'script-src': ["'self'"],
       'font-src': [


### PR DESCRIPTION
Call out to 3 different block explorers to get the current block height and use the result from whichever responds quickest.

Fix #463