### PR TITLE
fix(windows): reference webpack-serve js directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prestart": "npm run build",
     "start": "cross-env NODE_ENV=production electron ./app/",
     "start-main-dev": "cross-env HOT=1 NODE_ENV=development electron -r babel-register ./app/main.dev",
-    "start-renderer-dev": "node --trace-warnings -r babel-register ./node_modules/.bin/webpack-serve --config webpack.config.renderer.dev.js",
+    "start-renderer-dev": "node --trace-warnings -r babel-register ./node_modules/webpack-serve/lib/cli.js --config webpack.config.renderer.dev.js",
     "test": "cross-env NODE_ENV=test BABEL_DISABLE_CACHE=1 node --trace-warnings ./test/runTests.js",
     "test-ci": "npm run package && npm run test && npm run test-e2e",
     "test-all": "npm run lint && npm run lint-styles && npm run flow && npm run build && npm run test && npm run test-e2e",


### PR DESCRIPTION
Windows build is failing on this line with:

```
  > node --trace-warnings -r babel-register ./node_modules/.bin/webpack-serve --config webpack.config.renderer.dev.js

  C:\Users\user\Documents\zap-desktop\node_modules\.bin\webpack-serve:2
  basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
            ^^^^^^^

  SyntaxError: missing ) after argument list
      at createScript (vm.js:80:10)
      at Object.runInThisContext (vm.js:139:10)
      at Module._compile (module.js:616:28)
      at Module._extensions..js (module.js:663:10)
      at Object.require.extensions.(anonymous function) [as .js] (C:\Users\user\Documents\zap-desktop\node_modules\babel-register\lib\node.js:152:7)
      at Module.load (module.js:565:32)
      at tryModuleLoad (module.js:505:12)
      at Function.Module._load (module.js:497:3)
      at Function.Module.runMain (module.js:693:10)
      at startup (bootstrap_node.js:191:16)
```

This is because webpack-serve expects a js file, but on windows, which
lacks supports for shebang comments, they are wrapped in .cmd files to
be executable. e.g. see:
https://github.com/gotwarlost/istanbul#usage-on-windows

To fix this, we reference the js file directly to avoid the .cmd
wrapping.