### PR TITLE
fix(wallet): fetch updated channels and balance after a new transaction

### DIFF
--- a/app/lib/lnd/subscribe/channelgraph.js
+++ b/app/lib/lnd/subscribe/channelgraph.js
@@ -5,6 +5,7 @@ export default function subscribeToChannelGraph() {
   const call = this.lnd.subscribeChannelGraph({})
 
   call.on('data', channelGraphData => {
+    mainLog.info('CHANNELGRAPH:', channelGraphData)
     if (this.mainWindow) {
       this.mainWindow.send('channelGraphData', { channelGraphData })
     }
@@ -12,6 +13,7 @@ export default function subscribeToChannelGraph() {
   call.on('end', () => mainLog.info('end'))
   call.on('error', error => error.code !== status.CANCELLED && mainLog.error(error))
   call.on('status', channelGraphStatus => {
+    mainLog.info('CHANNELGRAPHSTATUS:', channelGraphStatus)
     if (this.mainWindow) {
       this.mainWindow.send('channelGraphStatus', { channelGraphStatus })
     }

--- a/app/reducers/transaction.js
+++ b/app/reducers/transaction.js
@@ -6,6 +6,7 @@ import { fetchBalance } from './balance'
 import { setFormType } from './form'
 import { resetPayForm } from './payform'
 import { setError } from './error'
+import { fetchChannels } from './channels'
 
 // ------------------------------------
 // Constants
@@ -129,12 +130,14 @@ export const newTransaction = (event, { transaction }) => (dispatch, getState) =
     !state.transaction.transactions ||
     !state.transaction.transactions.find(tx => tx.tx_hash === transaction.tx_hash)
   ) {
-    // Fetch new balance
-    dispatch(fetchBalance())
-
     decorateTransaction(transaction)
 
     dispatch({ type: ADD_TRANSACTION, transaction })
+
+    // fetch updated channels
+    dispatch(fetchChannels())
+    // fetch new balance
+    dispatch(fetchBalance())
 
     // HTML 5 desktop notification for the new transaction
     if (transaction.received) {

--- a/app/reducers/transaction.js
+++ b/app/reducers/transaction.js
@@ -70,7 +70,6 @@ export const fetchTransactions = () => dispatch => {
 // Receive IPC event for payments
 export const receiveTransactions = (event, { transactions }) => (dispatch, getState) => {
   dispatch({ type: RECEIVE_TRANSACTIONS, transactions })
-
   // If our current wallet address has been used, generate a new one.
   const state = getState()
   const currentAddress = state.address.address
@@ -82,6 +81,8 @@ export const receiveTransactions = (event, { transactions }) => (dispatch, getSt
   if (usedAddresses.includes(currentAddress)) {
     dispatch(newAddress('np2wkh'))
   }
+  // fetch new balance
+  dispatch(fetchBalance())
 }
 
 export const sendCoins = ({ value, addr, currency }) => dispatch => {
@@ -109,8 +110,7 @@ export const transactionSuccessful = (event, { txid }) => dispatch => {
   // Show successful tx state for 5 seconds
   dispatch(showSuccessTransactionScreen(txid))
   setTimeout(() => dispatch(hideSuccessTransactionScreen()), 5000)
-  // Fetch new balance
-  dispatch(fetchBalance())
+
   // Reset the payment form
   dispatch(resetPayForm())
 }

--- a/test/unit/reducers/__snapshots__/transaction.spec.js.snap
+++ b/test/unit/reducers/__snapshots__/transaction.spec.js.snap
@@ -1,0 +1,123 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`reducers transactionReducer should correctly addTransaction 1`] = `
+Object {
+  "sendingTransaction": false,
+  "successTransactionScreen": Object {
+    "show": false,
+    "txid": "",
+  },
+  "transactionLoading": false,
+  "transactions": Array [
+    undefined,
+  ],
+}
+`;
+
+exports[`reducers transactionReducer should correctly getTransactions 1`] = `
+Object {
+  "sendingTransaction": false,
+  "successTransactionScreen": Object {
+    "show": false,
+    "txid": "",
+  },
+  "transactionLoading": true,
+  "transactions": Array [],
+}
+`;
+
+exports[`reducers transactionReducer should correctly hideSuccessTransactionScreen 1`] = `
+Object {
+  "sendingTransaction": false,
+  "successTransactionScreen": Object {
+    "show": false,
+    "txid": "",
+  },
+  "transactionLoading": false,
+  "transactions": Array [],
+}
+`;
+
+exports[`reducers transactionReducer should correctly receiveTransactions 1`] = `
+Object {
+  "sendingTransaction": false,
+  "successTransactionScreen": Object {
+    "show": false,
+    "txid": "",
+  },
+  "transactionLoading": false,
+  "transactions": undefined,
+}
+`;
+
+exports[`reducers transactionReducer should correctly sendTransaction 1`] = `
+Object {
+  "sendingTransaction": true,
+  "successTransactionScreen": Object {
+    "show": false,
+    "txid": "",
+  },
+  "transactionLoading": false,
+  "transactions": Array [],
+}
+`;
+
+exports[`reducers transactionReducer should correctly sendTransactions 1`] = `
+Object {
+  "sendingTransaction": true,
+  "successTransactionScreen": Object {
+    "show": false,
+    "txid": "",
+  },
+  "transactionLoading": false,
+  "transactions": Array [],
+}
+`;
+
+exports[`reducers transactionReducer should correctly showSuccessTransactionScreen 1`] = `
+Object {
+  "sendingTransaction": false,
+  "successTransactionScreen": Object {
+    "show": true,
+    "txid": undefined,
+  },
+  "transactionLoading": false,
+  "transactions": Array [],
+}
+`;
+
+exports[`reducers transactionReducer should correctly transactionFailed 1`] = `
+Object {
+  "sendingTransaction": false,
+  "successTransactionScreen": Object {
+    "show": false,
+    "txid": "",
+  },
+  "transactionLoading": false,
+  "transactions": Array [],
+}
+`;
+
+exports[`reducers transactionReducer should correctly transactionSuccessful 1`] = `
+Object {
+  "sendingTransaction": false,
+  "successTransactionScreen": Object {
+    "show": false,
+    "txid": "",
+  },
+  "transactionLoading": false,
+  "transactions": Array [],
+}
+`;
+
+exports[`reducers transactionReducer should handle initial state 1`] = `
+Object {
+  "sendingTransaction": false,
+  "successTransactionScreen": Object {
+    "show": false,
+    "txid": "",
+  },
+  "transactionLoading": false,
+  "transactions": Array [],
+}
+`;

--- a/test/unit/reducers/transaction.spec.js
+++ b/test/unit/reducers/transaction.spec.js
@@ -1,0 +1,90 @@
+import transactionReducer, {
+  GET_TRANSACTIONS,
+  RECEIVE_TRANSACTIONS,
+  SEND_TRANSACTION,
+  TRANSACTION_SUCCESSFULL,
+  TRANSACTION_FAILED,
+  ADD_TRANSACTION,
+  SHOW_SUCCESS_TRANSACTION_SCREEN,
+  HIDE_SUCCESS_TRANSACTION_SCREEN
+} from 'reducers/transaction'
+
+describe('reducers', () => {
+  describe('transactionReducer', () => {
+    it('should handle initial state', () => {
+      expect(transactionReducer(undefined, {})).toMatchSnapshot()
+    })
+
+    it('should have GET_TRANSACTIONS', () => {
+      expect(GET_TRANSACTIONS).toEqual('GET_TRANSACTIONS')
+    })
+
+    it('should have RECEIVE_TRANSACTIONS', () => {
+      expect(RECEIVE_TRANSACTIONS).toEqual('RECEIVE_TRANSACTIONS')
+    })
+
+    it('should have GET_TICKER', () => {
+      expect(SEND_TRANSACTION).toEqual('SEND_TRANSACTION')
+    })
+
+    it('should have TRANSACTION_SUCCESSFULL', () => {
+      expect(TRANSACTION_SUCCESSFULL).toEqual('TRANSACTION_SUCCESSFULL')
+    })
+
+    it('should have TRANSACTION_FAILED', () => {
+      expect(TRANSACTION_FAILED).toEqual('TRANSACTION_FAILED')
+    })
+
+    it('should have ADD_TRANSACTION', () => {
+      expect(ADD_TRANSACTION).toEqual('ADD_TRANSACTION')
+    })
+
+    it('should have SHOW_SUCCESS_TRANSACTION_SCREEN', () => {
+      expect(SHOW_SUCCESS_TRANSACTION_SCREEN).toEqual('SHOW_SUCCESS_TRANSACTION_SCREEN')
+    })
+
+    it('should have HIDE_SUCCESS_TRANSACTION_SCREEN', () => {
+      expect(HIDE_SUCCESS_TRANSACTION_SCREEN).toEqual('HIDE_SUCCESS_TRANSACTION_SCREEN')
+    })
+
+    it('should correctly getTransactions', () => {
+      expect(transactionReducer(undefined, { type: GET_TRANSACTIONS })).toMatchSnapshot()
+    })
+
+    it('should correctly sendTransactions', () => {
+      expect(transactionReducer(undefined, { type: SEND_TRANSACTION })).toMatchSnapshot()
+    })
+
+    it('should correctly receiveTransactions', () => {
+      expect(transactionReducer(undefined, { type: RECEIVE_TRANSACTIONS })).toMatchSnapshot()
+    })
+
+    it('should correctly sendTransaction', () => {
+      expect(transactionReducer(undefined, { type: SEND_TRANSACTION })).toMatchSnapshot()
+    })
+
+    it('should correctly transactionSuccessful', () => {
+      expect(transactionReducer(undefined, { type: TRANSACTION_SUCCESSFULL })).toMatchSnapshot()
+    })
+
+    it('should correctly transactionFailed', () => {
+      expect(transactionReducer(undefined, { type: TRANSACTION_FAILED })).toMatchSnapshot()
+    })
+
+    it('should correctly addTransaction', () => {
+      expect(transactionReducer(undefined, { type: ADD_TRANSACTION })).toMatchSnapshot()
+    })
+
+    it('should correctly showSuccessTransactionScreen', () => {
+      expect(
+        transactionReducer(undefined, { type: SHOW_SUCCESS_TRANSACTION_SCREEN })
+      ).toMatchSnapshot()
+    })
+
+    it('should correctly hideSuccessTransactionScreen', () => {
+      expect(
+        transactionReducer(undefined, { type: HIDE_SUCCESS_TRANSACTION_SCREEN })
+      ).toMatchSnapshot()
+    })
+  })
+})


### PR DESCRIPTION
Make a call to fetch the updated balance and channels list whenever a new transaction is detected.

Fix #579