### PR TITLE
feat(autopilot): use new routing flag

### DIFF
--- a/resources/lnd.conf
+++ b/resources/lnd.conf
@@ -338,3 +338,8 @@ autopilot.minconfs=0
 ; This means that multiple applications (other than lnd) using Tor won't be mixed
 ; in with lnd's traffic.
 ; tor.streamisolation=1
+
+[routing]
+; Use the experimental routing config assumechanvalid
+
+routing.assumechanvalid=1


### PR DESCRIPTION
This PR adds the new experimental routing flag that will improve the efficiency of autopilot and improve the overall on-boarding UX as autopilot will now start searching for channels before the headers are synced

## Description:

Added the new routing flag

## Motivation and Context:

Autopilot will open channels quicker and users will be on-boarded more seamlessly 

## How Has This Been Tested?

Use the new routing flag with autopilot

## Types of changes:

Push a new flag into the neutrino args
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
