### PR TITLE
fix(app): quit when window closed on non-darwin

### DIFF
--- a/app/lib/zap/controller.js
+++ b/app/lib/zap/controller.js
@@ -119,11 +119,10 @@ class ZapController {
 
     // When the window is closed, just hide it unless we are force closing.
     this.mainWindow.on('close', e => {
-      if (this.mainWindow.forceClose) {
-        return
+      if (process.platform === 'darwin' && !this.mainWindow.forceClose) {
+        e.preventDefault()
+        this.mainWindow.hide()
       }
-      e.preventDefault()
-      this.mainWindow.hide()
     })
   }
 


### PR DESCRIPTION
On darwin, we keep the app running and just hide it when the window is closed as that is the standard convention. On linux and windows the app should be quit when the window is closed.

This resolves an issue where on linux/windows the app would remain open when the window is closed, with no way to properly quit it short of doing a force quit.