### PR TITLE
fix(network): ensure accurate btc balance

### DIFF
--- a/app/components/Contacts/Network.js
+++ b/app/components/Contacts/Network.js
@@ -158,9 +158,12 @@ class Network extends Component {
           <section>
             <h2>My Network</h2>
             <span className={styles.channelAmount}>
-              {btc.satoshisToBtc(balance.channelBalance)} {currencyName} ≈ ${usdAmount
-                ? usdAmount.toLocaleString()
-                : ''}
+              <Value
+                value={balance.channelBalance}
+                currency={ticker.currency}
+                currentTicker={currentTicker}
+              />
+              {` ≈ $${usdAmount ? usdAmount.toLocaleString() : ''}`}
             </span>
           </section>
           <section


### PR DESCRIPTION
We had `satoshisToBtc` hardcoded for our network (channel) balance. This updates it to use the `Value` component to ensure it displays correct balance depending on if the user is viewing in `sats`, `bits` or `btc` 