### PR TITLE
fix(grpc): use Numbers to represent long values

### DIFF
--- a/app/lib/lnd/lightning.js
+++ b/app/lib/lnd/lightning.js
@@ -71,7 +71,7 @@ class Lightning {
       // See https://github.com/grpc/grpc-node/blob/master/packages/grpc-protobufjs/README.md
       const options = {
         keepCase: true,
-        longs: String,
+        longs: Number,
         enums: String,
         defaults: true,
         oneofs: true

--- a/app/lib/lnd/walletUnlocker.js
+++ b/app/lib/lnd/walletUnlocker.js
@@ -21,7 +21,7 @@ export const walletUnlocker = lndConfig => {
   // See https://github.com/grpc/grpc-node/blob/master/packages/grpc-protobufjs/README.md
   const options = {
     keepCase: true,
-    longs: String,
+    longs: Number,
     enums: String,
     defaults: true,
     oneofs: true


### PR DESCRIPTION
Configure gRPC to use Numbers to represent long values instead of Strings. This ensures that we can do accurate handling of numerical values.

<!--- Provide a general summary of your changes in the Title above -->

## Description:

This ensures that numbers are actually numbers and not strings so a check like `if (val) { ... }` would will give expected results.

For example:
```
if (0) { echo "something" }
   => undefined
```
but 
```
if ("0") { echo "something" }
    => "something"
```

(`"0"` is a truthy value, whilst `0` is not)

## Motivation and Context:

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #727

## Types of changes:

<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

Bux fix

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
