### PR TITLE
feat(ui): show activity type icon in activity list

### DIFF
--- a/app/routes/activity/components/components/Activity.scss
+++ b/app/routes/activity/components/components/Activity.scss
@@ -16,14 +16,15 @@
     opacity: 0.5;
   }
 
-  .pendingIcon {
+  .activityTypeIcon {
     position: absolute;
     left: -5%;
-    top: 30%;
+    top: 37%;
 
     svg {
-      width: 10.5px;
-      height: 10.5px;
+      width: 16px;
+      height: 16px;
+      opacity: 0.5;
     }
   }
 }

--- a/app/routes/activity/components/components/Invoice/Invoice.js
+++ b/app/routes/activity/components/components/Invoice/Invoice.js
@@ -14,8 +14,13 @@ const Invoice = ({ invoice, ticker, currentTicker, showActivityModal, currencyNa
     onClick={() => showActivityModal('INVOICE', { invoice })}
   >
     {!invoice.settled && (
-      <div className={styles.pendingIcon}>
-        <Isvg src={checkmarkIcon} />
+      <div className={styles.activityTypeIcon}>
+        <section
+          className="hint--bottom"
+          data-hint={`Lightning invoice${!invoice.settled ? ' (unpaid)' : undefined}`}
+        >
+          <Isvg src={checkmarkIcon} />
+        </section>
       </div>
     )}
 

--- a/app/routes/activity/components/components/Payment/Payment.js
+++ b/app/routes/activity/components/components/Payment/Payment.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Moment from 'react-moment'
+import Isvg from 'react-inlinesvg'
+import zap from 'icons/zap.svg'
 import { btc } from 'utils'
 
 import Value from 'components/Value'
@@ -19,6 +21,12 @@ const Payment = ({ payment, ticker, currentTicker, showActivityModal, nodes, cur
 
   return (
     <div className={styles.container} onClick={() => showActivityModal('PAYMENT', { payment })}>
+      <div className={styles.activityTypeIcon}>
+        <section className="hint--bottom" data-hint="Lightning payment">
+          <Isvg src={zap} />
+        </section>
+      </div>
+
       <div className={styles.data}>
         <div className={styles.title}>
           <h3>{displayNodeName(payment.path[payment.path.length - 1])}</h3>

--- a/app/routes/activity/components/components/Transaction/Transaction.js
+++ b/app/routes/activity/components/components/Transaction/Transaction.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Moment from 'react-moment'
+import Isvg from 'react-inlinesvg'
+import link from 'icons/link.svg'
 import { btc } from 'utils'
 
 import Value from 'components/Value'
@@ -11,6 +13,12 @@ const Transaction = ({ transaction, ticker, currentTicker, showActivityModal, cu
     className={styles.container}
     onClick={() => showActivityModal('TRANSACTION', { transaction })}
   >
+    <div className={styles.activityTypeIcon}>
+      <section className="hint--bottom" data-hint="On-chain transaction">
+        <Isvg src={link} />
+      </section>
+    </div>
+
     <div className={styles.data}>
       <div className={styles.title}>
         <h3>{transaction.received ? 'Received' : 'Sent'}</h3>


### PR DESCRIPTION
Currently, it's not immediately obvious which transactions are on-chain vs off-chain when scanning the activity list.

Add an icon that shows the activity type in the activity list to help users clearly distinguish between on-chain and off-chain transactions.

**Before:**
<img width="665" alt="screenshot 2018-07-15 23 01 49" src="https://user-images.githubusercontent.com/200251/42738398-60477d76-8883-11e8-8335-fbc4d30256b7.png">

**After:**
<img width="665" alt="screenshot 2018-07-15 23 02 19" src="https://user-images.githubusercontent.com/200251/42738399-664b0c10-8883-11e8-861b-567ff04629c4.png">
