### PR TITLE
fix(qrcode): re-invert QR colors and 2 px border for maximum compatibility

### DIFF
--- a/app/components/Activity/InvoiceModal.js
+++ b/app/components/Activity/InvoiceModal.js
@@ -43,8 +43,8 @@ const InvoiceModal = ({
             value={invoice.payment_request}
             renderAs="svg"
             size={150}
-            bgColor="transparent"
-            fgColor="white"
+            bgColor="white"
+            fgColor="#252832"
             level="L"
             className={styles.qrcode}
           />

--- a/app/components/Activity/InvoiceModal.scss
+++ b/app/components/Activity/InvoiceModal.scss
@@ -16,13 +16,16 @@
   .left {
     width: 25%;
     padding: 0 60px;
+    text-align: center;
 
     h2 {
-      text-align: center;
       margin-bottom: 20px;
     }
 
     .qrcode {
+      border-style: solid;
+      border-color: white;
+      border-width: 2px;
       margin-bottom: 20px;
     }
   }

--- a/app/components/Onboarding/Syncing.js
+++ b/app/components/Onboarding/Syncing.js
@@ -108,8 +108,8 @@ class Syncing extends Component {
                       value={address}
                       renderAs="svg"
                       size={100}
-                      bgColor="transparent"
-                      fgColor="white"
+                      bgColor="white"
+                      fgColor="#252832"
                       level="L"
                       className={styles.qrcode}
                     />

--- a/app/components/Onboarding/Syncing.scss
+++ b/app/components/Onboarding/Syncing.scss
@@ -70,6 +70,12 @@
       }
     }
   }
+
+  .qrcode {
+    border-style: solid;
+    border-color: white;
+    border-width: 2px;
+  }
 }
 
 .progressContainer {

--- a/app/components/Wallet/ReceiveModal.js
+++ b/app/components/Wallet/ReceiveModal.js
@@ -76,9 +76,10 @@ class ReceiveModal extends React.Component {
                 value={qrCodeType === 1 ? pubkey : address}
                 renderAs="svg"
                 size={150}
-                bgColor="transparent"
-                fgColor="white"
+                bgColor="white"
+                fgColor="#252832"
                 level="L"
+                className={styles.qrcode}
               />
             </div>
           </section>

--- a/app/components/Wallet/ReceiveModal.scss
+++ b/app/components/Wallet/ReceiveModal.scss
@@ -69,6 +69,12 @@
     .qrCodeContainer {
       text-align: center;
     }
+
+    .qrcode {
+      border-style: solid;
+      border-color: white;
+      border-width: 2px;
+    }
   }
 
   .right {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description: 
Fix for a more standard QR code color scheme for compatibility with QR scanners. Changed background color to white, and foreground color to dark. Added 2 pixel wide css border. Changes applied to wallet, invoice and syncing js and scss files (where the the element is invoked). Able to test wallet and invoice QR codes with my Android device, but not lnd syncing.

<!--- Describe your changes in detail -->

## Motivation and Context:

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix for #675 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Scanning with Android barcode scanner and Eclair wallet now works.

## Screenshots (if appropriate):

## Types of changes:

<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->
Minor UI changes.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
