### PR TITLE
fix(channels): closing channels link to closing_txid

### DIFF
--- a/app/components/Contacts/Network.js
+++ b/app/components/Contacts/Network.js
@@ -280,7 +280,7 @@ class Network extends Component {
                           onClick={() =>
                             blockExplorer.showTransaction(
                               network,
-                              channel.channel_point.split(':')[0]
+                              channelObj.closing_txid || channel.channel_point.split(':')[0]
                             )
                           }
                         >


### PR DESCRIPTION
We currently hard code our channel explorer links to the channel point (funding transaction). For closing channels this isn't really relevant and bad UX. This PR updates the logic for the explorer link: if the channel has a closing tx (it's in the process of being closed) then let's link to that, otherwise the funding tx is fine 👍 