### PR TITLE
fix(log): log lnd stderr output as errors

### DIFF
--- a/app/lib/lnd/neutrino.js
+++ b/app/lib/lnd/neutrino.js
@@ -114,10 +114,9 @@ class Neutrino extends EventEmitter {
     // Listen for when neutrino prints data to stderr.
     this.process.stderr.pipe(split2()).on('data', line => {
       if (process.env.NODE_ENV === 'development') {
-        const level = lndLogGetLevel(line)
-        lndLog[level](line)
-        if (level === 'error') {
-          this.lastError = line.split('[ERR] LTND:')[1]
+        lndLog.error(line)
+        if (line.startsWith('panic:')) {
+          this.lastError = line
         }
       }
     })

--- a/app/lib/lnd/neutrino.js
+++ b/app/lib/lnd/neutrino.js
@@ -113,22 +113,18 @@ class Neutrino extends EventEmitter {
 
     // Listen for when neutrino prints data to stderr.
     this.process.stderr.pipe(split2()).on('data', line => {
-      if (process.env.NODE_ENV === 'development') {
-        lndLog.error(line)
-        if (line.startsWith('panic:')) {
-          this.lastError = line
-        }
+      lndLog.error(line)
+      if (line.startsWith('panic:')) {
+        this.lastError = line
       }
     })
 
     // Listen for when neutrino prints data to stdout.
     this.process.stdout.pipe(split2()).on('data', line => {
-      if (process.env.NODE_ENV === 'development') {
-        const level = lndLogGetLevel(line)
-        lndLog[level](line)
-        if (level === 'error') {
-          this.lastError = line.split('[ERR] LTND:')[1]
-        }
+      const level = lndLogGetLevel(line)
+      lndLog[level](line)
+      if (level === 'error') {
+        this.lastError = line.split('[ERR] LTND:')[1]
       }
 
       // password RPC server listening (wallet unlocker started).

--- a/app/lib/utils/log.js
+++ b/app/lib/utils/log.js
@@ -8,7 +8,7 @@ debugLogger.inspectOptions = {
 // Enable all zap logs if DEBUG has not been explicitly set.
 if (!process.env.DEBUG) {
   // debugLogger.debug.enable('zap:*')
-  process.env.DEBUG = 'zap:main,zap:lnd*,zap:updater'
+  process.env.DEBUG = 'zap:main,zap:lnd,zap:updater'
 }
 if (!process.env.DEBUG_LEVEL) {
   process.env.DEBUG_LEVEL = 'info'
@@ -53,7 +53,7 @@ const logConfig = name => ({
 
 // Create logs for use in the app.
 export const mainLog = debugLogger.config(logConfig('main'))('zap')
-export const lndLog = debugLogger.config(logConfig('lnd '))('zap')
+export const lndLog = debugLogger.config(logConfig('lnd'))('zap')
 export const updaterLog = debugLogger.config(logConfig('updater'))('zap')
 
 let lndLogLevel = null // stored most recent log level for continuity


### PR DESCRIPTION
## Description:

This PR includes three enhancements to our error logging:

1. Ensure that lnd output that goes to the stderr stream gets logged using the error log level and that the cause of the error is captured.

2. Limit the log namespaces that are enabled by default to only include the top level zap namespace and not also all of it's sub-namespaces.

3. Ensure that logs are output when the app is run in production mode. not only development mode so that its easier to diagnose an issue with a production build.

## Motivation and Context:

If lnd has a panic attack, the log messages are not using the proper error level and the cause of the error is not being captured and displayed to the user.

## How Has This Been Tested?

Manual testing with lnd instance that is crashing.

## Screenshots (if appropriate):

**Before:**

<img width="1428" alt="screenshot 2018-09-16 23 05 28" src="https://user-images.githubusercontent.com/200251/45600967-8b54e680-ba05-11e8-9cb7-62658624ae3e.png">

<img width="455" alt="screenshot 2018-09-16 23 10 44" src="https://user-images.githubusercontent.com/200251/45600988-c1926600-ba05-11e8-96a6-d6fc526dd394.png">

**After:**

<img width="1428" alt="screenshot 2018-09-16 23 04 50" src="https://user-images.githubusercontent.com/200251/45600969-8ee86d80-ba05-11e8-8865-f0fb4849992e.png">

<img width="473" alt="screenshot 2018-09-16 23 03 16" src="https://user-images.githubusercontent.com/200251/45600975-9b6cc600-ba05-11e8-9768-ec42202491e5.png">


## Types of changes:

Bug fix

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
