### PR TITLE
feat(payment): add 60 second payment timeout

### DIFF
--- a/app/components/Wallet/Wallet.js
+++ b/app/components/Wallet/Wallet.js
@@ -30,7 +30,8 @@ const Wallet = ({
   setCurrency,
   setWalletCurrencyFilters,
   network,
-  settingsProps
+  settingsProps,
+  paymentTimeout
 }) => {
   const fiatAmount = btc.satoshisToFiat(
     parseInt(balance.walletBalance, 10) + parseInt(balance.channelBalance, 10),
@@ -112,8 +113,11 @@ const Wallet = ({
           <div className={styles.notificationBox}>
             {showPayLoadingScreen && (
               <span>
-                <section className={`${styles.spinner} ${styles.icon}`} />
-                <section>Sending your transaction...</section>
+                <div className={styles.spinnerContainer}>
+                  <section className={`${styles.spinner} ${styles.icon}`} />
+                  <span className={styles.timeout}>{paymentTimeout / 1000}</span>
+                </div>
+                <section>Sending your transaction</section>
               </span>
             )}
             {showSuccessPayScreen && (
@@ -165,6 +169,7 @@ Wallet.propTypes = {
   settingsProps: PropTypes.object.isRequired,
   currentCurrencyFilters: PropTypes.array.isRequired,
   currencyName: PropTypes.string.isRequired,
+  paymentTimeout: PropTypes.number.isRequired,
   setCurrency: PropTypes.func.isRequired,
   setWalletCurrencyFilters: PropTypes.func.isRequired
 }

--- a/app/components/Wallet/Wallet.scss
+++ b/app/components/Wallet/Wallet.scss
@@ -196,9 +196,14 @@
     transition: all 0.25s;
   }
 
+  .spinnerContainer {
+    position: relative;
+    display: inline;
+  }
+
   .spinner {
-    height: 20px;
-    width: 20px;
+    height: 30px;
+    width: 30px;
     border: 1px solid rgba(235, 184, 100, 0.1);
     border-left-color: rgba(235, 184, 100, 0.4);
     -webkit-border-radius: 999px;
@@ -208,6 +213,15 @@
     -moz-animation: animation-rotate 1000ms linear infinite;
     -o-animation: animation-rotate 1000ms linear infinite;
     animation: animation-rotate 1000ms linear infinite;
+  }
+
+  .timeout {
+    position: absolute;
+    top: 20%;
+    left: 0;
+    font-size: 10px;
+    width: 32px;
+    text-align: center;
   }
 
   .icon {

--- a/app/routes/activity/containers/ActivityContainer.js
+++ b/app/routes/activity/containers/ActivityContainer.js
@@ -98,6 +98,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => ({
     currentCurrencyFilters: stateProps.currentCurrencyFilters,
     currencyName: stateProps.currencyName,
     network: stateProps.info.network,
+    paymentTimeout: stateProps.payment.paymentTimeout,
 
     setCurrency: dispatchProps.setCurrency,
     setWalletCurrencyFilters: dispatchProps.setWalletCurrencyFilters,

--- a/test/unit/reducers/__snapshots__/payment.spec.js.snap
+++ b/test/unit/reducers/__snapshots__/payment.spec.js.snap
@@ -3,7 +3,9 @@
 exports[`reducers paymentReducer should correctly getPayments 1`] = `
 Object {
   "payment": null,
+  "paymentInterval": null,
   "paymentLoading": true,
+  "paymentTimeout": 60000,
   "payments": Array [],
   "sendingPayment": false,
   "showSuccessPayScreen": false,
@@ -13,7 +15,9 @@ Object {
 exports[`reducers paymentReducer should correctly paymentSuccessful 1`] = `
 Object {
   "payment": null,
+  "paymentInterval": null,
   "paymentLoading": false,
+  "paymentTimeout": 60000,
   "payments": Array [],
   "sendingPayment": false,
   "showSuccessPayScreen": false,
@@ -23,7 +27,9 @@ Object {
 exports[`reducers paymentReducer should correctly receivePayments 1`] = `
 Object {
   "payment": null,
+  "paymentInterval": null,
   "paymentLoading": false,
+  "paymentTimeout": 60000,
   "payments": Array [
     1,
     2,
@@ -36,7 +42,9 @@ Object {
 exports[`reducers paymentReducer should correctly sendPayment 1`] = `
 Object {
   "payment": "foo",
+  "paymentInterval": null,
   "paymentLoading": false,
+  "paymentTimeout": 60000,
   "payments": Array [],
   "sendingPayment": false,
   "showSuccessPayScreen": false,
@@ -46,7 +54,9 @@ Object {
 exports[`reducers paymentReducer should handle initial state 1`] = `
 Object {
   "payment": null,
+  "paymentInterval": null,
   "paymentLoading": false,
+  "paymentTimeout": 60000,
   "payments": Array [],
   "sendingPayment": false,
   "showSuccessPayScreen": false,


### PR DESCRIPTION
In this commit we add a 60 second timeout when paying a LN invoice. If the payment doesn't successfully route after 60 seconds we display an error. 

Addresses #715, #637 

New payment success UX:

![ezgif com-video-to-gif 2](https://user-images.githubusercontent.com/4040039/44681074-24936d00-aa05-11e8-8c8b-8e2222722302.gif)

New payment fail UX:

![ezgif com-video-to-gif 3](https://user-images.githubusercontent.com/4040039/44681114-4e4c9400-aa05-11e8-98c8-990d1d1d03a3.gif)