### PR TITLE
feat(autopilot): enable private and minconfs=0

### DIFF
--- a/resources/lnd.conf
+++ b/resources/lnd.conf
@@ -317,6 +317,11 @@ litecoin.node=ltcd
 ; amount of attempted channels will still respect the maxchannels param.
 ; autopilot.allocation=0.6
 
+; If the user toggled autopilot on let's make sure channels are private and allow
+; it to use 0 conf txs
+autopilot.private=1
+autopilot.minconfs=0
+
 [tor]
 ; The port that Tor's exposed SOCKS5 proxy is listening on. Using Tor allows
 ; outbound-only connections (listening will be disabled) -- NOTE port must be


### PR DESCRIPTION
This PR adds private channels and minconfs=0 to our autopilot configuration.

We don't want our light client users advertising channels because they are not likely to be reliable nodes with high uptime. Fixes #681.

**NOTE: This PR can only be merged _after_ we update to LND master. These new flags aren't supported with the LND that is currently packaged and LND will shut down on start because of it at the moment. (Customized my binary path to test this works)**