### PR TITLE
fix(invoice): only notify on settled invoices

### DIFF
--- a/app/reducers/invoice.js
+++ b/app/reducers/invoice.js
@@ -136,11 +136,13 @@ export const invoiceUpdate = (event, { invoice }) => dispatch => {
   // Fetch new balance
   dispatch(fetchBalance())
 
-  // HTML 5 desktop notification for the invoice update
-  const notifTitle = "You've been Zapped"
-  const notifBody = 'Congrats, someone just paid an invoice of yours'
+  if (invoice.settled) {
+    // HTML 5 desktop notification for the invoice update
+    const notifTitle = "You've been Zapped"
+    const notifBody = 'Congrats, someone just paid an invoice of yours'
 
-  showNotification(notifTitle, notifBody)
+    showNotification(notifTitle, notifBody)
+  }
 }
 // ------------------------------------
 // Action Handlers


### PR DESCRIPTION
Fix a bug where we were incorrectly notifying users that an invoice had been successfully paid when it had actually just been created.

Fix #670