### PR TITLE
fix(windows): read lnd config from %LOCALAPPDATA%

### DIFF
--- a/app/lnd/config/index.js
+++ b/app/lnd/config/index.js
@@ -34,7 +34,7 @@ switch (plat) {
     lndBin = 'lnd'
     break
   case 'win32':
-    lndDataDir = join(process.env.APPDATA, 'Local', 'Lnd')
+    lndDataDir = join(process.env.LOCALAPPDATA, 'Local', 'Lnd')
     lndBin = 'lnd.exe'
     break
   default:


### PR DESCRIPTION
Lnd stores it's config files in %LOCALAPPDATA% on windows. Ensure that we use this path in our lookups.

Fix #628