### PR TITLE
Handle case where BTCd node is not fully synced with the blockchain

### DIFF
--- a/app/components/Onboarding/Syncing.scss
+++ b/app/components/Onboarding/Syncing.scss
@@ -95,7 +95,7 @@
     margin-top: 10px;
   }
 
-  .progressCounter {
+  .progressDetail {
     color: $gold;
     font-size: 12px;
     margin-top: 10px;

--- a/app/containers/Root.js
+++ b/app/containers/Root.js
@@ -81,6 +81,7 @@ const mapStateToProps = state => ({
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const syncingProps = {
     blockHeight: stateProps.lnd.blockHeight,
+    syncStatus: stateProps.lnd.syncStatus,
     lndBlockHeight: stateProps.lnd.lndBlockHeight,
     hasSynced: stateProps.info.hasSynced,
     syncPercentage: stateProps.syncPercentage,
@@ -213,7 +214,11 @@ const Root = ({
   }
 
   // If we are syncing show the syncing screen
-  if (lnd.grpcStarted && lnd.syncing) {
+  if (
+    onboardingProps.onboarding.connectionType === 'local' &&
+    lnd.grpcStarted &&
+    lnd.syncStatus !== 'complete'
+  ) {
     return <Syncing {...syncingProps} />
   }
 

--- a/app/lnd/lib/neutrino.js
+++ b/app/lnd/lib/neutrino.js
@@ -5,20 +5,37 @@ import config from '../config'
 import { mainLog, lndLog, lndLogGetLevel } from '../../utils/log'
 import { fetchBlockHeight } from './util'
 
+// Sync status is currenty pending.
+const NEUTRINO_SYNC_STATUS_PENDING = 'chain-sync-pending'
+
+// Waiting for chain backend to finish synchronizing.
+const NEUTRINO_SYNC_STATUS_WAITING = 'chain-sync-waiting'
+
+// Initial sync is currently in progress.
+const NEUTRINO_SYNC_STATUS_IN_PROGRESS = 'chain-sync-started'
+
+// Initial sync has completed.
+const NEUTRINO_SYNC_STATUS_COMPLETE = 'chain-sync-finished'
+
+/**
+ * Wrapper class for Lnd to run and monitor it in Neutrino mode.
+ * @extends EventEmitter
+ */
 class Neutrino extends EventEmitter {
   constructor(alias, autopilot) {
     super()
     this.alias = alias
     this.autopilot = autopilot
     this.process = null
-    this.state = {
-      grpcProxyStarted: false,
-      walletOpened: false,
-      chainSyncStarted: false,
-      chainSyncFinished: false
-    }
+    this.grpcProxyStarted = false
+    this.walletOpened = false
+    this.chainSyncStatus = NEUTRINO_SYNC_STATUS_PENDING
   }
 
+  /**
+   * Start the Lnd process in Neutrino mode.
+   * @return {Number} PID of the Lnd process that was started.
+   */
   start() {
     if (this.process) {
       throw new Error('Neutrino process with PID ${this.process.pid} already exists.')
@@ -59,28 +76,43 @@ class Neutrino extends EventEmitter {
       }
 
       // gRPC started.
-      if (!this.state.grpcProxyStarted) {
+      if (!this.grpcProxyStarted) {
         if (line.includes('gRPC proxy started') && line.includes('password')) {
-          this.state.grpcProxyStarted = true
+          this.grpcProxyStarted = true
           this.emit('grpc-proxy-started')
         }
       }
 
       // Wallet opened.
-      if (!this.state.walletOpened) {
+      if (!this.walletOpened) {
         if (line.includes('gRPC proxy started') && !line.includes('password')) {
-          this.state.walletOpened = true
+          this.walletOpened = true
           this.emit('wallet-opened')
         }
       }
 
-      // LND syncing has started.
-      if (!this.state.chainSyncStarted) {
+      // If the sync has already completed then we don't need to do anythibng else.
+      if (this.is(NEUTRINO_SYNC_STATUS_COMPLETE)) {
+        return
+      }
+
+      // Lnd waiting for backend to finish syncing.
+      if (this.is(NEUTRINO_SYNC_STATUS_PENDING) || this.is(NEUTRINO_SYNC_STATUS_IN_PROGRESS)) {
+        if (
+          line.includes('No sync peer candidates available') ||
+          line.includes('Unable to synchronize wallet to chain') ||
+          line.includes('Waiting for chain backend to finish sync')
+        ) {
+          this.setState(NEUTRINO_SYNC_STATUS_WAITING)
+        }
+      }
+
+      // Lnd syncing has started or resumed.
+      if (this.is(NEUTRINO_SYNC_STATUS_PENDING) || this.is(NEUTRINO_SYNC_STATUS_WAITING)) {
         const match = line.match(/Syncing to block height (\d+)/)
         if (match) {
           // Notify that chhain syncronisation has now started.
-          this.state.chainSyncStarted = true
-          this.emit('chain-sync-started')
+          this.setState(NEUTRINO_SYNC_STATUS_IN_PROGRESS)
 
           // This is the latest block that BTCd is aware of.
           const btcdHeight = Number(match[1])
@@ -98,25 +130,27 @@ class Neutrino extends EventEmitter {
         }
       }
 
-      // LND syncing has completed.
-      if (!this.state.chainSyncFinished) {
-        if (line.includes('Chain backend is fully synced')) {
-          this.state.chainSyncFinished = true
-          this.emit('chain-sync-finished')
-        }
-      }
-
-      // Pass current block height progress to front end for loading state UX
-      if (this.state.chainSyncStarted) {
+      // Lnd as received some updated block data.
+      if (this.is(NEUTRINO_SYNC_STATUS_WAITING) || this.is(NEUTRINO_SYNC_STATUS_IN_PROGRESS)) {
+        let height
         let match
-        if ((match = line.match(/Downloading headers for blocks (\d+) to \d+/))) {
-          this.emit('got-lnd-block-height', match[1])
-        } else if ((match = line.match(/Rescanned through block.+\(height (\d+)/))) {
-          this.emit('got-lnd-block-height', match[1])
+
+        if ((match = line.match(/Rescanned through block.+\(height (\d+)/))) {
+          height = match[1]
         } else if ((match = line.match(/Caught up to height (\d+)/))) {
-          this.emit('got-lnd-block-height', match[1])
+          height = match[1]
         } else if ((match = line.match(/Processed \d* blocks? in the last.+\(height (\d+)/))) {
-          this.emit('got-lnd-block-height', match[1])
+          height = match[1]
+        }
+
+        if (height) {
+          this.setState(NEUTRINO_SYNC_STATUS_IN_PROGRESS)
+          this.emit('got-lnd-block-height', height)
+        }
+
+        // Lnd syncing has completed.
+        if (line.includes('Chain backend is fully synced')) {
+          this.setState(NEUTRINO_SYNC_STATUS_COMPLETE)
         }
       }
     })
@@ -124,10 +158,33 @@ class Neutrino extends EventEmitter {
     return this.process
   }
 
+  /**
+   * Stop the Lnd process.
+   */
   stop() {
     if (this.process) {
       this.process.kill()
       this.process = null
+    }
+  }
+
+  /**
+   * Check if the current state matches the passted in state.
+   * @param  {String} state State to compare against the current state.
+   * @return {Boolean} Boolean indicating if the current state matches the passed in state.
+   */
+  is(state) {
+    return this.chainSyncStatus === state
+  }
+
+  /**
+   * Set the current state and emit an event to notify others if te state as canged.
+   * @param {String} state Target state.
+   */
+  setState(state) {
+    if (state !== this.chainSyncStatus) {
+      this.chainSyncStatus = state
+      this.emit(state)
     }
   }
 }

--- a/app/reducers/ipc.js
+++ b/app/reducers/ipc.js
@@ -1,7 +1,6 @@
 import createIpc from 'redux-electron-ipc'
 import {
-  lndSyncing,
-  lndSynced,
+  lndSyncStatus,
   currentBlockHeight,
   lndBlockHeight,
   grpcDisconnected,
@@ -58,8 +57,7 @@ import {
 
 // Import all receiving IPC event handlers and pass them into createIpc
 const ipc = createIpc({
-  lndSyncing,
-  lndSynced,
+  lndSyncStatus,
   currentBlockHeight,
   lndBlockHeight,
   grpcDisconnected,

--- a/app/zap.js
+++ b/app/zap.js
@@ -160,14 +160,19 @@ class ZapController {
       this.startGrpc()
     })
 
+    this.neutrino.on('chain-sync-waiting', () => {
+      mainLog.info('Neutrino sync waiting')
+      this.sendMessage('lndSyncStatus', 'waiting')
+    })
+
     this.neutrino.on('chain-sync-started', () => {
       mainLog.info('Neutrino sync started')
-      this.sendMessage('lndSyncing')
+      this.sendMessage('lndSyncStatus', 'in-progress')
     })
 
     this.neutrino.on('chain-sync-finished', () => {
       mainLog.info('Neutrino sync finished')
-      this.sendMessage('lndSynced')
+      this.sendMessage('lndSyncStatus', 'complete')
     })
 
     this.neutrino.on('got-current-block-height', height => {


### PR DESCRIPTION
Handle the case were the Neutrino backend BTCd node is still synchronising the blockchain as LND is not able to start syncing until the BTCd node that it is connected to is fully synced.

In this case, we display a message to the user indicating that we are waiting for peers. If it takes more than 10 seconds that generally indicates that the btcd node is quite far behind (eg, it has been restarted and is doing a full/fresh sync) and so after 10 seconds of waiting we advise the user that it could take some time.

This PR corrects a bug from https://github.com/LN-Zap/zap-desktop/pull/529 where we calculate the current block height incorrectly. In that PR, we incorrectly assumed that the message `Syncing to block height X` from lnd would tell us the current block height however it actually only tells us the highest block that BTCd is aware of (ie, the highest block that it has already synced). To resolve that and ensure that we know the actual current block height, we fetch the block height from the block explorers and we now do this as early as possible from the main process rather than waiting for the react `Syncing` component to mount.