### PR TITLE
feat(help): add help link to tutorial

### DIFF
--- a/app/components/Onboarding/FormContainer.js
+++ b/app/components/Onboarding/FormContainer.js
@@ -1,3 +1,4 @@
+import { shell } from 'electron'
 import React from 'react'
 import PropTypes from 'prop-types'
 import Isvg from 'react-inlinesvg'
@@ -16,7 +17,18 @@ const FormContainer = ({ title, description, back, next, children }) => (
       <section>
         <Isvg src={zapLogo} />
       </section>
-      <section />
+      <section>
+        <div
+          className={styles.help}
+          onClick={() =>
+            shell.openExternal(
+              'https://github.com/LN-Zap/zap-tutorials/blob/master/zap-desktop-getting-started.md'
+            )
+          }
+        >
+          Need help?
+        </div>
+      </section>
     </header>
 
     <div className={styles.info}>

--- a/app/components/Onboarding/FormContainer.js
+++ b/app/components/Onboarding/FormContainer.js
@@ -21,9 +21,7 @@ const FormContainer = ({ title, description, back, next, children }) => (
         <div
           className={styles.help}
           onClick={() =>
-            shell.openExternal(
-              'https://github.com/LN-Zap/zap-tutorials/blob/master/zap-desktop-getting-started.md'
-            )
+            shell.openExternal('https://ln-zap.github.io/zap-tutorials/zap-desktop-getting-started')
           }
         >
           Need help?

--- a/app/components/Onboarding/FormContainer.scss
+++ b/app/components/Onboarding/FormContainer.scss
@@ -18,6 +18,17 @@
   flex-direction: row;
   justify-content: space-between;
   padding: 20px 40px;
+
+  .help {
+    color: $white;
+    text-decoration: underline;
+    cursor: pointer;
+    transition: all 0.25s;
+
+    &:hover {
+      opacity: 0.5;
+    }
+  }
 }
 
 .info {


### PR DESCRIPTION
Add a help link to our onboarding forms that links to our Desktop "Getting Started" tutorial in case anyone gets stuck

<img width="951" alt="screen shot 2018-07-21 at 8 53 00 pm" src="https://user-images.githubusercontent.com/4040039/43041500-465552c2-8d28-11e8-98ff-7495b159d430.png">
