### PR TITLE
Don't show sent for received tx

### DIFF
--- a/app/components/Activity/TransactionModal.js
+++ b/app/components/Activity/TransactionModal.js
@@ -31,7 +31,7 @@ const TransactionModal = ({
 }) => (
   <div className={styles.container}>
     <header className={styles.header}>
-      {transaction.amount > 0 ? (
+      {transaction.amount < 0 ? (
         <section>
           <Isvg src={paperPlane} />
           <span>Sent</span>


### PR DESCRIPTION
It seems that the fix in https://github.com/LN-Zap/zap-desktop/pull/542 for #539 was the wrong way round (sent showing as received, received showing as sent). This reverses it.

Fix for #539 
