### PR TITLE
feat(invoice): add priv routing hints for light clients

### DIFF
--- a/app/lib/lnd/methods/invoicesController.js
+++ b/app/lib/lnd/methods/invoicesController.js
@@ -7,9 +7,9 @@ import pushinvoices from '../push/subscribeinvoice'
  * @param  value [description]
  * @return     [description]
  */
-export function addInvoice(lnd, { memo, value }) {
+export function addInvoice(lnd, { memo, value, private: privateInvoice }) {
   return new Promise((resolve, reject) => {
-    lnd.addInvoice({ memo, value }, (err, data) => {
+    lnd.addInvoice({ memo, value, private: privateInvoice }, (err, data) => {
       if (err) {
         return reject(err)
       }

--- a/test/unit/reducers/__snapshots__/activity.spec.js.snap
+++ b/test/unit/reducers/__snapshots__/activity.spec.js.snap
@@ -29,6 +29,7 @@ Object {
   },
   "searchActive": false,
   "searchText": "",
+  "showExpiredRequests": false,
 }
 `;
 
@@ -63,6 +64,7 @@ Object {
   },
   "searchActive": false,
   "searchText": "",
+  "showExpiredRequests": false,
 }
 `;
 
@@ -98,6 +100,7 @@ Object {
   },
   "searchActive": false,
   "searchText": "",
+  "showExpiredRequests": false,
 }
 `;
 
@@ -132,6 +135,7 @@ Object {
   },
   "searchActive": false,
   "searchText": "",
+  "showExpiredRequests": false,
 }
 `;
 
@@ -167,6 +171,7 @@ Object {
   },
   "searchActive": false,
   "searchText": "",
+  "showExpiredRequests": false,
 }
 `;
 
@@ -202,6 +207,7 @@ Object {
   },
   "searchActive": undefined,
   "searchText": "",
+  "showExpiredRequests": false,
 }
 `;
 
@@ -237,5 +243,6 @@ Object {
   },
   "searchActive": false,
   "searchText": undefined,
+  "showExpiredRequests": false,
 }
 `;


### PR DESCRIPTION
We currently do not flag for private channel routing hints when we create invoices. We need to if the user is a light client because all channels will be private. This commit checks which type of client is using zap and flags invoices to add private hints if it's a light client.

Fix for #725 