### PR TITLE
feat(errors): create a util for making error messages more user-friendly

### DIFF
--- a/app/components/GlobalError/GlobalError.js
+++ b/app/components/GlobalError/GlobalError.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import MdClose from 'react-icons/lib/md/close'
+import errorToUserFriendly from 'lib/utils/userFriendlyErrors'
 import styles from './GlobalError.scss'
 
 class GlobalError extends React.Component {
@@ -20,7 +21,7 @@ class GlobalError extends React.Component {
           <div className={styles.close} onClick={clearError}>
             <MdClose />
           </div>
-          <h2>{error}</h2>
+          <h2>{errorToUserFriendly(error)}</h2>
         </div>
       </div>
     )

--- a/app/components/GlobalError/GlobalError.scss
+++ b/app/components/GlobalError/GlobalError.scss
@@ -35,7 +35,8 @@
       max-width: 75%;
       margin-left: auto;
       margin-right: auto;
-      font-size: 20px;
+      font-size: 15px;
+      line-height: 20px;
       letter-spacing: 1.5px;
       font-weight: bold;
     }

--- a/app/lib/utils/userFriendlyErrors.js
+++ b/app/lib/utils/userFriendlyErrors.js
@@ -1,0 +1,9 @@
+const userFriendlyErrors = {
+  'Error: 11 OUT_OF_RANGE: EOF':
+    "The person you're trying to connect to isn't available or rejected the connection.\
+ Their public key may have changed or the server may no longer be responding."
+}
+
+const errorToUserFriendly = error => userFriendlyErrors[error] || error
+
+export default errorToUserFriendly

--- a/test/unit/utils/userFriendlyErrors.spec.js
+++ b/test/unit/utils/userFriendlyErrors.spec.js
@@ -1,0 +1,17 @@
+import errorToUserFriendly from 'lib/utils/userFriendlyErrors'
+
+describe('userFriendlyErrors', () => {
+  describe('errorToUserFriendly', () => {
+    it('should handle defined user-friendly errors', () => {
+      expect(errorToUserFriendly('Error: 11 OUT_OF_RANGE: EOF')).toBe(
+        "The person you're trying to connect to isn't available or rejected the connection.\
+ Their public key may have changed or the server may no longer be responding."
+      )
+    })
+
+    it('should return the original error when there is no user-friendly error conversion', () => {
+      expect(errorToUserFriendly('Error 12')).toBe('Error 12')
+      expect(errorToUserFriendly('???')).toBe('???')
+    })
+  })
+})


### PR DESCRIPTION
<img width="978" alt="screen shot 2018-08-24 at 11 45 45 pm" src="https://user-images.githubusercontent.com/1878621/44614755-1de3da80-a7f8-11e8-93b2-ac34aa0aeafb.png">

I know the lnd team is working on improving their error messages but I think zap would really benefit by having its own set of user-friendly error messages. You may understand what `Error: 11 OUT_OF_RANGE: EOF` means if you've been hands on with `lnd`, but the average user is left confused by seeing that after the failure of a channel connection - I sure was.