### PR TITLE
feat(toggle-expired-requests): add button to show/hide expired requests

### DIFF
--- a/app/routes/activity/components/Activity.js
+++ b/app/routes/activity/components/Activity.js
@@ -74,9 +74,11 @@ class Activity extends Component {
   render() {
     const {
       balance,
-      activity: { filters, filter, filterPulldown, searchActive, searchText },
+      activity: { filters, filter, filterPulldown, searchActive, searchText, showExpiredRequests },
       changeFilter,
       currentActivity,
+      showExpiredToggle,
+      toggleExpiredRequests,
 
       fetchPayments,
       fetchInvoices,
@@ -199,6 +201,13 @@ class Activity extends Component {
                 </ul>
               </li>
             ))}
+            {showExpiredToggle && (
+              <li>
+                <div className={styles.toggleExpired} onClick={toggleExpiredRequests}>
+                  {showExpiredRequests ? 'Hide Expired Requests' : 'Show Expired Requests'}
+                </div>
+              </li>
+            )}
           </ul>
         </div>
       </div>
@@ -220,9 +229,11 @@ Activity.propTypes = {
   changeFilter: PropTypes.func.isRequired,
   updateSearchActive: PropTypes.func.isRequired,
   updateSearchText: PropTypes.func.isRequired,
+  toggleExpiredRequests: PropTypes.func.isRequired,
 
   activity: PropTypes.object.isRequired,
   currentActivity: PropTypes.array.isRequired,
+  showExpiredToggle: PropTypes.bool.isRequired,
   balance: PropTypes.object.isRequired,
   walletProps: PropTypes.object.isRequired,
 

--- a/app/routes/activity/components/Activity.scss
+++ b/app/routes/activity/components/Activity.scss
@@ -140,6 +140,25 @@
   }
 }
 
+.toggleExpired {
+  margin: 0 auto;
+  font-size: 16px;
+  font-weight: bold;
+  color: $white;
+  background: #31343f;
+  padding: 10px;
+  width: 200px;
+  text-align: center;
+  border-radius: 5px;
+  cursor: pointer;
+  opacity: 0.5;
+  transition: all 0.25s;
+
+  &:hover {
+    opacity: 1;
+  }
+}
+
 .activity {
   position: relative;
   padding: 0 60px;

--- a/app/routes/activity/containers/ActivityContainer.js
+++ b/app/routes/activity/containers/ActivityContainer.js
@@ -9,6 +9,7 @@ import {
   hideActivityModal,
   changeFilter,
   toggleFilterPulldown,
+  toggleExpiredRequests,
   activitySelectors,
   updateSearchActive,
   updateSearchText
@@ -36,6 +37,7 @@ const mapDispatchToProps = {
   hideActivityModal,
   changeFilter,
   toggleFilterPulldown,
+  toggleExpiredRequests,
   walletAddress,
   openWalletModal,
   fetchBalance,
@@ -77,6 +79,7 @@ const mapStateToProps = state => ({
 
   currentActivity: activitySelectors.currentActivity(state)(state),
   nonActiveFilters: activitySelectors.nonActiveFilters(state),
+  showExpiredToggle: activitySelectors.showExpiredToggle(state),
 
   showPayLoadingScreen: payFormSelectors.showPayLoadingScreen(state)
 })


### PR DESCRIPTION
Adds a toggle button to show/hide expired payment requests (invoices). The button is only displayed on the 'All' and 'Requested' tabs. 

TODO: The UI needs to be improved as discussed in slack with @JimmyMow 
A few options I've thought of:
- display an icon in the activity header next to Refresh and change the word 'Refresh' to an icon as well.
- display a footer positioned absolute to the bottom of the activity list, similar to the My Network search field. Inside of the footer on the left or right, display a toggle switch and 'Show Expired Requests' label

Suggestions and nitpicks are welcome on this first PR.

Fixes #521 