### PR TITLE
fix: aezeedPasswordConfirmation propagation

### DIFF
--- a/app/containers/Root.js
+++ b/app/containers/Root.js
@@ -153,7 +153,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
 
   const newAezeedPasswordProps = {
     aezeedPassword: stateProps.onboarding.aezeedPassword,
-    aezeedPasswordConfirmation: stateProps.onboarding.updateAezeedPasswordConfirmation,
+    aezeedPasswordConfirmation: stateProps.onboarding.aezeedPasswordConfirmation,
     showAezeedPasswordConfirmationError: stateProps.showAezeedPasswordConfirmationError,
     updateAezeedPassword: dispatchProps.updateAezeedPassword,
     updateAezeedPasswordConfirmation: dispatchProps.updateAezeedPasswordConfirmation


### PR DESCRIPTION
I saw a warning that a required argument to NewAezeedPassword was not
present and tracked it back to here.

updateAezeedPasswordConfirmation is a function and should be sourced
via the dispatchProps, while the aezeedPasswordConfirmation holds the
value.