### PR TITLE
fix(accessibility): don't use white on yellow text

### DIFF
--- a/app/components/Contacts/ConnectManually.scss
+++ b/app/components/Contacts/ConnectManually.scss
@@ -124,6 +124,8 @@
 
     &.active {
       background: $gold;
+      color: $spaceblue;
+      font-weight: bold;
       opacity: 1;
 
       &:hover {

--- a/app/components/Contacts/SubmitChannelForm.scss
+++ b/app/components/Contacts/SubmitChannelForm.scss
@@ -132,6 +132,8 @@
 
     &.active {
       background: $gold;
+      color: $spacegrey;
+      font-weight: bold;
       opacity: 1;
 
       &:hover {

--- a/app/components/Form/Pay.scss
+++ b/app/components/Form/Pay.scss
@@ -163,6 +163,8 @@
 
       &.active {
         background: $gold;
+        color: $spaceblue;
+        font-weight: bold;
         opacity: 1;
 
         &:hover {

--- a/app/components/Form/Request.scss
+++ b/app/components/Form/Request.scss
@@ -142,6 +142,8 @@
 
       &.active {
         background: $gold;
+        color: $spaceblue;
+        font-weight: bold;
         opacity: 1;
 
         &:hover {


### PR DESCRIPTION
White on yellow presents accessibility challenges and should be avoided. Change the white on yellow used in highlighted buttons for a darker colour against the yellow background.

Fix #356

**Before:**
<img width="705" alt="screenshot 2018-07-16 10 02 26" src="https://user-images.githubusercontent.com/200251/42748169-6e8157c0-88df-11e8-94ae-dd6acf5369a8.png">


**After:**
<img width="726" alt="screenshot 2018-07-16 10 01 43" src="https://user-images.githubusercontent.com/200251/42748171-71a70c92-88df-11e8-98db-afa5e96709c0.png">
