### PR TITLE
chore(version): bump to 0.2.2-beta

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap-desktop",
   "productName": "Zap",
-  "version": "0.2.1-beta",
+  "version": "0.2.2-beta",
   "description": "desktop application for the lightning network",
   "main": "./main.prod.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap-desktop",
   "productName": "ZapDesktop",
-  "version": "0.2.1-beta",
+  "version": "0.2.2-beta",
   "description": "desktop application for the lightning network",
   "scripts": {
     "build": "concurrently --raw \"npm:build-main\" \"npm:build-renderer\"",


### PR DESCRIPTION
This bumps the version to 0.2.2-beta which will trigger electron-builder to start publishing builds to the 0.2.2-beta release draft.