### PR TITLE
 fix(lnd): disable lnd REST interface on port 8080

### DIFF
--- a/resources/lnd.conf
+++ b/resources/lnd.conf
@@ -84,6 +84,7 @@
 ;   restlisten=localhost:443
 ; On an Unix socket:
 ;   restlisten=unix:///var/run/lnd-restlistener.sock
+restlisten=0
 
 ; Adding an external IP will advertise your node to the network. This signals
 ; that your node is available to accept incoming channels. If you don't wish to

--- a/resources/lnd.conf
+++ b/resources/lnd.conf
@@ -1,4 +1,4 @@
-; Imported from https://github.com/lightningnetwork/lnd/blob/v0.4.2-beta/sample-lnd.conf
+; Imported from https://github.com/lightningnetwork/lnd/blob/fab1aa2d49380a3e8aef545c6b6a82e650e3b20f/sample-lnd.conf
 ; updated to include default Zap settings
 
 [Application Options]
@@ -27,6 +27,14 @@
 ; Path to TLS private key for lnd's RPC and REST services.
 ; tlskeypath=~/.lnd/tls.key
 
+; Adds an extra ip to the generated certificate
+; (old tls files must be deleted if changed)
+; tlsextraip=
+
+; Adds an extra domain to the generate certificate
+; (old tls files must be deleted if changed)
+; tlsextradomain=
+
 ; Disable macaroon authentication. Macaroons are used are bearer credentials to
 ; authenticate all RPC access. If one wishes to opt out of macaroons, uncomment
 ; the line below.
@@ -41,7 +49,7 @@
 ; Path to write the read-only macaroon for lnd's RPC and REST services if it
 ; doesn't exist. This can be set if one wishes to store the read-only macaroon
 ; in a distinct location. The read only macaroon allows users which can read
-; the file to access RPC's which don't modify the state of the daemon.
+; the file to access RPCs which don't modify the state of the daemon.
 ; readonlymacaroonpath=~/.lnd/readonly.macaroon
 
 
@@ -64,6 +72,8 @@
 ; On ipv4 localhost port 10009 and ipv6 port 10010:
 ;   rpclisten=localhost:10009
 ;   rpclisten=[::1]:10010
+; On an Unix socket:
+;   rpclisten=unix:///var/run/lnd/lnd-rpclistener.sock
 
 ; Specify the interfaces to listen on for REST connections.  One listen
 ; address per line.
@@ -72,7 +82,8 @@
 ; On ipv4 localhost port 80 and 443:
 ;   restlisten=localhost:80
 ;   restlisten=localhost:443
-
+; On an Unix socket:
+;   restlisten=unix:///var/run/lnd-restlistener.sock
 
 ; Adding an external IP will advertise your node to the network. This signals
 ; that your node is available to accept incoming channels. If you don't wish to
@@ -80,6 +91,18 @@
 ; (with host:port notation), the default port (9735) will be added to the
 ; address.
 ; externalip=
+;
+; Instead of explicitly stating your external IP address, you can also enable
+; UPnP or NAT-PMP support on the daemon. Both techniques will be tried and
+; require proper hardware support. In order to detect this hardware support,
+; `lnd` uses a dependency that retrieves the router's gateway address by using
+; different built-in binaries in each platform. Therefore, it is possible that
+; we are unable to detect the hardware and `lnd` will exit with an error
+; indicating this. This option will automatically retrieve your external IP
+; address, even after it has changed in the case of dynamic IPs, and advertise
+; it to the network using the ports the daemon is listening on. This does not
+; support devices behind multiple NATs.
+; nat=true
 
 
 ; Debug logging level.
@@ -124,12 +147,9 @@ debuglevel=debug
 ; active.
 bitcoin.active=1
 
-; Use Bitcoin's main network.
-; bitcoin.mainnet=1
-
 ; Use Bitcoin's test network.
 bitcoin.testnet=1
-
+;
 ; Use Bitcoin's simulation test network
 ; bitcoin.simnet=1
 
@@ -195,11 +215,11 @@ bitcoin.node=neutrino
 ; (other than for a remote bitcoind instance).
 ; bitcoind.rpcpass=kek
 
-; ZMQ socket which sends rawblock and (optionally) rawtx notifications from
-; bitcoind. By default, lnd will attempt to automatically obtain this
-; information, so this likely won't need to be set (other than for a remote
-; bitcoind instance).
-; bitcoind.zmqpath=tcp://127.0.0.1:28332
+; ZMQ socket which sends rawblock and rawtx notifications from bitcoind. By
+; default, lnd will attempt to automatically obtain this information, so this
+; likely won't need to be set (other than for a remote bitcoind instance).
+; bitcoind.zmqpubrawblock=tcp://127.0.0.1:28332
+; bitcoind.zmqpubrawtx=tcp://127.0.0.1:28333
 
 
 [neutrino]
@@ -273,11 +293,11 @@ litecoin.node=ltcd
 ; (other than for a remote litecoind instance).
 ; litecoind.rpcpass=kek
 
-; ZMQ socket which sends rawblock and (optionally) rawtx notifications from
-; litecoind. By default, lnd will attempt to automatically obtain this
-; information, so this likely won't need to be set (other than for a remote
-; litecoind instance).
-; litecoind.zmqpath=tcp://127.0.0.1:28332
+; ZMQ socket which sends rawblock and rawtx notifications from litecoind. By
+; default, lnd will attempt to automatically obtain this information, so this
+; likely won't need to be set (other than for a remote litecoind instance).
+; litecoind.zmqpubrawblock=tcp://127.0.0.1:28332
+; litecoind.zmqpubrawtx=tcp://127.0.0.1:28333
 
 
 [autopilot]


### PR DESCRIPTION
Disable the REST interface which by default runs on port 8080 so as to avoid conflicts with users that are using port 8080 for other things. We don't use the REST interface so we don't need to expose it.

Fix #674