### PR TITLE
fix: honour currency when opening channel

### DIFF
--- a/app/reducers/channels.js
+++ b/app/reducers/channels.js
@@ -183,8 +183,9 @@ export const receiveChannels = (event, { channels, pendingChannels }) => dispatc
   dispatch({ type: RECEIVE_CHANNELS, channels, pendingChannels })
 
 // Send IPC event for opening a channel
-export const openChannel = ({ pubkey, host, local_amt }) => dispatch => {
-  const localamt = btc.btcToSatoshis(local_amt)
+export const openChannel = ({ pubkey, host, local_amt }) => (dispatch, getState) => {
+  const state = getState()
+  const localamt = btc.convert(state.ticker.currency, 'sats', local_amt)
 
   dispatch(openingChannel())
   dispatch(addLoadingPubkey(pubkey))


### PR DESCRIPTION
Ensure that the currently active unit of account is honoured when opening a new channel.

Fix #523
Also see #604