### PR TITLE
fix(lnd): only connect to single btcd host

### DIFF
--- a/app/lib/lnd/neutrino.js
+++ b/app/lib/lnd/neutrino.js
@@ -82,10 +82,10 @@ class Neutrino extends EventEmitter {
 
     if (this.lndConfig.network === 'mainnet') {
       neutrinoArgs.push('--neutrino.connect=mainnet1-btcd.zaphq.io')
-      neutrinoArgs.push('--neutrino.connect=mainnet2-btcd.zaphq.io')
+      // neutrinoArgs.push('--neutrino.connect=mainnet2-btcd.zaphq.io')
     } else {
       neutrinoArgs.push('--neutrino.connect=testnet1-btcd.zaphq.io')
-      neutrinoArgs.push('--neutrino.connect=testnet2-btcd.zaphq.io')
+      // neutrinoArgs.push('--neutrino.connect=testnet2-btcd.zaphq.io')
     }
 
     this.process = spawn(this.lndConfig.binaryPath, neutrinoArgs)


### PR DESCRIPTION
The lnd sync process doesn't currently handle multiple btcd connections well. Remove the alternate btcd hosts for testnet and mainnet.

See https://github.com/lightningnetwork/lnd/issues/1752