### PR TITLE
feat(channels): warn when opening multiple channels to the same node

### DIFF
--- a/app/components/Contacts/SubmitChannelForm.js
+++ b/app/components/Contacts/SubmitChannelForm.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import FaAngleDown from 'react-icons/lib/fa/angle-down'
+import FaExclamationCircle from 'react-icons/lib/fa/exclamation-circle'
 
 import AmountInput from 'components/AmountInput'
 import styles from './SubmitChannelForm.scss'
@@ -17,6 +18,7 @@ class SubmitChannelForm extends React.Component {
       updateContactCapacity,
       openChannel,
       fiatTicker,
+      dupeChanInfo,
 
       ticker,
 
@@ -38,6 +40,22 @@ class SubmitChannelForm extends React.Component {
       }
 
       return node.pub_key
+    }
+
+    const renderWarning = dupeChanInfo => {
+      const { alias, activeChannels, capacity, currencyName } = dupeChanInfo
+
+      const chansMsg =
+        activeChannels === 1 ? ' an active channel ' : ` ${activeChannels} active channels `
+      const aliasMsg = alias ? <span className={styles.alias}>{alias}</span> : ' this node '
+
+      return (
+        <p>
+          {`You currently have ${chansMsg} open to `}
+          {aliasMsg}
+          {` with a capacity of ${capacity} ${currencyName}.`}
+        </p>
+      )
     }
 
     const formSubmitted = () => {
@@ -74,6 +92,13 @@ class SubmitChannelForm extends React.Component {
         <section className={styles.title}>
           <h2>{renderTitle()}</h2>
         </section>
+
+        {dupeChanInfo && (
+          <section className={styles.warn}>
+            <FaExclamationCircle className={styles.exclamation} style={{ verticalAlign: 'top' }} />
+            {renderWarning(dupeChanInfo)}
+          </section>
+        )}
 
         <section className={styles.amount}>
           <div className={styles.input}>
@@ -128,6 +153,7 @@ SubmitChannelForm.propTypes = {
   updateContactCapacity: PropTypes.func.isRequired,
   openChannel: PropTypes.func.isRequired,
   fiatTicker: PropTypes.string.isRequired,
+  dupeChanInfo: PropTypes.object,
 
   ticker: PropTypes.object.isRequired,
 

--- a/app/components/Contacts/SubmitChannelForm.scss
+++ b/app/components/Contacts/SubmitChannelForm.scss
@@ -39,6 +39,32 @@
   }
 }
 
+.warn {
+  color: #dea326;
+  margin: 20px 0;
+  display: flex;
+
+  p {
+    flex: 1;
+    font-size: 12px;
+    line-height: 1.5;
+  }
+
+  .exclamation {
+    flex: 0 0 25px;
+    vertical-align: top;
+  }
+
+  .alias {
+    background: #252832;
+    padding: 2px 5px 4px;
+    border-radius: 8px;
+    display: inline;
+    color: #fff;
+    font-size: 10px;
+  }
+}
+
 .input {
   display: flex;
   flex-direction: row;

--- a/app/routes/app/containers/AppContainer.js
+++ b/app/routes/app/containers/AppContainer.js
@@ -183,6 +183,7 @@ const mapStateToProps = state => ({
   showManualForm: contactFormSelectors.showManualForm(state),
   manualFormIsValid: contactFormSelectors.manualFormIsValid(state),
   contactFormFiatAmount: contactFormSelectors.contactFormFiatAmount(state),
+  dupeChanInfo: contactFormSelectors.dupeChanInfo(state),
 
   currentChannels: currentChannels(state),
   activeChannelPubkeys: channelsSelectors.activeChannelPubkeys(state),
@@ -408,6 +409,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     node: stateProps.contactsform.node,
     contactCapacity: stateProps.contactsform.contactCapacity,
     fiatTicker: stateProps.ticker.fiatTicker,
+    dupeChanInfo: stateProps.dupeChanInfo,
 
     updateContactCapacity: dispatchProps.updateContactCapacity,
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:

Display a warning when the user attempts to open a channel to a node that already has active channels open. Also display the node alias and total capacity of the existing channels in the warning message. The total capacity units automatically change when the user changes the unit in the dropdown menu on this screen.

## Motivation and Context:

Fixes #252 

## How Has This Been Tested?

Attempted to open channels to a node in each of these scenarios:
- node with no existing channels open. the warning is not displayed
- node with multiple open channels. the warning shows with the number of open channels, the alias and total capacity
- node with an open channel but no alias: the warning shows with the total capacity but no alias

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1356600/44926414-59623580-ad1f-11e8-923e-d52de5ec9b7d.png)

![image](https://user-images.githubusercontent.com/1356600/44926433-64b56100-ad1f-11e8-8ebb-e9776650ce0f.png)

## Types of changes:

Minor UI improvement

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
