### PR TITLE
fix(invoice-amt-paid): settled invoices show amt_paid

### DIFF
--- a/app/components/Activity/InvoiceModal.js
+++ b/app/components/Activity/InvoiceModal.js
@@ -55,7 +55,7 @@ const InvoiceModal = ({
             <section className={styles.amount}>
               <h1>
                 <Value
-                  value={invoice.value}
+                  value={invoice.finalAmount}
                   currency={ticker.currency}
                   currentTicker={currentTicker}
                 />

--- a/app/lib/utils/btc.js
+++ b/app/lib/utils/btc.js
@@ -69,6 +69,16 @@ export function satoshisToUsd(satoshis, price) {
   return btcToUsd(satoshisToBtc(satoshis), price)
 }
 
+////////////////////////////////
+// millisatoshis to satoshis //
+////////////////////////////// 
+
+export function millisatoshisToSatoshis(millisatoshis) {
+  if (millisatoshis === undefined || millisatoshis === null || millisatoshis === '') return null
+
+  return Math.round(millisatoshis / 1000)
+}
+
 
 export function renderCurrency(currency) {
   switch (currency) {
@@ -138,6 +148,8 @@ export default {
   satoshisToBtc,
   satoshisToBits,
   satoshisToUsd,
+
+  millisatoshisToSatoshis,
 
   renderCurrency,
 

--- a/app/routes/activity/components/components/Invoice/Invoice.js
+++ b/app/routes/activity/components/components/Invoice/Invoice.js
@@ -40,11 +40,15 @@ const Invoice = ({ invoice, ticker, currentTicker, showActivityModal, currencyNa
     >
       <span>
         <i className={styles.plus}>+</i>
-        <Value value={invoice.value} currency={ticker.currency} currentTicker={currentTicker} />
+        <Value
+          value={invoice.finalAmount}
+          currency={ticker.currency}
+          currentTicker={currentTicker}
+        />
         <i> {currencyName}</i>
       </span>
       <span>
-        <span>${btc.convert('sats', 'usd', invoice.value, currentTicker.price_usd)}</span>
+        <span>${btc.convert('sats', 'usd', invoice.finalAmount, currentTicker.price_usd)}</span>
       </span>
     </div>
   </div>


### PR DESCRIPTION
Settled invoices show the amount paid by the payee instead of the requested
value from the invoice. This involves using an updated version of the lnd rpc
protocol.

This is in response to issue #654.

amt_paid is exposed to users via invoice.finalAmount, which is constructed
via a new invoice decorator.