### PR TITLE
fix(onboarding): improve existing wallet found message

### DIFF
--- a/app/components/Onboarding/Onboarding.js
+++ b/app/components/Onboarding/Onboarding.js
@@ -161,7 +161,10 @@ const Onboarding = ({
         return (
           <FormContainer
             title="Welcome back!"
-            description="It looks like you have already a wallet. Please enter your wallet password to unlock it."
+            description={`It looks like you have already a wallet
+              ${Boolean(initWalletProps.loginProps.existingWalletDir) &&
+                `(we found one at \`${initWalletProps.loginProps.existingWalletDir}\`)`}.
+            Please enter your wallet password to unlock it.`}
             back={null}
             next={null}
           >

--- a/app/components/Onboarding/Onboarding.js
+++ b/app/components/Onboarding/Onboarding.js
@@ -161,7 +161,7 @@ const Onboarding = ({
         return (
           <FormContainer
             title="Welcome back!"
-            description="Enter your wallet password or create a new wallet"
+            description="It looks like you have already a wallet. Please enter your wallet password to unlock it."
             back={null}
             next={null}
           >

--- a/app/containers/Root.js
+++ b/app/containers/Root.js
@@ -127,6 +127,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
       password: stateProps.onboarding.password,
       passwordIsValid: stateProps.passwordIsValid,
       hasSeed: stateProps.onboarding.hasSeed,
+      existingWalletDir: stateProps.onboarding.existingWalletDir,
       unlockingWallet: stateProps.onboarding.unlockingWallet,
       unlockWalletError: stateProps.onboarding.unlockWalletError,
 

--- a/app/lnd/walletUnlockerMethods/index.js
+++ b/app/lnd/walletUnlockerMethods/index.js
@@ -1,13 +1,28 @@
+import { dirname } from 'path'
 import * as walletController from '../methods/walletController'
+import config from '../config'
 
 export default function(walletUnlocker, log, event, msg, data) {
+  const lndConfig = config.lnd()
+
+  const decorateError = error => {
+    switch (error.code) {
+      // wallet already exists
+      case 2:
+        error.context = {
+          lndDataDir: dirname(lndConfig.cert)
+        }
+    }
+    return error
+  }
+
   log.info(`Calling walletUnlocker method '${msg}'`)
   switch (msg) {
     case 'genSeed':
       walletController
         .genSeed(walletUnlocker)
         .then(genSeedData => event.sender.send('receiveSeed', genSeedData))
-        .catch(error => event.sender.send('receiveSeedError', error))
+        .catch(error => event.sender.send('receiveSeedError', decorateError(error)))
       break
     case 'unlockWallet':
       walletController

--- a/app/reducers/onboarding.js
+++ b/app/reducers/onboarding.js
@@ -38,6 +38,8 @@ export const STARTING_LND = 'STARTING_LND'
 export const LND_STARTED = 'LND_STARTED'
 export const SET_START_LND_ERROR = 'SET_START_LND_ERROR'
 
+export const LOADING_EXISTING_WALLET = 'LOADING_EXISTING_WALLET'
+
 export const CREATING_NEW_WALLET = 'CREATING_NEW_WALLET'
 
 export const UNLOCKING_WALLET = 'UNLOCKING_WALLET'
@@ -268,10 +270,14 @@ export const receiveSeed = (event, { cipher_seed_mnemonic }) => dispatch => {
 }
 
 // Listener for when LND throws an error on seed creation
-export const receiveSeedError = () => dispatch => {
+export const receiveSeedError = (event, error) => dispatch => {
   dispatch({ type: SET_HAS_SEED, hasSeed: true })
   // there is already a seed, send user to the login component
   dispatch({ type: CHANGE_STEP, step: 3 })
+  dispatch({
+    type: LOADING_EXISTING_WALLET,
+    existingWalletDir: get(error, 'context.lndDataDir')
+  })
 }
 
 // Unlock an existing wallet with a wallet password
@@ -339,6 +345,8 @@ const ACTION_HANDLERS = {
     startLndCertError: errors.cert,
     startLndMacaroonError: errors.macaroon
   }),
+
+  [LOADING_EXISTING_WALLET]: (state, { existingWalletDir }) => ({ ...state, existingWalletDir }),
 
   [CREATING_NEW_WALLET]: state => ({ ...state, creatingNewWallet: true }),
 
@@ -464,6 +472,7 @@ const initialState = {
   createWalletPasswordConfirmation: '',
   creatingNewWallet: false,
 
+  existingWalletDir: null,
   unlockingWallet: false,
   unlockWalletError: {
     isError: false,


### PR DESCRIPTION
Improve the wording of the message users see when they go through onboarding and we detect that they already have an existing wallet

Addresses:
https://github.com/LN-Zap/zap-desktop/issues/602
https://github.com/LN-Zap/zap-desktop/issues/598
https://github.com/LN-Zap/zap-desktop/issues/597
https://github.com/LN-Zap/zap-desktop/issues/594
https://github.com/LN-Zap/zap-desktop/issues/591

**Before:**
<img width="948" alt="screenshot 2018-07-25 13 17 02" src="https://user-images.githubusercontent.com/200251/43197929-13fdd6fe-900d-11e8-9852-c36efdada797.png">

**After:**
<img width="946" alt="screenshot 2018-07-25 13 16 38" src="https://user-images.githubusercontent.com/200251/43197928-125aaff2-900d-11e8-804a-e749ba23058a.png">
