### PR TITLE
fix(lnd): do not require a single lnd process

### DIFF
--- a/app/lib/lnd/util.js
+++ b/app/lib/lnd/util.js
@@ -4,7 +4,6 @@ import axios from 'axios'
 import { promisify } from 'util'
 import { basename, dirname, join, normalize } from 'path'
 import { platform } from 'os'
-import { lookup } from 'ps-node'
 import { app } from 'electron'
 import isDev from 'electron-is-dev'
 import grpc from 'grpc'
@@ -181,28 +180,4 @@ export const createMacaroonCreds = async macaroonPath => {
   return grpc.credentials.createFromMetadataGenerator((params, callback) =>
     callback(null, metadata)
   )
-}
-
-/**
- * Check to see if an LND process is running.
- * @return {Promise} Boolean indicating wether an existing lnd process was found on the host machine.
- */
-export const isLndRunning = () => {
-  return new Promise((resolve, reject) => {
-    mainLog.info('Looking for existing lnd process')
-    lookup({ command: 'lnd' }, (err, results) => {
-      // There was an error checking for the LND process.
-      if (err) {
-        return reject(err)
-      }
-
-      if (!results.length) {
-        // An LND process was found, no need to start our own.
-        mainLog.info('Existing lnd process not found')
-        return resolve(false)
-      }
-      mainLog.info('Found existing lnd process')
-      return resolve(true)
-    })
-  })
 }

--- a/app/lib/zap/controller.js
+++ b/app/lib/zap/controller.js
@@ -5,7 +5,6 @@ import pick from 'lodash.pick'
 import Store from 'electron-store'
 import StateMachine from 'javascript-state-machine'
 import { mainLog } from '../utils/log'
-import { isLndRunning } from '../lnd/util'
 
 import LndConfig from '../lnd/config'
 import Lightning from '../lnd/lightning'
@@ -152,22 +151,11 @@ class ZapController {
   onBeforeStartLnd() {
     mainLog.debug('[FSM] onBeforeStartLnd...')
 
-    return isLndRunning().then(res => {
-      if (res) {
-        mainLog.error('lnd already running: %s', res)
-        dialog.showMessageBox({
-          type: 'error',
-          message: 'Unable to start lnd because it is already running.'
-        })
-        return app.quit()
-      }
+    mainLog.info('Starting new lnd instance')
+    mainLog.info(' > alias:', this.lndConfig.alias)
+    mainLog.info(' > autopilot:', this.lndConfig.autopilot)
 
-      mainLog.info('Starting new lnd instance')
-      mainLog.info(' > alias:', this.lndConfig.alias)
-      mainLog.info(' > autopilot:', this.lndConfig.autopilot)
-
-      return this.startNeutrino()
-    })
+    return this.startNeutrino()
   }
 
   onBeforeConnectLnd() {

--- a/package.json
+++ b/package.json
@@ -297,7 +297,6 @@
     "lodash.pick": "^4.4.0",
     "moment": "^2.22.2",
     "prop-types": "^15.6.2",
-    "ps-node": "^0.1.6",
     "qrcode.react": "0.8.0",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3159,10 +3159,6 @@ connect-history-api-fallback@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz#b06873934bc5e344fef611a196a6faae0aee015a"
 
-connected-domain@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/connected-domain/-/connected-domain-1.0.0.tgz#bfe77238c74be453a79f0cb6058deeb4f2358e93"
-
 console-browserify@1.1.x, console-browserify@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.1.0.tgz#f0241c45730a9fc6323b206dbf38edc741d0bb10"
@@ -9604,12 +9600,6 @@ prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
 
-ps-node@^0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/ps-node/-/ps-node-0.1.6.tgz#9af67a99d7b1d0132e51a503099d38a8d2ace2c3"
-  dependencies:
-    table-parser "^0.1.3"
-
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -11523,12 +11513,6 @@ symbol-observable@^1.1.0, symbol-observable@^1.2.0:
 symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
-
-table-parser@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/table-parser/-/table-parser-0.1.3.tgz#0441cfce16a59481684c27d1b5a67ff15a43c7b0"
-  dependencies:
-    connected-domain "^1.0.0"
 
 table@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
## Description:

There is no need to check wether an lnd process exists and prevent Zap from starting if so. We don't care if there is another process running. We only care that we can successfully start up our own process. If there is a conflict with another lnd process such as a port that we need already being in use we already handle this elsewhere in our code and we pass more detail to the error message the other way.

## Motivation and Context:

The lnd process lookup is slow, unreliable, and not needed. Remove redundant code that adds unneeded dependencies and improve user experience.

## How Has This Been Tested?

1. Start up an lnd process:
```
lnd --bitcoin.active --bitcoin.testnet --bitcoin.node=neutrino --neutrino.connect=mainnet1-btcd.zaphq.io
```
2. Then start up zap and verify that it gives you an error message, as before (actually we get more specific detail now)

## Screenshots (if appropriate):

**Before:*
<img width="497" alt="screenshot 2018-09-07 01 14 36" src="https://user-images.githubusercontent.com/200251/45190161-bdfc2380-b23c-11e8-912f-688ef97cae52.png">

**After:**
<img width="505" alt="screenshot 2018-09-07 01 14 14" src="https://user-images.githubusercontent.com/200251/45190164-c0f71400-b23c-11e8-83c8-fce959f60707.png">

## Types of changes:

Enhancement

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
