### PR TITLE
fix(grpc): ensure connection errors show onscreen

### DIFF
--- a/app/lib/zap/controller.js
+++ b/app/lib/zap/controller.js
@@ -284,6 +284,7 @@ class ZapController {
       this.sendMessage('lightningGrpcActive')
     } catch (err) {
       mainLog.warn('Unable to connect to Lighitnng gRPC interface: %o', err)
+      throw err
     }
   }
 


### PR DESCRIPTION
## Description:

Fix an issue that was preventing grpc connection errors from showing
after a failed connection to a remote node.

Re-throw the error from `startLightningWallet` after logging it so that
it can be handled properly afterwards.

## Motivation and Context:

After making a failed connection to a remote node the wallet would hang indefinitely on the loading screen.

## How Has This Been Tested?

Attempt to connect to a remote node using invalid connection details (wrong hostname or cert path etc)

## Types of changes:

Bug fix

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have reviewed and updated the documentation accordingly.
- [ ] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [ ] My commits have been squashed into a concise set of changes.
