### PR TITLE
build(flow): include node_modules in flow config

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,4 @@
 [ignore]
-<PROJECT_ROOT>/node_modules/*
-<PROJECT_ROOT>/app/node_modules/*
 <PROJECT_ROOT>/app/main.prod.js
 <PROJECT_ROOT>/app/main.prod.js.map
 <PROJECT_ROOT>/app/dist/.*
@@ -8,7 +6,7 @@
 <PROJECT_ROOT>/release/.*
 <PROJECT_ROOT>/dll/.*
 <PROJECT_ROOT>/release/.*
-<PROJECT_ROOT>/git/.*
+<PROJECT_ROOT>/.git/.*
 
 [include]
 
@@ -19,6 +17,9 @@ flow-typed
 esproposal.class_static_fields=enable
 esproposal.class_instance_fields=enable
 esproposal.export_star_as=enable
+
+module.system.node.resolve_dirname=node_modules
+module.system.node.resolve_dirname=app/node_modules
 
 # Map stylesheets to csssmodule tyoe def
 module.name_mapper.extension='css' -> '<PROJECT_ROOT>/internals/flow/CSSModule.js.flow'


### PR DESCRIPTION
## Problem / Motivation

We're missing flow type definitions for grpc. This is due to the fact that it is installed in `app/node_modules` and not `node_modules`


```
$ yarn flow
yarn run v1.9.2
$ flow
Launching Flow server for /Users/tom/workspace/zap-desktop
Spawned flow server (pid=76836)
Logs will go to /private/tmp/flow/zSUserszStomzSworkspacezSzZap-desktop.log
Monitor logs will go to /private/tmp/flow/zSUserszStomzSworkspacezSzZap-desktop.monitor_log
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ app/lib/lnd/lightning.js:3:18

Cannot resolve module grpc.

     1│ // @flow
     2│
     3│ import grpc from 'grpc'
     4│ import { loadSync } from '@grpc/proto-loader'
     5│ import { BrowserWindow } from 'electron'
     6│ import LndConfig from './config'
```

## Proposed Solution

Currently, in our `.flowconfig` file we specifically exclude `node_modules` and `app/node_modules`. I believe that this is left over from `electron-react-boilerplate` and it isn't needed.

See https://github.com/facebook/flow/issues/869 for some context about why `node_modules` shouldn't really be excluded.

This PR adds `node_modules` and `app/node_modules` back into the flow type processing, which as well as fixing the above issue, also makes flow generally more useful as it will provide type hints for many more packages.