### PR TITLE
feat(wallet): show node public address if set

### DIFF
--- a/app/components/Wallet/ReceiveModal.scss
+++ b/app/components/Wallet/ReceiveModal.scss
@@ -35,8 +35,8 @@
   color: $white;
 
   .left {
-    width: 25%;
-    padding: 30px 40px;
+    width: 30%;
+    padding: 30px 30px;
 
     .header {
       h2 {
@@ -78,14 +78,14 @@
   }
 
   .right {
-    width: 75%;
+    width: 70%;
     min-height: 220px;
     border-left: 1px solid $spaceborder;
-    padding: 30px 40px;
+    padding: 30px 30px;
 
     .pubkey,
     .address {
-      padding: 25px;
+      padding: 25px 0;
 
       h4 {
         font-size: 12px;

--- a/app/routes/app/containers/AppContainer.js
+++ b/app/routes/app/containers/AppContainer.js
@@ -1,5 +1,6 @@
 import { withRouter } from 'react-router'
 import { connect } from 'react-redux'
+import get from 'lodash.get'
 
 import { btc } from 'lib/utils'
 
@@ -397,7 +398,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const receiveModalProps = {
     isOpen: stateProps.address.walletModal,
     network: stateProps.info.network,
-    pubkey: stateProps.info.data.identity_pubkey,
+    pubkey: get(stateProps.info, 'data.uris[0]') || get(stateProps.info, 'data.identity_pubkey'),
     address: stateProps.address.address,
     alias: stateProps.info.data.alias,
     closeReceiveModal: dispatchProps.closeWalletModal


### PR DESCRIPTION
## Description:

Show the node public address if known to make it easier to share node
details with other users. Add the data in both the Node address text
field as well as the node address QR code.


## Motivation and Context:

There is currently no way to see the public node address including the IP address and port.

## How Has This Been Tested?

1. Start the internal node and verify that the node address shows ok
2. Connect to a custom node with external ip address set and verify that the ip address and port are included in the node address (text and QR code)

## Screenshots (if appropriate):

<img width="837" alt="screenshot 2018-09-04 15 18 55" src="https://user-images.githubusercontent.com/200251/45034000-86338700-b056-11e8-94ba-bb806cac286e.png">

## Types of changes:

New feature

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
