### PR TITLE
ci(crowdin): skip ci builds on crowdin commits

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,4 @@
+commit_message: '[ci skip]'
 files:
   - source: /app/translation/source/*.json
     translation: /app/translation/dest/%file_name%/%locale%.%file_extension%


### PR DESCRIPTION
Add `[skip ci]` to commit messages that originate from crowdin in order to skip builds on those commits since nothing will have changed except for translation files.

See https://support.crowdin.com/configuration-file/#configuration-file-for-vcs-integrations