### PR TITLE
fix(ui): increase line-height in seed reentry form

### DIFF
--- a/app/components/Onboarding/ReEnterSeed.scss
+++ b/app/components/Onboarding/ReEnterSeed.scss
@@ -17,16 +17,12 @@
 
     section {
       display: inline-block;
-      vertical-align: middle;
       color: $white;
+      margin: 0;
 
       &:nth-child(1) {
         text-align: center;
         opacity: 0.5;
-      }
-
-      &:nth-child(2) {
-        margin: 0 5px;
       }
     }
   }
@@ -37,9 +33,11 @@
   background-color: inherit;
   outline: 0;
   border: none;
-  padding: 5px 10px;
+  padding: 8px 10px 6px 10px;
   color: $white;
   font-family: 'Courier', courier, sans-serif;
+  font-size: 14px;
+  line-height: 18px;
 
   &.valid {
     color: $green;

--- a/app/components/Onboarding/RecoverForm.scss
+++ b/app/components/Onboarding/RecoverForm.scss
@@ -12,18 +12,18 @@
 
     section {
       display: inline-block;
-      vertical-align: middle;
       color: $white;
+      margin: 0;
 
       &:nth-child(1) {
-        width: 15%;
+        width: 10%;
         text-align: center;
         opacity: 0.5;
       }
 
       &:nth-child(2) {
-        width: calc(85% - 10px);
-        margin: 0 5px;
+        width: calc(90% - 10px);
+        margin-right: 10px;
       }
     }
   }
@@ -34,9 +34,11 @@
   background-color: #1c1e26;
   outline: 0;
   border: none;
-  padding: 5px 10px;
+  padding: 8px 10px 6px 10px;
   color: $white;
   font-family: 'Courier', courier, sans-serif;
+  font-size: 14px;
+  line-height: 18px;
 
   &.valid {
     color: $green;


### PR DESCRIPTION
Due to differences in font rendering cross-platform set line-height to ensure consistent experience on mac/linux.

Fix #665

**before:**
<img width="794" alt="screenshot 2018-08-14 11 43 59" src="https://user-images.githubusercontent.com/200251/44084751-dd1ff666-9fb7-11e8-9eb4-62df6935e41e.png">

**after:**
<img width="830" alt="screenshot 2018-08-20 12 56 35" src="https://user-images.githubusercontent.com/200251/44336696-905f5e00-a478-11e8-9a4f-9dfe40e5410e.png">
