### PR TITLE
fix(lnd): do not resolve after rejecting

### DIFF
--- a/app/lib/lnd/methods/channelController.js
+++ b/app/lib/lnd/methods/channelController.js
@@ -51,17 +51,13 @@ export function connectAndOpen(lnd, event, payload) {
  */
 export function openChannel(lnd, event, payload) {
   const { pubkey, localamt, pushamt } = payload
-  const res = {
+  const req = {
     node_pubkey: Buffer.from(pubkey, 'hex'),
     local_funding_amount: Number(localamt),
     push_sat: Number(pushamt)
   }
 
-  return new Promise((resolve, reject) =>
-    pushopenchannel(lnd, event, res)
-      .then(data => resolve(data))
-      .catch(error => reject(error))
-  )
+  return pushopenchannel(lnd, event, req)
 }
 
 /**
@@ -73,7 +69,7 @@ export function channelBalance(lnd) {
   return new Promise((resolve, reject) => {
     lnd.channelBalance({}, (err, data) => {
       if (err) {
-        reject(err)
+        return reject(err)
       }
 
       resolve(data)
@@ -90,7 +86,7 @@ export function listChannels(lnd) {
   return new Promise((resolve, reject) => {
     lnd.listChannels({}, (err, data) => {
       if (err) {
-        reject(err)
+        return reject(err)
       }
 
       resolve(data)
@@ -135,9 +131,9 @@ export function closeChannel(lnd, event, payload) {
       )
       call.on('status', status => event.sender.send('pushclosechannelstatus', { status, chan_id }))
 
-      resolve(null, res)
+      resolve(call)
     } catch (error) {
-      reject(error, null)
+      reject(error)
     }
   })
 }
@@ -151,7 +147,7 @@ export function pendingChannels(lnd) {
   return new Promise((resolve, reject) => {
     lnd.pendingChannels({}, (err, data) => {
       if (err) {
-        reject(err)
+        return reject(err)
       }
 
       resolve(data)
@@ -169,7 +165,7 @@ export function getChanInfo(lnd, { chanId }) {
   return new Promise((resolve, reject) => {
     lnd.getChanInfo({ chan_id: chanId }, (err, data) => {
       if (err) {
-        reject(err)
+        return reject(err)
       }
 
       resolve(data)

--- a/app/lib/lnd/methods/index.js
+++ b/app/lib/lnd/methods/index.js
@@ -183,7 +183,7 @@ export default function(lnd, log, event, msg, data) {
           event.sender.send('paymentSuccessful', Object.assign(data, { payment_route }))
           return payment
         })
-        .catch(({ error }) => {
+        .catch(error => {
           log.error('error: ', error)
           event.sender.send('paymentFailed', { error: error.toString() })
         })

--- a/app/lib/lnd/methods/invoicesController.js
+++ b/app/lib/lnd/methods/invoicesController.js
@@ -11,7 +11,7 @@ export function addInvoice(lnd, { memo, value }) {
   return new Promise((resolve, reject) => {
     lnd.addInvoice({ memo, value }, (err, data) => {
       if (err) {
-        reject(err)
+        return reject(err)
       }
 
       resolve(data)
@@ -28,7 +28,7 @@ export function listInvoices(lnd) {
   return new Promise((resolve, reject) => {
     lnd.listInvoices({}, (err, data) => {
       if (err) {
-        reject(err)
+        return reject(err)
       }
 
       resolve(data)
@@ -44,7 +44,7 @@ export function getInvoice(lnd, { pay_req }) {
   return new Promise((resolve, reject) => {
     lnd.decodePayReq({ pay_req }, (err, data) => {
       if (err) {
-        reject(err)
+        return reject(err)
       }
 
       resolve(data)
@@ -62,7 +62,7 @@ export function lookupInvoice(lnd, { rhash }) {
   return new Promise((resolve, reject) => {
     lnd.lookupInvoice({ r_hash: rhash }, (err, data) => {
       if (err) {
-        reject(err)
+        return reject(err)
       }
 
       resolve(data)
@@ -77,9 +77,5 @@ export function lookupInvoice(lnd, { rhash }) {
  * @return {[type]}       [description]
  */
 export function subscribeInvoices(lnd, event) {
-  return new Promise((resolve, reject) => {
-    pushinvoices(lnd, event)
-      .then(data => resolve(data))
-      .catch(error => reject(error))
-  })
+  return pushinvoices(lnd, event)
 }

--- a/app/lib/lnd/methods/networkController.js
+++ b/app/lib/lnd/methods/networkController.js
@@ -7,7 +7,7 @@ export function getInfo(lnd) {
   return new Promise((resolve, reject) => {
     lnd.getInfo({}, (err, data) => {
       if (err) {
-        reject(err)
+        return reject(err)
       }
 
       resolve(data)
@@ -25,7 +25,7 @@ export function getNodeInfo(lnd, { pubkey }) {
   return new Promise((resolve, reject) => {
     lnd.getNodeInfo({ pub_key: pubkey }, (err, data) => {
       if (err) {
-        reject(err)
+        return reject(err)
       }
 
       resolve(data)
@@ -42,7 +42,7 @@ export function describeGraph(lnd) {
   return new Promise((resolve, reject) => {
     lnd.describeGraph({}, (err, data) => {
       if (err) {
-        reject(err)
+        return reject(err)
       }
 
       resolve(data)
@@ -62,7 +62,7 @@ export function queryRoutes(lnd, { pubkey, amount }) {
   return new Promise((resolve, reject) => {
     lnd.queryRoutes({ pub_key: pubkey, amt: amount }, (err, data) => {
       if (err) {
-        reject(err)
+        return reject(err)
       }
 
       resolve(data)
@@ -79,7 +79,7 @@ export function getNetworkInfo(lnd) {
   return new Promise((resolve, reject) => {
     lnd.getNetworkInfo({}, (err, data) => {
       if (err) {
-        reject(err)
+        return reject(err)
       }
 
       resolve(data)

--- a/app/lib/lnd/methods/paymentsController.js
+++ b/app/lib/lnd/methods/paymentsController.js
@@ -8,12 +8,11 @@ export function sendPaymentSync(lnd, { paymentRequest }) {
   return new Promise((resolve, reject) => {
     lnd.sendPaymentSync({ payment_request: paymentRequest }, (error, data) => {
       if (error) {
-        reject({ error })
+        return reject(error)
       } else if (!data || !data.payment_route) {
-        reject({ error: data.payment_error })
-      } else {
-        resolve(data)
+        return reject(data.payment_error)
       }
+      resolve(data)
     })
   })
 }
@@ -28,7 +27,7 @@ export function sendPayment(lnd, { paymentRequest }) {
   return new Promise((resolve, reject) => {
     lnd.sendPayment({ payment_request: paymentRequest }, (err, data) => {
       if (err) {
-        reject(err)
+        return reject(err)
       }
 
       resolve(data)
@@ -46,7 +45,7 @@ export function decodePayReq(lnd, { payReq }) {
   return new Promise((resolve, reject) => {
     lnd.decodePayReq({ pay_req: payReq }, (err, data) => {
       if (err) {
-        reject(err)
+        return reject(err)
       }
 
       resolve(data)
@@ -63,7 +62,7 @@ export function listPayments(lnd) {
   return new Promise((resolve, reject) => {
     lnd.listPayments({}, (err, data) => {
       if (err) {
-        reject(err)
+        return reject(err)
       }
 
       resolve(data)
@@ -80,7 +79,7 @@ export function deleteAllPayments(lnd) {
   return new Promise((resolve, reject) => {
     lnd.deleteAllPayments({}, (err, data) => {
       if (err) {
-        reject(err)
+        return reject(err)
       }
 
       resolve(data)

--- a/app/lib/lnd/methods/peersController.js
+++ b/app/lib/lnd/methods/peersController.js
@@ -9,7 +9,7 @@ export function connectPeer(lnd, { pubkey, host }) {
   return new Promise((resolve, reject) => {
     lnd.connectPeer({ addr: { pubkey, host } }, (err, data) => {
       if (err) {
-        reject(err)
+        return reject(err)
       }
 
       resolve(data)
@@ -27,7 +27,7 @@ export function disconnectPeer(lnd, { pubkey }) {
   return new Promise((resolve, reject) => {
     lnd.disconnectPeer({ pub_key: pubkey }, (err, data) => {
       if (err) {
-        reject(err)
+        return reject(err)
       }
 
       resolve(data)
@@ -44,7 +44,7 @@ export function listPeers(lnd) {
   return new Promise((resolve, reject) => {
     lnd.listPeers({}, (err, data) => {
       if (err) {
-        reject(err)
+        return reject(err)
       }
 
       resolve(data)

--- a/app/lib/lnd/methods/walletController.js
+++ b/app/lib/lnd/methods/walletController.js
@@ -7,7 +7,7 @@ export function walletBalance(lnd) {
   return new Promise((resolve, reject) => {
     lnd.walletBalance({}, (err, data) => {
       if (err) {
-        reject(err)
+        return reject(err)
       }
 
       resolve(data)
@@ -25,7 +25,7 @@ export function newAddress(lnd, type) {
   return new Promise((resolve, reject) => {
     lnd.newAddress({ type }, (err, data) => {
       if (err) {
-        reject(err)
+        return reject(err)
       }
 
       resolve(data)
@@ -42,7 +42,7 @@ export function newWitnessAddress(lnd, { addr }) {
   return new Promise((resolve, reject) => {
     lnd.newWitnessAddress({ address: addr }, (err, data) => {
       if (err) {
-        reject(err)
+        return reject(err)
       }
 
       resolve(data)
@@ -59,7 +59,7 @@ export function getTransactions(lnd) {
   return new Promise((resolve, reject) => {
     lnd.getTransactions({}, (err, data) => {
       if (err) {
-        reject(err)
+        return reject(err)
       }
 
       resolve(data)
@@ -78,7 +78,7 @@ export function sendCoins(lnd, { addr, amount }) {
   return new Promise((resolve, reject) => {
     lnd.sendCoins({ addr, amount }, (err, data) => {
       if (err) {
-        reject(err)
+        return reject(err)
       }
 
       resolve(data)
@@ -94,7 +94,7 @@ export function setAlias(lnd, { new_alias }) {
   return new Promise((resolve, reject) => {
     lnd.setAlias({ new_alias }, (err, data) => {
       if (err) {
-        reject(err)
+        return reject(err)
       }
 
       resolve(data)
@@ -109,7 +109,7 @@ export function genSeed(walletUnlocker) {
   return new Promise((resolve, reject) => {
     walletUnlocker.genSeed({}, (err, data) => {
       if (err) {
-        reject(err)
+        return reject(err)
       }
 
       resolve(data)
@@ -125,7 +125,7 @@ export function unlockWallet(walletUnlocker, { wallet_password }) {
   return new Promise((resolve, reject) => {
     walletUnlocker.unlockWallet({ wallet_password: Buffer.from(wallet_password) }, (err, data) => {
       if (err) {
-        reject(err)
+        return reject(err)
       }
 
       resolve(data)
@@ -152,7 +152,7 @@ export function initWallet(
       },
       (err, data) => {
         if (err) {
-          reject(err)
+          return reject(err)
         }
 
         resolve(data)

--- a/app/lib/lnd/push/closechannel.js
+++ b/app/lib/lnd/push/closechannel.js
@@ -8,9 +8,9 @@ export default function pushclosechannel(lnd, event, payload) {
       call.on('error', error => event.sender.send('pushclosechannelerror', { error }))
       call.on('status', status => event.sender.send('pushclosechannelstatus', { status }))
 
-      resolve(null, payload)
+      resolve(call)
     } catch (error) {
-      reject(error, null)
+      reject(error)
     }
   })
 }

--- a/app/lib/lnd/push/openchannel.js
+++ b/app/lib/lnd/push/openchannel.js
@@ -8,9 +8,9 @@ export default function pushopenchannel(lnd, event, payload) {
       call.on('error', error => event.sender.send('pushchannelerror', { error: error.toString() }))
       call.on('status', status => event.sender.send('pushchannelstatus', { status }))
 
-      resolve(null, payload)
+      resolve(call)
     } catch (error) {
-      reject(error, null)
+      reject(error)
     }
   })
 }

--- a/app/lib/lnd/push/subscribeinvoice.js
+++ b/app/lib/lnd/push/subscribeinvoice.js
@@ -8,9 +8,9 @@ export default function pushinvoices(lnd, event) {
       call.on('error', error => event.sender.send('pushinvoiceserror', { error }))
       call.on('status', status => event.sender.send('pushinvoicesstatus', { status }))
 
-      resolve(null)
+      resolve(call)
     } catch (error) {
-      reject(error, null)
+      reject(error)
     }
   })
 }


### PR DESCRIPTION
Update a number of places in the lnd service wrapper where a call error was being resolved after it was already rejected.