### PR TITLE
fix(validation): improve hostname/ip validation

### DIFF
--- a/app/lib/lnd/util.js
+++ b/app/lib/lnd/util.js
@@ -7,6 +7,7 @@ import { platform } from 'os'
 import { app } from 'electron'
 import isDev from 'electron-is-dev'
 import grpc from 'grpc'
+import isFQDN from 'validator/lib/isFQDN'
 import isIP from 'validator/lib/isIP'
 import isPort from 'validator/lib/isPort'
 import get from 'lodash.get'
@@ -117,7 +118,7 @@ export const validateHost = async host => {
   const lndPort = splits[1]
 
   // If the hostname starts with a number, ensure that it is a valid IP address.
-  if (lndHost.match(/^\d/) && !isIP(lndHost)) {
+  if (!isFQDN(lndHost, { require_tld: false }) && !isIP(lndHost)) {
     const error = new Error(`${lndHost} is not a valid IP address or hostname`)
     error.code = 'LND_GRPC_HOST_ERROR'
     return Promise.reject(error)

--- a/test/unit/__mocks__/dns.js
+++ b/test/unit/__mocks__/dns.js
@@ -1,0 +1,13 @@
+const dns = jest.genMockFromModule('dns')
+
+function lookup(hostname, options, callback = jest.fn()) {
+  let cb = callback
+  if (typeof options === 'function') {
+    cb = options
+  }
+  process.nextTick(cb, null, hostname)
+}
+
+dns.lookup = lookup
+
+module.exports = dns

--- a/test/unit/lnd/util.spec.js
+++ b/test/unit/lnd/util.spec.js
@@ -1,0 +1,19 @@
+import { validateHost } from 'lib/lnd/util'
+
+jest.mock('dns')
+
+describe('Util', function() {
+  describe('validateHost', () => {
+    it('should resolve true for valid hostnames', async () => {
+      await expect(validateHost('example.com')).resolves.toBeTruthy()
+      await expect(validateHost('localhost')).resolves.toBeTruthy()
+      await expect(validateHost('192.168.0.1')).resolves.toBeTruthy()
+      await expect(validateHost('11.111.11.111.rdns.example.com')).resolves.toBeTruthy()
+    })
+    it('should reject for invalid hostnames', async () => {
+      await expect(validateHost('1+-000invlidhost')).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"1+-000invlidhost is not a valid IP address or hostname"`
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Description:

Do not assume that an address that starts with a number is an IP address and expand validation to cover all FQDNs and IP addresses.

## Motivation and Context:

Fix #766

## How Has This Been Tested?

Added some unit tests

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
