### PR TITLE
fix(lnd): don't treat filters as filter headers

### DIFF
--- a/app/lib/lnd/neutrino.js
+++ b/app/lib/lnd/neutrino.js
@@ -184,14 +184,10 @@ class Neutrino extends EventEmitter {
           height = match[1]
         } else if ((match = line.match(/Got cfheaders from height=(\d*) to height=(\d+)/))) {
           cfilter = match[2]
+        } else if ((match = line.match(/Writing filter headers up to height=(\d*)/))) {
+          cfilter = match[1]
         } else if ((match = line.match(/Verified \d* filter headers? in the.+\(height (\d+)/))) {
           cfilter = match[1]
-        }
-
-        if (!this.lndCfilterHeight || this.lndCfilterHeight > this.currentBlockHeight - 10000) {
-          if ((match = line.match(/Fetching filter for height=(\d+)/))) {
-            cfilter = match[1]
-          }
         }
 
         if (height) {


### PR DESCRIPTION
During the sync process there are log message that relate to syncing filters and filter headers. This fixes an issue where we were parsing messages about syncing filters as if they were filter headers, which would cause the progress indicator to jump around during the middle of the sync process due to it thinking that more filter headers had been synced than was actually the case.