### PR TITLE
fix(channels): neutrino clients manual channels flagged private

### DIFF
--- a/app/lib/lnd/methods/channelController.js
+++ b/app/lib/lnd/methods/channelController.js
@@ -19,13 +19,14 @@ function ensurePeerConnected(lnd, pubkey, host) {
  * @return {[type]}         [description]
  */
 export function connectAndOpen(lnd, event, payload) {
-  const { pubkey, host, localamt } = payload
+  const { pubkey, host, localamt, private: privateChannel } = payload
 
   return ensurePeerConnected(lnd, pubkey, host)
     .then(() => {
       const call = lnd.openChannel({
         node_pubkey: Buffer.from(pubkey, 'hex'),
-        local_funding_amount: Number(localamt)
+        local_funding_amount: Number(localamt),
+        private: privateChannel
       })
 
       call.on('data', data => event.sender.send('pushchannelupdated', { pubkey, data }))

--- a/test/unit/reducers/channels.spec.js
+++ b/test/unit/reducers/channels.spec.js
@@ -1,3 +1,5 @@
+// @flow
+
 import channelsReducer, {
   SET_CHANNEL_FORM,
   SET_CHANNEL,


### PR DESCRIPTION
This PR we make sure that if a user of ours is using neutrino that we flag their channels as private when they manually open them. Reason for this is because light consumer clients are not expected to have high uptime. 

However we cannot hardcode channels as private every time because we do support more power users driving their remote nodes or BTCPay Server with Zap. So we only flag channels as private if the `activeConnection` is `local`.

Addresses #681 