### PR TITLE
fix(grpc): ensure connection to lnd on init

### DIFF
--- a/app/containers/Root.js
+++ b/app/containers/Root.js
@@ -225,8 +225,8 @@ const Root = ({
     return <Syncing {...syncingProps} />
   }
 
-  // Don't launch the app without a connection to the lightning wallet gRPC interface.
-  if (!lnd.lightningGrpcActive) {
+  // Don't launch the app without a connection to lnd.
+  if (!lnd.lightningGrpcActive && !lnd.walletUnlockerGrpcActive) {
     return <LoadingBolt />
   }
 

--- a/app/lib/lnd/lightning.js
+++ b/app/lib/lnd/lightning.js
@@ -95,7 +95,7 @@ class Lightning {
 
         // Wait for the gRPC connection to be established.
         return new Promise((resolve, reject) => {
-          this.service.waitForReady(getDeadline(5), err => {
+          this.service.waitForReady(getDeadline(10), err => {
             if (err) {
               return reject(err)
             }

--- a/app/lib/lnd/lightning.js
+++ b/app/lib/lnd/lightning.js
@@ -5,7 +5,7 @@ import { loadSync } from '@grpc/proto-loader'
 import { BrowserWindow } from 'electron'
 import StateMachine from 'javascript-state-machine'
 import LndConfig from './config'
-import { getDeadline, validateHost, createSslCreds, createMacaroonCreds } from './util'
+import { getDeadline, validateHost, createSslCreds, createMacaroonCreds, waitForFile } from './util'
 import methods from './methods'
 import { mainLog } from '../utils/log'
 import subscribeToTransactions from './subscribe/transactions'
@@ -63,51 +63,59 @@ class Lightning {
    */
   async onBeforeConnect() {
     mainLog.info('Connecting to Lightning gRPC service')
-    const { rpcProtoPath, host, cert, macaroon } = this.lndConfig
+    const { rpcProtoPath, host, cert, macaroon, type } = this.lndConfig
 
     // Verify that the host is valid before creating a gRPC client that is connected to it.
-    return validateHost(host)
-      .then(async () => {
-        // Load the gRPC proto file.
-        // The following options object closely approximates the existing behavior of grpc.load.
-        // See https://github.com/grpc/grpc-node/blob/master/packages/grpc-protobufjs/README.md
-        const options = {
-          keepCase: true,
-          longs: Number,
-          enums: String,
-          defaults: true,
-          oneofs: true
-        }
-        const packageDefinition = loadSync(rpcProtoPath, options)
+    return (
+      validateHost(host)
+        // If we are trying to connect to the internal lnd, wait upto 20 seconds for the macaroon to be generated.
+        .then(() => (type === 'local' ? waitForFile(macaroon, 20000) : Promise.resolve()))
+        // Attempt to connect using the supplied credentials.
+        .then(async () => {
+          // Load the gRPC proto file.
+          // The following options object closely approximates the existing behavior of grpc.load.
+          // See https://github.com/grpc/grpc-node/blob/master/packages/grpc-protobufjs/README.md
+          const options = {
+            keepCase: true,
+            longs: Number,
+            enums: String,
+            defaults: true,
+            oneofs: true
+          }
+          const packageDefinition = loadSync(rpcProtoPath, options)
 
-        // Load gRPC package definition as a gRPC object hierarchy.
-        const rpc = grpc.loadPackageDefinition(packageDefinition)
+          // Load gRPC package definition as a gRPC object hierarchy.
+          const rpc = grpc.loadPackageDefinition(packageDefinition)
 
-        // Create ssl and macaroon credentials to use with the gRPC client.
-        const [sslCreds, macaroonCreds] = await Promise.all([
-          createSslCreds(cert),
-          createMacaroonCreds(macaroon)
-        ])
-        const credentials = grpc.credentials.combineChannelCredentials(sslCreds, macaroonCreds)
+          // Create ssl and macaroon credentials to use with the gRPC client.
+          const [sslCreds, macaroonCreds] = await Promise.all([
+            createSslCreds(cert),
+            createMacaroonCreds(macaroon)
+          ])
+          const credentials = grpc.credentials.combineChannelCredentials(sslCreds, macaroonCreds)
 
-        // Create a new gRPC client instance.
-        this.service = new rpc.lnrpc.Lightning(host, credentials)
+          // Create a new gRPC client instance.
+          this.service = new rpc.lnrpc.Lightning(host, credentials)
 
-        // Wait for the gRPC connection to be established.
-        return new Promise((resolve, reject) => {
-          this.service.waitForReady(getDeadline(10), err => {
-            if (err) {
-              return reject(err)
-            }
-            return resolve()
+          // Wait upto 20 seconds for the gRPC connection to be established.
+          return new Promise((resolve, reject) => {
+            this.service.waitForReady(getDeadline(20), err => {
+              if (err) {
+                return reject(err)
+              }
+              return resolve()
+            })
           })
         })
-      })
-      .then(() => getInfo(this.service))
-      .catch(err => {
-        this.service.close()
-        throw err
-      })
+        // Once connected, make a call to getInfo to verify that we can make successful calls.
+        .then(() => getInfo(this.service))
+        .catch(err => {
+          if (this.service) {
+            this.service.close()
+          }
+          throw err
+        })
+    )
   }
 
   /**

--- a/app/lib/lnd/neutrino.js
+++ b/app/lib/lnd/neutrino.js
@@ -187,6 +187,8 @@ class Neutrino extends EventEmitter {
           height = match[1]
         } else if ((match = line.match(/Processed \d* blocks? in the last.+\(height (\d+)/))) {
           height = match[1]
+        } else if ((match = line.match(/Difficulty retarget at block height (\d+)/))) {
+          height = match[1]
         } else if ((match = line.match(/Fetching set of headers from tip \(height=(\d+)/))) {
           height = match[1]
         } else if ((match = line.match(/Waiting for filter headers \(height=(\d+)\) to catch/))) {
@@ -200,6 +202,8 @@ class Neutrino extends EventEmitter {
         } else if ((match = line.match(/Writing filter headers up to height=(\d*)/))) {
           cfilter = match[1]
         } else if ((match = line.match(/Verified \d* filter headers? in the.+\(height (\d+)/))) {
+          cfilter = match[1]
+        } else if ((match = line.match(/Fetching filter for height=(\d+)/))) {
           cfilter = match[1]
         }
 
@@ -285,8 +289,11 @@ class Neutrino extends EventEmitter {
    */
   setLndCfilterHeight(height: number | string) {
     const heightAsNumber = Number(height)
-    this.lndCfilterHeight = heightAsNumber
-    this.emit(GOT_LND_CFILTER_HEIGHT, heightAsNumber)
+    const changed = Neutrino.incrementIfHigher(this, 'lndCfilterHeight', heightAsNumber)
+    if (changed) {
+      this.emit(GOT_LND_CFILTER_HEIGHT, heightAsNumber)
+      this.setCurrentBlockHeight(heightAsNumber)
+    }
   }
 }
 

--- a/app/lib/lnd/util.js
+++ b/app/lib/lnd/util.js
@@ -165,18 +165,19 @@ export const createSslCreds = async certPath => {
 export const createMacaroonCreds = async macaroonPath => {
   const metadata = new grpc.Metadata()
 
-  // If it's not a filepath, then assume it is a hex encoded string.
-  if (macaroonPath === basename(macaroonPath)) {
-    metadata.add('macaroon', macaroonPath)
-  } else {
-    const macaroon = await fsReadFile(macaroonPath).catch(e => {
-      const error = new Error(`Macaroon path could not be accessed: ${e.message}`)
-      error.code = 'LND_GRPC_MACAROON_ERROR'
-      throw error
-    })
-    metadata.add('macaroon', macaroon.toString('hex'))
+  if (macaroonPath) {
+    // If it's not a filepath, then assume it is a hex encoded string.
+    if (macaroonPath === basename(macaroonPath)) {
+      metadata.add('macaroon', macaroonPath)
+    } else {
+      const macaroon = await fsReadFile(macaroonPath).catch(e => {
+        const error = new Error(`Macaroon path could not be accessed: ${e.message}`)
+        error.code = 'LND_GRPC_MACAROON_ERROR'
+        throw error
+      })
+      metadata.add('macaroon', macaroon.toString('hex'))
+    }
   }
-
   return grpc.credentials.createFromMetadataGenerator((params, callback) =>
     callback(null, metadata)
   )

--- a/app/lib/lnd/walletUnlocker.js
+++ b/app/lib/lnd/walletUnlocker.js
@@ -4,7 +4,7 @@ import grpc from 'grpc'
 import { loadSync } from '@grpc/proto-loader'
 import StateMachine from 'javascript-state-machine'
 import LndConfig from './config'
-import { getDeadline, validateHost, createSslCreds, createMacaroonCreds } from './util'
+import { getDeadline, validateHost, createSslCreds } from './util'
 import methods from './walletUnlockerMethods'
 import { mainLog } from '../utils/log'
 
@@ -43,7 +43,7 @@ class WalletUnlocker {
    */
   async onBeforeConnect() {
     mainLog.info('Connecting to WalletUnlocker gRPC service')
-    const { rpcProtoPath, host, cert, macaroon } = this.lndConfig
+    const { rpcProtoPath, host, cert } = this.lndConfig
 
     // Verify that the host is valid before creating a gRPC client that is connected to it.
     return await validateHost(host).then(async () => {
@@ -62,19 +62,15 @@ class WalletUnlocker {
       // Load gRPC package definition as a gRPC object hierarchy.
       const rpc = grpc.loadPackageDefinition(packageDefinition)
 
-      // Create ssl and macaroon credentials to use with the gRPC client.
-      const [sslCreds, macaroonCreds] = await Promise.all([
-        createSslCreds(cert),
-        createMacaroonCreds(macaroon)
-      ])
-      const credentials = grpc.credentials.combineChannelCredentials(sslCreds, macaroonCreds)
+      // Create ssl credentials to use with the gRPC client.
+      const sslCreds = await createSslCreds(cert)
 
       // Create a new gRPC client instance.
-      this.service = new rpc.lnrpc.WalletUnlocker(host, credentials)
+      this.service = new rpc.lnrpc.WalletUnlocker(host, sslCreds)
 
       // Wait for the gRPC connection to be established.
       return new Promise((resolve, reject) => {
-        this.service.waitForReady(getDeadline(5), err => {
+        this.service.waitForReady(getDeadline(10), err => {
           if (err) {
             this.service.close()
             return reject(err)

--- a/app/lib/lnd/walletUnlocker.js
+++ b/app/lib/lnd/walletUnlocker.js
@@ -70,9 +70,11 @@ class WalletUnlocker {
 
       // Wait for the gRPC connection to be established.
       return new Promise((resolve, reject) => {
-        this.service.waitForReady(getDeadline(10), err => {
+        this.service.waitForReady(getDeadline(20), err => {
           if (err) {
-            this.service.close()
+            if (this.service) {
+              this.service.close()
+            }
             return reject(err)
           }
           return resolve()

--- a/app/lib/lnd/walletUnlockerMethods/index.js
+++ b/app/lib/lnd/walletUnlockerMethods/index.js
@@ -30,7 +30,7 @@ export default function(walletUnlocker, log, event, msg, data, lndConfig) {
     case 'initWallet':
       walletController
         .initWallet(walletUnlocker, data)
-        .then(() => event.sender.send('finishOnboarding'))
+        .then(() => event.sender.send('walletCreated'))
         .catch(error => log.error('initWallet:', error))
       break
     default:

--- a/app/lib/zap/controller.js
+++ b/app/lib/zap/controller.js
@@ -166,7 +166,7 @@ class ZapController {
     mainLog.info(' > macaroon:', this.lndConfig.macaroon)
 
     return this.startLightningWallet()
-      .then(() => this.sendMessage('finishOnboarding'))
+      .then(() => this.sendMessage('walletConnected'))
       .catch(e => {
         const errors = {}
         // There was a problem connectig to the host.

--- a/app/reducers/ipc.js
+++ b/app/reducers/ipc.js
@@ -4,7 +4,8 @@ import {
   currentBlockHeight,
   lndBlockHeight,
   lndCfilterHeight,
-  lightningGrpcActive
+  lightningGrpcActive,
+  walletUnlockerGrpcActive
 } from './lnd'
 import { receiveInfo } from './info'
 import { receiveAddress } from './address'
@@ -47,11 +48,11 @@ import { receiveDescribeNetwork, receiveQueryRoutes, receiveInvoiceAndQueryRoute
 import {
   startOnboarding,
   startLndError,
-  walletUnlockerGrpcActive,
   receiveSeed,
   receiveSeedError,
-  finishOnboarding,
+  walletCreated,
   walletUnlocked,
+  walletConnected,
   unlockWalletError
 } from './onboarding'
 
@@ -118,8 +119,9 @@ const ipc = createIpc({
   walletUnlockerGrpcActive,
   receiveSeed,
   receiveSeedError,
-  finishOnboarding,
+  walletCreated,
   walletUnlocked,
+  walletConnected,
   unlockWalletError
 })
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "config": {
     "style_paths": "app/styles/*.scss app/components/**/*.scss",
     "lnd-binary": {
-      "binaryVersion": "0.5-beta-rc1-52-gbaee07ef",
+      "binaryVersion": "0.5-beta-rc2-41-g4dd4f7cf",
       "binarySite": "https://github.com/LN-Zap/lnd/releases/download"
     }
   },


### PR DESCRIPTION
## Description:

Consolidate the flow for local and remote wallet connections for consolidate. When unlocking a local wallet wait for the macaroon to be generated before we try to use it.

## Motivation and Context:

Before this PR, creating a new local wallet would hang indefinitely because it was trying to use the macaroon file before it exists.

## How Has This Been Tested?

Test all init flows:

- [x] Create new local wallet
- [x] Unlock existing local wallet
- [x] Connect to unlocked remote wallet
- [x] Connect to locked remote wallet.

## Types of changes:

Bug Fix
Refactor

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
