### PR TITLE
fix(lnd): ensure graceful shutdown

### DIFF
--- a/app/lib/lnd/neutrino.js
+++ b/app/lib/lnd/neutrino.js
@@ -141,7 +141,10 @@ class Neutrino extends EventEmitter {
 
       if (this.is(CHAIN_SYNC_PENDING) || this.is(CHAIN_SYNC_IN_PROGRESS)) {
         // If we cant get a connectionn to the backend.
-        if (line.includes('Waiting for chain backend to finish sync')) {
+        if (
+          line.includes('Waiting for chain backend to finish sync') ||
+          line.includes('Waiting for block headers to sync, then will start cfheaders sync')
+        ) {
           this.setState(CHAIN_SYNC_WAITING)
         }
         // If we are still waiting for the back end to finish synncing.
@@ -223,8 +226,9 @@ class Neutrino extends EventEmitter {
   /**
    * Stop the Lnd process.
    */
-  stop() {
+  kill() {
     if (this.process) {
+      mainLog.info('Killing Neutrino process...')
       this.process.kill()
       this.process = null
     }

--- a/package.json
+++ b/package.json
@@ -258,6 +258,7 @@
     "lint-staged": "^7.2.0",
     "lnd-binary": "^0.3.5",
     "minimist": "^1.2.0",
+    "mock-spawn": "^0.2.6",
     "node-sass": "^4.9.0",
     "prettier": "^1.13.5",
     "react-addons-test-utils": "^15.6.2",

--- a/test/unit/lnd/neutrino.spec.js
+++ b/test/unit/lnd/neutrino.spec.js
@@ -177,14 +177,14 @@ describe('Neutrino', function() {
     })
   })
 
-  describe('.stop', () => {
+  describe('.kill', () => {
     describe('called when neutrino is already running', () => {
       beforeEach(() => {
         this.neutrino = new Neutrino()
         this.neutrino.process = {
           kill: jest.fn()
         }
-        this.neutrino.stop()
+        this.neutrino.kill()
       })
       it('should kill the neutrino process', () => {
         expect(this.neutrino.process).toBeNull()

--- a/test/unit/lnd/neutrino.spec.js
+++ b/test/unit/lnd/neutrino.spec.js
@@ -1,10 +1,22 @@
+// @flow
+
 import Neutrino from 'lib/lnd/neutrino'
+import LndConfig from 'lib/lnd/config'
+import mockSpawn from 'mock-spawn'
 
 jest.mock('electron-store')
+jest.mock('child_process', () => {
+  var mockSpawn = require('mock-spawn')
+  return {
+    spawn: mockSpawn()
+  }
+})
 
 describe('Neutrino', function() {
   describe('Constructor', () => {
-    beforeAll(() => (this.neutrino = new Neutrino()))
+    beforeAll(() => {
+      this.neutrino = new Neutrino(new LndConfig())
+    })
 
     describe('initial values', () => {
       it('should set the "process" property to null', () => {
@@ -37,7 +49,7 @@ describe('Neutrino', function() {
   describe('.setState', () => {
     describe('called with new state', () => {
       beforeEach(() => {
-        this.neutrino = new Neutrino()
+        this.neutrino = new Neutrino(new LndConfig())
         this.callback = jest.fn()
         this.newVal = 'chain-sync-finished'
         this.neutrino.on('chain-sync-finished', this.callback)
@@ -53,7 +65,7 @@ describe('Neutrino', function() {
     })
     describe('called with current state', () => {
       beforeEach(() => {
-        this.neutrino = new Neutrino()
+        this.neutrino = new Neutrino(new LndConfig())
         this.callback = jest.fn()
         this.newVal = 'chain-sync-pending'
         this.neutrino.on('chain-sync-pending', this.callback)
@@ -72,7 +84,7 @@ describe('Neutrino', function() {
   describe('.setCurrentBlockHeight', () => {
     describe('called with higher height', () => {
       beforeEach(() => {
-        this.neutrino = new Neutrino()
+        this.neutrino = new Neutrino(new LndConfig())
         this.callback = jest.fn()
         this.newVal = 100
         this.neutrino.on('got-current-block-height', this.callback)
@@ -89,7 +101,7 @@ describe('Neutrino', function() {
     })
     describe('called with lower height', () => {
       beforeEach(() => {
-        this.neutrino = new Neutrino()
+        this.neutrino = new Neutrino(new LndConfig())
         this.callback = jest.fn()
         this.newVal = -1
         this.neutrino.on('got-current-block-height', this.callback)
@@ -108,7 +120,7 @@ describe('Neutrino', function() {
   describe('.setLndBlockHeight', () => {
     describe('called with higher height', () => {
       beforeEach(() => {
-        this.neutrino = new Neutrino()
+        this.neutrino = new Neutrino(new LndConfig())
         this.callback = jest.fn()
         this.newVal = 100
         this.neutrino.on('got-lnd-block-height', this.callback)
@@ -130,7 +142,7 @@ describe('Neutrino', function() {
     })
     describe('called with lower height', () => {
       beforeEach(() => {
-        this.neutrino = new Neutrino()
+        this.neutrino = new Neutrino(new LndConfig())
         this.callback = jest.fn()
         this.newVal = -1
         this.neutrino.on('got-lnd-block-height', this.callback)
@@ -152,7 +164,9 @@ describe('Neutrino', function() {
 
   describe('.is', () => {
     describe('called with current state', () => {
-      beforeEach(() => (this.neutrino = new Neutrino()))
+      beforeEach(() => {
+        this.neutrino = new Neutrino(new LndConfig())
+      })
 
       it('should returnn true if the current state matches', () => {
         expect(this.neutrino.is('chain-sync-pending')).toEqual(true)
@@ -164,10 +178,20 @@ describe('Neutrino', function() {
   })
 
   describe('.start', () => {
+    describe('called when neutrino is not running', () => {
+      beforeEach(() => {
+        this.neutrino = new Neutrino(new LndConfig())
+        this.neutrino.start()
+      })
+      it('should set the subprocess object on the `process` property', () => {
+        expect(this.neutrino.process.pid).toBeDefined()
+      })
+    })
+
     describe('called when neutrino is already running', () => {
       beforeEach(() => {
-        this.neutrino = new Neutrino()
-        this.neutrino.process = 123
+        this.neutrino = new Neutrino(new LndConfig())
+        this.neutrino.process = mockSpawn()
       })
       it('should throw an error', () => {
         expect(() => {
@@ -180,7 +204,7 @@ describe('Neutrino', function() {
   describe('.kill', () => {
     describe('called when neutrino is already running', () => {
       beforeEach(() => {
-        this.neutrino = new Neutrino()
+        this.neutrino = new Neutrino(new LndConfig())
         this.neutrino.process = {
           kill: jest.fn()
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8084,6 +8084,12 @@ mkdirp@0.5.0:
   dependencies:
     minimist "0.0.8"
 
+mock-spawn@^0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/mock-spawn/-/mock-spawn-0.2.6.tgz#b39c15a1c067504310144151f2c1de344d03937f"
+  dependencies:
+    through "2.3.x"
+
 moment@^2.22.2:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
@@ -11648,7 +11654,7 @@ through2@~0.2.3:
     readable-stream "~1.1.9"
     xtend "~2.1.1"
 
-through@2, "through@>=2.2.7 <3", through@^2.3.6, through@^2.3.8:
+through@2, through@2.3.x, "through@>=2.2.7 <3", through@^2.3.6, through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 


### PR DESCRIPTION
Lnd doesn't currently do a graceful shutdown when a `SIGTERM` is issued. To ensure a graceful shutdown, call `stopDaemon` on the gRPC interface prior to terminating lnd. If a graceful shutdown is unsuccessful then force kill the daemon.