### PR TITLE
fix(ui): increase currency selector z-index

### DIFF
--- a/app/components/Form/Pay.scss
+++ b/app/components/Form/Pay.scss
@@ -123,6 +123,7 @@
       visibility: hidden;
       position: absolute;
       top: 30px;
+      z-index: 10;
 
       &.active {
         visibility: visible;

--- a/app/components/Form/Request.scss
+++ b/app/components/Form/Request.scss
@@ -102,6 +102,7 @@
       visibility: hidden;
       position: absolute;
       top: 30px;
+      z-index: 10;
 
       &.active {
         visibility: visible;


### PR DESCRIPTION
Ensure that the currency selector dropdown on the pay/request form shows ontop of other elements on the page to ensure that the full area of the dropdown is clickable.

(currently it is partially hidden behind the errors message divs.

<img width="610" alt="screenshot 2018-07-15 19 34 24" src="https://user-images.githubusercontent.com/200251/42736394-78a73d74-8866-11e8-869a-8e702b9fce6c.png">