### PR TITLE
Ensure that we fetch the correct block height in the case where BTCd is mid way through syncing

### DIFF
--- a/app/api/index.js
+++ b/app/api/index.js
@@ -28,36 +28,6 @@ export function requestTickers(ids) {
     )
 }
 
-export function requestBlockHeight() {
-  const sources = [
-    {
-      baseUrl: `${scheme}testnet-api.smartbit.com.au/v1/blockchain/blocks?limit=1`,
-      path: 'blocks[0].height'
-    },
-    {
-      baseUrl: `${scheme}tchain.api.btc.com/v3/block/latest`,
-      path: 'data.height'
-    },
-    {
-      baseUrl: `${scheme}api.blockcypher.com/v1/btc/test3`,
-      path: 'height'
-    }
-  ]
-  const fetchData = (baseUrl, path) => {
-    return axios({
-      method: 'get',
-      timeout: 5000,
-      url: baseUrl
-    })
-      .then(response => path.split('.').reduce((a, b) => a[b], response.data))
-      .catch(() => null)
-  }
-
-  const promises = []
-  sources.forEach(source => promises.push(fetchData(source.baseUrl, source.path)))
-  return Promise.race(promises)
-}
-
 export function requestSuggestedNodes() {
   const BASE_URL = `${scheme}zap.jackmallers.com/suggested-peers`
   return axios({

--- a/app/components/Onboarding/Syncing.js
+++ b/app/components/Onboarding/Syncing.js
@@ -8,14 +8,7 @@ import { showNotification } from 'notifications'
 import styles from './Syncing.scss'
 
 class Syncing extends Component {
-  componentWillMount() {
-    const { fetchBlockHeight, blockHeight } = this.props
-
-    // If we don't already know the target block height, fetch it now.
-    if (!blockHeight) {
-      fetchBlockHeight()
-    }
-  }
+  componentWillMount() {}
 
   render() {
     const { hasSynced, syncPercentage, address, blockHeight, lndBlockHeight } = this.props
@@ -112,7 +105,6 @@ class Syncing extends Component {
 }
 
 Syncing.propTypes = {
-  fetchBlockHeight: PropTypes.func.isRequired,
   address: PropTypes.string.isRequired,
   hasSynced: PropTypes.bool,
   syncPercentage: PropTypes.number,

--- a/app/containers/Root.js
+++ b/app/containers/Root.js
@@ -31,7 +31,7 @@ import {
   updateRecoverSeedInput,
   setReEnterSeedIndexes
 } from '../reducers/onboarding'
-import { fetchBlockHeight, lndSelectors } from '../reducers/lnd'
+import { lndSelectors } from '../reducers/lnd'
 import { walletAddress } from '../reducers/address'
 import Routes from '../routes'
 
@@ -57,9 +57,7 @@ const mapDispatchToProps = {
   walletAddress,
   updateReEnterSeedInput,
   updateRecoverSeedInput,
-  setReEnterSeedIndexes,
-
-  fetchBlockHeight
+  setReEnterSeedIndexes
 }
 
 const mapStateToProps = state => ({
@@ -82,7 +80,6 @@ const mapStateToProps = state => ({
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const syncingProps = {
-    fetchBlockHeight: dispatchProps.fetchBlockHeight,
     blockHeight: stateProps.lnd.blockHeight,
     lndBlockHeight: stateProps.lnd.lndBlockHeight,
     hasSynced: stateProps.info.hasSynced,

--- a/app/reducers/ipc.js
+++ b/app/reducers/ipc.js
@@ -2,7 +2,7 @@ import createIpc from 'redux-electron-ipc'
 import {
   lndSyncing,
   lndSynced,
-  lndBlockHeightTarget,
+  currentBlockHeight,
   lndBlockHeight,
   grpcDisconnected,
   grpcConnected
@@ -60,7 +60,7 @@ import {
 const ipc = createIpc({
   lndSyncing,
   lndSynced,
-  lndBlockHeightTarget,
+  currentBlockHeight,
   lndBlockHeight,
   grpcDisconnected,
   grpcConnected,

--- a/app/reducers/lnd.js
+++ b/app/reducers/lnd.js
@@ -3,7 +3,6 @@ import { createSelector } from 'reselect'
 import { fetchTicker } from './ticker'
 import { fetchBalance } from './balance'
 import { fetchInfo, setHasSynced } from './info'
-import { requestBlockHeight } from '../api'
 import { showNotification } from '../notifications'
 // ------------------------------------
 // Constants
@@ -62,14 +61,8 @@ export const lndBlockHeight = (event, height) => dispatch => {
   dispatch({ type: RECEIVE_BLOCK, lndBlockHeight: height })
 }
 
-export const lndBlockHeightTarget = (event, height) => dispatch => {
+export const currentBlockHeight = (event, height) => dispatch => {
   dispatch({ type: RECEIVE_BLOCK_HEIGHT, blockHeight: height })
-}
-
-export function getBlockHeight() {
-  return {
-    type: GET_BLOCK_HEIGHT
-  }
 }
 
 export function receiveBlockHeight(blockHeight) {
@@ -79,13 +72,6 @@ export function receiveBlockHeight(blockHeight) {
   }
 }
 
-// Fetch current block height
-export const fetchBlockHeight = () => async dispatch => {
-  dispatch(getBlockHeight())
-  const blockHeight = await requestBlockHeight()
-  dispatch(receiveBlockHeight(blockHeight))
-}
-
 // ------------------------------------
 // Action Handlers
 // ------------------------------------
@@ -93,11 +79,9 @@ const ACTION_HANDLERS = {
   [START_SYNCING]: state => ({ ...state, syncing: true }),
   [STOP_SYNCING]: state => ({ ...state, syncing: false }),
 
-  [GET_BLOCK_HEIGHT]: state => ({ ...state, fetchingBlockHeight: true }),
   [RECEIVE_BLOCK_HEIGHT]: (state, { blockHeight }) => ({
     ...state,
-    blockHeight,
-    fetchingBlockHeight: false
+    blockHeight
   }),
   [RECEIVE_BLOCK]: (state, { lndBlockHeight }) => ({ ...state, lndBlockHeight }),
 
@@ -111,7 +95,6 @@ const ACTION_HANDLERS = {
 const initialState = {
   syncing: false,
   grpcStarted: false,
-  fetchingBlockHeight: false,
   lines: [],
   blockHeight: 0,
   lndBlockHeight: 0

--- a/app/routes/app/containers/AppContainer.js
+++ b/app/routes/app/containers/AppContainer.js
@@ -32,7 +32,7 @@ import { payInvoice } from 'reducers/payment'
 
 import { createInvoice, fetchInvoice } from 'reducers/invoice'
 
-import { fetchBlockHeight, lndSelectors } from 'reducers/lnd'
+import { lndSelectors } from 'reducers/lnd'
 
 import {
   fetchChannels,
@@ -99,7 +99,6 @@ const mapDispatchToProps = {
   createInvoice,
   fetchInvoice,
 
-  fetchBlockHeight,
   clearError,
 
   fetchBalance,

--- a/app/zap.js
+++ b/app/zap.js
@@ -170,11 +170,11 @@ class ZapController {
       this.sendMessage('lndSynced')
     })
 
-    this.neutrino.on('got-final-block-height', height => {
-      this.sendMessage('lndBlockHeightTarget', Number(height))
+    this.neutrino.on('got-current-block-height', height => {
+      this.sendMessage('currentBlockHeight', Number(height))
     })
 
-    this.neutrino.on('got-current-block-height', height => {
+    this.neutrino.on('got-lnd-block-height', height => {
       this.sendMessage('lndBlockHeight', Number(height))
     })
 

--- a/package.json
+++ b/package.json
@@ -236,6 +236,7 @@
     "electron-store": "^2.0.0",
     "font-awesome": "^4.7.0",
     "history": "^4.6.3",
+    "lodash.get": "^4.4.2",
     "moment": "^2.22.2",
     "prop-types": "^15.5.10",
     "qrcode.react": "0.8.0",

--- a/webpack.config.renderer.dev.js
+++ b/webpack.config.renderer.dev.js
@@ -233,8 +233,7 @@ export default merge.smart(baseConfig, {
         'http://localhost:*',
         'ws://localhost:*',
         'https://api.coinmarketcap.com',
-        'https://zap.jackmallers.com',
-        'https://testnet-api.smartbit.com.au'
+        'https://zap.jackmallers.com'
       ],
       'script-src': ["'self'", 'http://localhost:*', "'unsafe-eval'"],
       'font-src': [
@@ -293,33 +292,6 @@ export default merge.smart(baseConfig, {
           proxy('/proxy/api.coinmarketcap.com', {
             target: 'https://api.coinmarketcap.com',
             pathRewrite: { '^/proxy/api.coinmarketcap.com': '' },
-            changeOrigin: true
-          })
-        )
-      )
-      app.use(
-        convert(
-          proxy('/proxy/testnet-api.smartbit.com.au', {
-            target: 'https://testnet-api.smartbit.com.au',
-            pathRewrite: { '^/proxy/testnet-api.smartbit.com.au': '' },
-            changeOrigin: true
-          })
-        )
-      )
-      app.use(
-        convert(
-          proxy('/proxy/tchain.api.btc.com', {
-            target: 'https://tchain.api.btc.com',
-            pathRewrite: { '^/proxy/tchain.api.btc.com': '' },
-            changeOrigin: true
-          })
-        )
-      )
-      app.use(
-        convert(
-          proxy('/proxy/api.blockcypher.com', {
-            target: 'https://api.blockcypher.com',
-            pathRewrite: { '^/proxy/api.blockcypher.com': '' },
             changeOrigin: true
           })
         )

--- a/webpack.config.renderer.prod.js
+++ b/webpack.config.renderer.prod.js
@@ -155,14 +155,7 @@ export default merge.smart(baseConfig, {
     new CspHtmlWebpackPlugin({
       'default-src': "'self'",
       'object-src': "'none'",
-      'connect-src': [
-        "'self'",
-        'https://api.coinmarketcap.com',
-        'https://zap.jackmallers.com',
-        'https://testnet-api.smartbit.com.au',
-        'https://tchain.api.btc.com',
-        'https://api.blockcypher.com'
-      ],
+      'connect-src': ["'self'", 'https://api.coinmarketcap.com', 'https://zap.jackmallers.com'],
       'script-src': ["'self'"],
       'font-src': [
         "'self'",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7268,6 +7268,10 @@ lodash.foreach@^4.3.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
 lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"


### PR DESCRIPTION
Fetch the current block height from multiple block explorers early on in the sync process. This ensures that we get the correct block height in the case where our BTCd node is still mid way through syncing. Do this in the main process rather than in the render process.