### PR TITLE
fix(pay): dont focus on value input

### DIFF
--- a/app/components/Form/Pay.js
+++ b/app/components/Form/Pay.js
@@ -14,16 +14,10 @@ import styles from './Pay.scss'
 class Pay extends Component {
   componentDidUpdate(prevProps) {
     const {
-      isOnchain,
       isLn,
       payform: { payInput },
       fetchInvoice
     } = this.props
-
-    // If on-chain, focus on amount to let user know it's editable
-    if (isOnchain) {
-      this.amountInput.focus()
-    }
 
     // If LN go retrieve invoice details
     if (prevProps.payform.payInput !== payInput && isLn) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
This PR fixes a bug where Zap crashes when a user tries to send to an on-chain address
<!--- Describe your changes in detail -->

## Motivation and Context:
When entering an on-chain address into the Pay form the Pay form goes blank. This is because it is trying to focus on `amountInput` which does not exist.

## How Has This Been Tested?

You can reproduce the issue on master by simply pasting an on-chain address in the pay form and watch the app crash. 

If you checkout to this PR and paste an on-chain address the app acts normally.
## Checklist:


- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [] I have added tests to cover my changes where needed.
- [] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
