### PR TITLE
fix: ensure conditional display uses boolean

### DIFF
--- a/app/components/Contacts/Network.js
+++ b/app/components/Contacts/Network.js
@@ -214,7 +214,7 @@ class Network extends Component {
           )}
 
           <ul className={filterPulldown && styles.fade}>
-            {loadingChannelPubkeys.length &&
+            {loadingChannelPubkeys.length > 0 &&
               loadingChannelPubkeys.map(loadingPubkey => {
                 // TODO(jimmymow): refactor this out. same logic is in displayNodeName above
                 const node = nodes.find(n => loadingPubkey === n.pub_key)
@@ -237,7 +237,7 @@ class Network extends Component {
                   </li>
                 )
               })}
-            {currentChannels.length &&
+            {currentChannels.length > 0 &&
               currentChannels.map((channelObj, index) => {
                 const channel = Object.prototype.hasOwnProperty.call(channelObj, 'channel')
                   ? channelObj.channel


### PR DESCRIPTION
Prevents the display of an unwanted "0" by ensuring that conditional uses an actual boolean value.

<img width="367" alt="screenshot 2018-07-20 00 27 17" src="https://user-images.githubusercontent.com/200251/42973765-cb48e630-8bb4-11e8-8ddd-06e54767f89f.png">