### PR TITLE
fix(fsm): ensure lnd connect before state change

### DIFF
--- a/app/lib/zap/controller.js
+++ b/app/lib/zap/controller.js
@@ -147,8 +147,8 @@ class ZapController {
     this.sendMessage('startOnboarding', this.lndConfig)
   }
 
-  onStartLnd() {
-    mainLog.debug('[FSM] onStartLnd...')
+  onBeforeStartLnd() {
+    mainLog.debug('[FSM] onBeforeStartLnd...')
 
     return isLndRunning().then(res => {
       if (res) {
@@ -168,8 +168,8 @@ class ZapController {
     })
   }
 
-  onConnectLnd() {
-    mainLog.debug('[FSM] onConnectLnd...')
+  onBeforeConnectLnd() {
+    mainLog.debug('[FSM] onBeforeConnectLnd...')
     mainLog.info('Connecting to custom lnd instance')
     mainLog.info(' > host:', this.lndConfig.host)
     mainLog.info(' > cert:', this.lndConfig.cert)
@@ -197,7 +197,8 @@ class ZapController {
         }
 
         // Notify the app of errors.
-        return this.sendMessage('startLndError', errors)
+        this.sendMessage('startLndError', errors)
+        throw e
       })
   }
 


### PR DESCRIPTION
## Description:

Ensure that a failed lnd connection attempt prevents the FSM from changing state by moving the connect handlers to the `onBefore<TRANSITION>` lifecycle events.

See https://github.com/jakesgordon/javascript-state-machine/blob/master/docs/lifecycle-events.md#cancelling-a-transition

## Motivation and Context:

Fix for #739

## How Has This Been Tested?

1. Start zap
2. select custom mode
3. enter invalid connection details
4. proceed to connect
5. after returning to the connect form, submit for a second time with invalid credentials

## Types of changes:

Bug fix

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
