### PR TITLE
 fix: don't show channel suggestions if pending channels exist

### DIFF
--- a/app/components/Contacts/Network.js
+++ b/app/components/Contacts/Network.js
@@ -32,7 +32,8 @@ class Network extends Component {
         selectedChannel,
         loadingChannelPubkeys,
         closingChannelIds,
-        channels
+        channels,
+        pendingChannels: { pending_open_channels }
       },
       currentChannels,
       balance,
@@ -174,10 +175,7 @@ class Network extends Component {
         </header>
 
         <div className={styles.channels}>
-          {loadingChannelPubkeys.length ||
-          currentChannels.length ||
-          channels.length ||
-          searchQuery.length ? (
+          {loadingChannelPubkeys.length || pending_open_channels.length || channels.length ? (
             <header className={styles.listHeader}>
               <section>
                 <h2 onClick={toggleFilterPulldown} className={styles.filterTitle}>
@@ -326,7 +324,7 @@ class Network extends Component {
               })}
           </ul>
         </div>
-        {(loadingChannelPubkeys.length || currentChannels.length || searchQuery.length) && (
+        {(loadingChannelPubkeys.length || pending_open_channels.length || channels.length) && (
           <footer className={styles.search}>
             <label htmlFor="search" className={`${styles.label} ${styles.input}`}>
               <Isvg src={search} />

--- a/app/components/Contacts/Network.js
+++ b/app/components/Contacts/Network.js
@@ -174,15 +174,10 @@ class Network extends Component {
         </header>
 
         <div className={styles.channels}>
-          {!loadingChannelPubkeys.length &&
-            !currentChannels.length &&
-            !channels.length &&
-            !searchQuery.length && <SuggestedNodes {...suggestedNodesProps} />}
-
-          {(loadingChannelPubkeys.length ||
-            currentChannels.length ||
-            channels.length ||
-            searchQuery.length) && (
+          {loadingChannelPubkeys.length ||
+          currentChannels.length ||
+          channels.length ||
+          searchQuery.length ? (
             <header className={styles.listHeader}>
               <section>
                 <h2 onClick={toggleFilterPulldown} className={styles.filterTitle}>
@@ -211,6 +206,8 @@ class Network extends Component {
                 </span>
               </section>
             </header>
+          ) : (
+            <SuggestedNodes {...suggestedNodesProps} />
           )}
 
           <ul className={filterPulldown && styles.fade}>

--- a/app/reducers/channels.js
+++ b/app/reducers/channels.js
@@ -444,10 +444,7 @@ channelsSelectors.nonActiveChannelPubkeys = createSelector(channelsSelector, ope
   openChannels.filter(channel => !channel.active).map(c => c.remote_pubkey)
 )
 
-channelsSelectors.pendingOpenChannels = createSelector(
-  pendingOpenChannelsSelector,
-  pendingOpenChannels => pendingOpenChannels
-)
+channelsSelectors.pendingOpenChannels = pendingOpenChannelsSelector
 
 channelsSelectors.pendingOpenChannelPubkeys = createSelector(
   pendingOpenChannelsSelector,


### PR DESCRIPTION
This changes the Network component conditional for showing channels suggestions to `!(loadingChannelPubkeys.length || pending_open_channels.length || channels.length)` from `!((loadingChannelPubkeys.length || currentChannels.length || channels.length || searchQuery.length)`

The theory is we should show search and selection whenever any channels exist or are being looked up, regardless of whether search input is supplied or current channels are selected.