### PR TITLE
fix(onboarding): default to create new wallet

### DIFF
--- a/app/reducers/onboarding.js
+++ b/app/reducers/onboarding.js
@@ -424,7 +424,7 @@ const initialState = {
   recoverSeedInput: [],
   // step where the user decides whether they want a newly created seed or to import an existing one
   signupForm: {
-    create: false,
+    create: true,
     import: false
   },
 


### PR DESCRIPTION
It is more common for new users to create a new wallet than to import an existing one. Make the "create new wallet" option the default selected value in the onboarding process.