### PR TITLE
feat(grpc): ability to unlock remote wallet

### DIFF
--- a/app/components/Onboarding/Onboarding.js
+++ b/app/components/Onboarding/Onboarding.js
@@ -159,16 +159,16 @@ const Onboarding = ({
           </FormContainer>
         )
       case 3:
+        // eslint-disable-next-line no-case-declarations
+        let message = 'It looks like you already have a wallet'
+        if (initWalletProps.loginProps.existingWalletDir && connectionType === 'local') {
+          message += ` (we found one at ${initWalletProps.loginProps.existingWalletDir})`
+        } else {
+          message += ` at ${connectionHost.split(':')[0]}`
+        }
+        message += '. Please enter your wallet password to unlock it.'
         return (
-          <FormContainer
-            title="Welcome back!"
-            description={`It looks like you already have a wallet
-              ${Boolean(initWalletProps.loginProps.existingWalletDir) &&
-                `(we found one at \`${initWalletProps.loginProps.existingWalletDir}\`)`}.
-            Please enter your wallet password to unlock it.`}
-            back={null}
-            next={null}
-          >
+          <FormContainer title="Welcome back!" description={`${message}`} back={null} next={null}>
             <Login {...initWalletProps.loginProps} />
           </FormContainer>
         )

--- a/app/lib/lnd/lightning.js
+++ b/app/lib/lnd/lightning.js
@@ -93,8 +93,9 @@ class Lightning {
 
       // Wait for the gRPC connection to be established.
       return new Promise((resolve, reject) => {
-        grpc.waitForClientReady(this.service, getDeadline(2), err => {
+        this.service.waitForReady(getDeadline(2), err => {
           if (err) {
+            this.service.close()
             return reject(err)
           }
           return resolve()

--- a/app/lib/lnd/methods/index.js
+++ b/app/lib/lnd/methods/index.js
@@ -28,7 +28,7 @@ export default function(lnd, log, event, msg, data) {
           event.sender.send('receiveCryptocurrency', infoData.chains[0])
           return infoData
         })
-        .catch(() => event.sender.send('infoFailed'))
+        .catch(error => log.error('info:', error))
       break
     case 'describeNetwork':
       networkController

--- a/app/lib/lnd/subscribe/channelgraph.js
+++ b/app/lib/lnd/subscribe/channelgraph.js
@@ -2,7 +2,7 @@ import { status } from 'grpc'
 import { mainLog } from '../../utils/log'
 
 export default function subscribeToChannelGraph() {
-  const call = this.lnd.subscribeChannelGraph({})
+  const call = this.service.subscribeChannelGraph({})
 
   call.on('data', channelGraphData => {
     mainLog.info('CHANNELGRAPH:', channelGraphData)

--- a/app/lib/lnd/subscribe/invoices.js
+++ b/app/lib/lnd/subscribe/invoices.js
@@ -2,7 +2,7 @@ import { status } from 'grpc'
 import { mainLog } from '../../utils/log'
 
 export default function subscribeToInvoices() {
-  const call = this.lnd.subscribeInvoices({})
+  const call = this.service.subscribeInvoices({})
 
   call.on('data', invoice => {
     mainLog.info('INVOICE:', invoice)

--- a/app/lib/lnd/subscribe/transactions.js
+++ b/app/lib/lnd/subscribe/transactions.js
@@ -2,7 +2,7 @@ import { status } from 'grpc'
 import { mainLog } from '../../utils/log'
 
 export default function subscribeToTransactions() {
-  const call = this.lnd.subscribeTransactions({})
+  const call = this.service.subscribeTransactions({})
 
   call.on('data', transaction => {
     mainLog.info('TRANSACTION:', transaction)

--- a/app/lib/lnd/walletUnlocker.js
+++ b/app/lib/lnd/walletUnlocker.js
@@ -74,8 +74,9 @@ class WalletUnlocker {
 
       // Wait for the gRPC connection to be established.
       return new Promise((resolve, reject) => {
-        grpc.waitForClientReady(this.service, getDeadline(2), err => {
+        this.service.waitForReady(getDeadline(2), err => {
           if (err) {
+            this.service.close()
             return reject(err)
           }
           return resolve()

--- a/app/lib/lnd/walletUnlocker.js
+++ b/app/lib/lnd/walletUnlocker.js
@@ -74,7 +74,7 @@ class WalletUnlocker {
 
       // Wait for the gRPC connection to be established.
       return new Promise((resolve, reject) => {
-        this.service.waitForReady(getDeadline(2), err => {
+        this.service.waitForReady(getDeadline(5), err => {
           if (err) {
             this.service.close()
             return reject(err)

--- a/app/lib/lnd/walletUnlockerMethods/index.js
+++ b/app/lib/lnd/walletUnlockerMethods/index.js
@@ -1,7 +1,7 @@
 import { dirname } from 'path'
 import * as walletController from '../methods/walletController'
 
-export default function(lndConfig, walletUnlocker, log, event, msg, data) {
+export default function(walletUnlocker, log, event, msg, data, lndConfig) {
   const decorateError = error => {
     switch (error.code) {
       // wallet already exists

--- a/app/lib/zap/controller.js
+++ b/app/lib/zap/controller.js
@@ -193,6 +193,16 @@ class ZapController {
         else if (e.code === 'LND_GRPC_MACAROON_ERROR') {
           errors.macaroon = e.message
         }
+
+        // The `startLightningWallet` call attempts to call the `getInfo` method on the Lightning service in order to
+        // verify that it is accessible. If it is not, an error 12 is throw whcih is the gRPC code for `UNIMPLEMENTED`
+        // which indicates that the requested operation is not implemented or not supported/enabled in the service.
+        // See https://github.com/grpc/grpc-node/blob/master/packages/grpc-native-core/src/constants.js#L129
+        if (e.code === 12) {
+          errors.host =
+            'Unable to connect to host. Please ensure wallet is unlocked before connecting.'
+        }
+
         // Other error codes such as UNAVAILABLE most likely indicate that there is a problem with the host.
         else {
           errors.host = `Unable to connect to host: ${e.details || e.message}`

--- a/app/lib/zap/controller.js
+++ b/app/lib/zap/controller.js
@@ -199,8 +199,7 @@ class ZapController {
         // which indicates that the requested operation is not implemented or not supported/enabled in the service.
         // See https://github.com/grpc/grpc-node/blob/master/packages/grpc-native-core/src/constants.js#L129
         if (e.code === 12) {
-          errors.host =
-            'Unable to connect to host. Please ensure wallet is unlocked before connecting.'
+          return this.startWalletUnlocker()
         }
 
         // Other error codes such as UNAVAILABLE most likely indicate that there is a problem with the host.
@@ -336,11 +335,6 @@ class ZapController {
       this.startWalletUnlocker()
     })
 
-    this.neutrino.on('lightning-grpc-active', () => {
-      mainLog.info('Lightning gRPC active')
-      this.startLightningWallet()
-    })
-
     this.neutrino.on('chain-sync-waiting', () => {
       mainLog.info('Neutrino sync waiting')
       this.sendMessage('lndSyncStatus', 'waiting')
@@ -467,6 +461,7 @@ class ZapController {
    */
   _registerIpcListeners() {
     ipcMain.on('startLnd', (event, options: onboardingOptions) => this.finishOnboarding(options))
+    ipcMain.on('startLightningWallet', () => this.startLightningWallet())
   }
 
   /**
@@ -474,6 +469,7 @@ class ZapController {
    */
   _removeIpcListeners() {
     ipcMain.removeAllListeners('startLnd')
+    ipcMain.removeAllListeners('startLightningWallet')
     ipcMain.removeAllListeners('walletUnlocker')
     ipcMain.removeAllListeners('lnd')
   }

--- a/app/lib/zap/controller.js
+++ b/app/lib/zap/controller.js
@@ -4,12 +4,13 @@ import { app, ipcMain, dialog, BrowserWindow } from 'electron'
 import pick from 'lodash.pick'
 import Store from 'electron-store'
 import StateMachine from 'javascript-state-machine'
+import { mainLog } from '../utils/log'
+import { isLndRunning } from '../lnd/util'
+
 import LndConfig from '../lnd/config'
 import Lightning from '../lnd/lightning'
 import Neutrino from '../lnd/neutrino'
-import { initWalletUnlocker } from '../lnd/walletUnlocker'
-import { mainLog } from '../utils/log'
-import { isLndRunning } from '../lnd/util'
+import WalletUnlocker from '../lnd/walletUnlocker'
 
 type onboardingOptions = {
   type: 'local' | 'custom' | 'btcpayserver',
@@ -53,6 +54,7 @@ class ZapController {
   mainWindow: BrowserWindow
   neutrino: Neutrino
   lightning: Lightning
+  walletUnlocker: WalletUnlocker
   splashScreenTime: number
   lndConfig: LndConfig
   _fsm: StateMachine
@@ -244,24 +246,24 @@ class ZapController {
   /**
    * Start the wallet unlocker.
    */
-  startWalletUnlocker() {
+  async startWalletUnlocker() {
     mainLog.info('Establishing connection to Wallet Unlocker gRPC interface...')
-    try {
-      const walletUnlockerMethods = initWalletUnlocker(this.lndConfig)
+    this.walletUnlocker = new WalletUnlocker(this.lndConfig)
 
-      // Listen for all gRPC restful methods
-      ipcMain.on('walletUnlocker', (event, { msg, data }) => {
-        walletUnlockerMethods(event, msg, data)
-      })
+    // Connect to the WalletUnlocker interface.
+    try {
+      await this.walletUnlocker.connect()
+
+      // Listen for all gRPC restful methods and pass to gRPC.
+      ipcMain.on('walletUnlocker', (event, { msg, data }) =>
+        this.walletUnlocker.registerMethods(event, msg, data)
+      )
 
       // Notify the renderer that the wallet unlocker is active.
       this.sendMessage('walletUnlockerGrpcActive')
-    } catch (error) {
-      dialog.showMessageBox({
-        type: 'error',
-        message: `Unable to start lnd wallet unlocker. Please check your lnd node and try again: ${error}`
-      })
-      app.quit()
+    } catch (err) {
+      mainLog.warn('Unable to connect to WalletUnlocker gRPC interface: %o', err)
+      throw err
     }
   }
 
@@ -279,7 +281,7 @@ class ZapController {
       this.lightning.subscribe(this.mainWindow)
 
       // Listen for all gRPC restful methods and pass to gRPC.
-      ipcMain.on('lnd', (event, { msg, data }) => this.lightning.lndMethods(event, msg, data))
+      ipcMain.on('lnd', (event, { msg, data }) => this.lightning.registerMethods(event, msg, data))
 
       // Let the renderer know that we are connected.
       this.sendMessage('lightningGrpcActive')

--- a/app/lib/zap/controller.js
+++ b/app/lib/zap/controller.js
@@ -147,8 +147,8 @@ class ZapController {
     this.sendMessage('startOnboarding', this.lndConfig)
   }
 
-  onStartLnd() {
-    mainLog.debug('[FSM] onStartLnd...')
+  onBeforeStartLnd() {
+    mainLog.debug('[FSM] onBeforeStartLnd...')
 
     return isLndRunning().then(res => {
       if (res) {
@@ -168,8 +168,8 @@ class ZapController {
     })
   }
 
-  onConnectLnd() {
-    mainLog.debug('[FSM] onConnectLnd...')
+  onBeforeConnectLnd() {
+    mainLog.debug('[FSM] onBeforeConnectLnd...')
     mainLog.info('Connecting to custom lnd instance')
     mainLog.info(' > host:', this.lndConfig.host)
     mainLog.info(' > cert:', this.lndConfig.cert)
@@ -197,7 +197,8 @@ class ZapController {
         }
 
         // Notify the app of errors.
-        return this.sendMessage('startLndError', errors)
+        this.sendMessage('startLndError', errors)
+        throw e
       })
   }
 

--- a/app/reducers/info.js
+++ b/app/reducers/info.js
@@ -72,8 +72,6 @@ const networks = {
     unitPrefix: ''
   }
 }
-// IPC info fetch failed
-// export const infoFailed = (event, data) => dispatch => {}
 
 // ------------------------------------
 // Action Handlers

--- a/app/reducers/onboarding.js
+++ b/app/reducers/onboarding.js
@@ -320,6 +320,7 @@ export const unlockWallet = wallet_password => dispatch => {
 export const walletUnlocked = () => dispatch => {
   dispatch({ type: WALLET_UNLOCKED })
   dispatch({ type: ONBOARDING_FINISHED })
+  ipcRenderer.send('startLightningWallet')
 }
 
 export const unlockWalletError = () => dispatch => {

--- a/test/unit/lnd/lightning.spec.js
+++ b/test/unit/lnd/lightning.spec.js
@@ -15,7 +15,7 @@ describe('Lightning', function() {
         expect(this.lightning.mainWindow).toBeNull()
       })
       it('should set the "lnd" property to null', () => {
-        expect(this.lightning.lnd).toBeNull()
+        expect(this.lightning.service).toBeNull()
       })
       it('should initialise the "subscriptions" object with null values', () => {
         expect(this.lightning.subscriptions).toMatchObject({


### PR DESCRIPTION
## Description:
    
If when connecting to a remote wallet we detect that it is locked initialise the wallet unlocker to allow users to unlock their remote wallets.

## Motivation and Context:

Users shouldn't need to manually unlock remote wallets before being able to connect to the as this adds friction.

Addresses #543

## How Has This Been Tested?

1. Start up a remote lnd node and leave it in a locked state.
2. Start up zap wallet and try to connect to the node
3. Verify that you are presented with the wallet unlocker screen and are able to log in.

**NOTE: This PR builds on #741 which should be merged first.**

## Types of changes:

New feature

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
