### PR TITLE
chore(version): bump to 0.2.1-beta

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap-desktop",
   "productName": "ZapDesktop",
-  "version": "0.2.0-beta",
+  "version": "0.2.1-beta",
   "description": "desktop application for the lightning network",
   "main": "./main.prod.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap-desktop",
   "productName": "ZapDesktop",
-  "version": "0.2.0-beta",
+  "version": "0.2.1-beta",
   "description": "desktop application for the lightning network",
   "scripts": {
     "build": "concurrently --raw \"npm:build-main\" \"npm:build-renderer\"",


### PR DESCRIPTION
This should be committed ASAP - release number should be bumped immediately after previous release.

Once https://github.com/LN-Zap/zap-desktop/pull/599 is in place, this will ensure that build artefacts are pushed up to our upcoming 0.2.1-beta release node on every push to master.