### PR TITLE
fix(ui): show wallet once balances are loaded

### DIFF
--- a/app/routes/activity/components/Activity.js
+++ b/app/routes/activity/components/Activity.js
@@ -90,7 +90,7 @@ class Activity extends Component {
       walletProps
     } = this.props
 
-    if (!balance.channelBalance || !balance.walletBalance) {
+    if (balance.channelBalance === null || balance.walletBalance === null) {
       return <LoadingBolt />
     }
 


### PR DESCRIPTION
## Description:

Due to a recent change in the way that we handle numeric data from gRPC we need to be explicit when checking for unset/null values.

## Motivation and Context:

Wallet GUI missing for new wallets with a zero balance.

## How Has This Been Tested?

Create and sync new wallet and verify that the UI shows correctly.

## Types of changes:

Bug fix

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
