### PR TITLE
feat(lnd): update lnd to v0.4.2-beta-913-g26f68da5

### DIFF
--- a/app/lib/lnd/config.js
+++ b/app/lib/lnd/config.js
@@ -113,7 +113,7 @@ class LndConfig {
   // Read only data properties.
   +key: string
   +binaryPath: string
-  +dataDir: string
+  +lndDir: string
   +configPath: string
   +rpcProtoPath: string
 
@@ -145,7 +145,7 @@ class LndConfig {
           return binaryPath()
         }
       },
-      dataDir: {
+      lndDir: {
         enumerable: true,
         get() {
           return join(app.getPath('userData'), 'lnd', this.currency, this.network, this.wallet)
@@ -252,8 +252,8 @@ class LndConfig {
     if (this.type === 'local') {
       const defaultLocalOptions = {
         host: 'localhost:10009',
-        cert: join(this.dataDir, 'tls.cert'),
-        macaroon: join(this.dataDir, 'admin.macaroon')
+        cert: join(this.lndDir, 'tls.cert'),
+        macaroon: join(this.lndDir, 'data', 'chain', this.currency, this.network, 'admin.macaroon')
       }
       debug('Connection type is local. Assigning settings as: %o', defaultLocalOptions)
       Object.assign(this, defaultLocalOptions)

--- a/app/lib/lnd/neutrino.js
+++ b/app/lib/lnd/neutrino.js
@@ -77,7 +77,7 @@ class Neutrino extends EventEmitter {
 
     const neutrinoArgs = [
       `--configfile=${this.lndConfig.configPath}`,
-      `--lnddir=${this.lndConfig.dataDir}`,
+      `--lnddir=${this.lndConfig.lndDir}`,
       `${this.lndConfig.autopilot ? '--autopilot.active' : ''}`,
       `${this.lndConfig.alias ? `--alias=${this.lndConfig.alias}` : ''}`
     ]

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "config": {
     "style_paths": "app/styles/*.scss app/components/**/*.scss",
     "lnd-binary": {
-      "binaryVersion": "0.4.2-beta-752-g6c903393",
+      "binaryVersion": "0.4.2-beta-913-g26f68da5",
       "binarySite": "https://github.com/LN-Zap/lnd/releases/download"
     }
   },

--- a/resources/rpc.proto
+++ b/resources/rpc.proto
@@ -1,4 +1,4 @@
-// Imported from https://github.com/lightningnetwork/lnd/blob/72aa79692cf4960ad27526358e333ba81e8ad99b/lnrpc/rpc.proto
+// Imported from https://github.com/lightningnetwork/lnd/blob/26f68da5b2883885fcf6a8e79b3fc9bb12cc9eef/lnrpc/rpc.proto
 syntax = "proto3";
 
 // import "google/api/annotations.proto";
@@ -1708,12 +1708,33 @@ message PaymentHash {
     /// The payment hash of the invoice to be looked up.
     bytes r_hash = 2 [json_name = "r_hash"];
 }
+
 message ListInvoiceRequest {
-    /// Toggles if all invoices should be returned, or only those that are currently unsettled.
-    bool pending_only = 1;
+    /// If set, only unsettled invoices will be returned in the response.
+    bool pending_only = 1 [json_name = "pending_only"];
+
+    /**
+    The offset in the time series to start at. As each response can only contain
+    50k invoices, callers can use this to skip around within a packed time
+    series.
+    */
+    uint32 index_offset = 4 [json_name = "index_offset"];
+
+    /// The max number of invoices to return in the response to this query.
+    uint32 num_max_invoices = 5 [json_name = "num_max_invoices"];
 }
 message ListInvoiceResponse {
+    /**
+    A list of invoices from the time slice of the time series specified in the
+    request.
+    */
     repeated Invoice invoices = 1 [json_name = "invoices"];
+
+    /**
+    The index of the last time in the set of returned invoices. Can be used to
+    seek further, pagination style.
+    */
+    uint32 last_index_offset = 2 [json_name = "last_index_offset"];
 }
 
 message InvoiceSubscription {

--- a/test/unit/lnd/lnd-config.spec.js
+++ b/test/unit/lnd/lnd-config.spec.js
@@ -39,10 +39,10 @@ describe('LndConfig', function() {
     it(`should have the "wallet" property set to the ${type}`, () => {
       expect(this.lndConfig.wallet).toEqual(this.wallet)
     })
-    it(`should have the "dataDir" set to a path derived from the config, under the app userData dir`, () => {
+    it(`should have the "lndDir" set to a path derived from the config, under the app userData dir`, () => {
       const baseDir = '/tmp/zap-test/userData/lnd/'
       const expectedDataDir = join(baseDir, this.currency, this.network, this.wallet)
-      expect(this.lndConfig.dataDir).toEqual(expectedDataDir)
+      expect(this.lndConfig.lndDir).toEqual(expectedDataDir)
     })
   }
 
@@ -78,8 +78,15 @@ describe('LndConfig', function() {
         this.lndConfig = new LndConfig()
 
         this.host = 'localhost:10009'
-        this.cert = join(this.lndConfig.dataDir, 'tls.cert')
-        this.macaroon = join(this.lndConfig.dataDir, 'admin.macaroon')
+        this.cert = join(this.lndConfig.lndDir, 'tls.cert')
+        this.macaroon = join(
+          this.lndConfig.lndDir,
+          'data',
+          'chain',
+          this.currency,
+          this.network,
+          'admin.macaroon'
+        )
       })
 
       describe('static properties', () => {
@@ -121,8 +128,15 @@ describe('LndConfig', function() {
         })
 
         this.host = 'localhost:10009'
-        this.cert = join(this.lndConfig.dataDir, 'tls.cert')
-        this.macaroon = join(this.lndConfig.dataDir, 'admin.macaroon')
+        this.cert = join(this.lndConfig.lndDir, 'tls.cert')
+        this.macaroon = join(
+          this.lndConfig.lndDir,
+          'data',
+          'chain',
+          this.currency,
+          this.network,
+          'admin.macaroon'
+        )
       })
 
       describe('static properties', () => {


### PR DESCRIPTION
This updates LND to the latest commit from master. This was incompatible with the version of BTCD that we were running so I have also updated `testnet1-btcd.zaphq.io` and `testnet2-btcd.zaphq.io` to the latest version of BTCD (which got several updates in the last week). I verified first that this new version of BTCD was still compatible with the old version of lnd that we were previously running so as not to impact users of 0.2.1.