### PR TITLE
refactor(styles): use portable scss include path

### DIFF
--- a/app/components/Activity/Activity.scss
+++ b/app/components/Activity/Activity.scss
@@ -1,4 +1,4 @@
-@import '../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .search {
   height: 55px;

--- a/app/components/Activity/ActivityModal/ActivityModal.scss
+++ b/app/components/Activity/ActivityModal/ActivityModal.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .container {
   position: relative;

--- a/app/components/Activity/Countdown/Countdown.scss
+++ b/app/components/Activity/Countdown/Countdown.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .container {
   display: block;

--- a/app/components/Activity/InvoiceModal/InvoiceModal.scss
+++ b/app/components/Activity/InvoiceModal/InvoiceModal.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .container {
   color: $white;

--- a/app/components/Activity/PaymentModal/PaymentModal.scss
+++ b/app/components/Activity/PaymentModal/PaymentModal.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .container {
   color: $white;

--- a/app/components/Activity/Transaction/Transaction.scss
+++ b/app/components/Activity/Transaction/Transaction.scss
@@ -1,4 +1,4 @@
-@import '../../../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .container {
   display: flex;

--- a/app/components/Activity/TransactionModal/TransactionModal.scss
+++ b/app/components/Activity/TransactionModal/TransactionModal.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .container {
   color: $white;

--- a/app/components/App/App.scss
+++ b/app/components/App/App.scss
@@ -1,4 +1,4 @@
-@import '../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .content {
   position: relative;

--- a/app/components/Contacts/AddChannel/AddChannel.scss
+++ b/app/components/Contacts/AddChannel/AddChannel.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .container {
   position: relative;

--- a/app/components/Contacts/ChannelForm/ChannelForm.scss
+++ b/app/components/Contacts/ChannelForm/ChannelForm.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .container {
   position: absolute;

--- a/app/components/Contacts/ConnectManually/ConnectManually.scss
+++ b/app/components/Contacts/ConnectManually/ConnectManually.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .container {
   position: absolute;

--- a/app/components/Contacts/ContactModal/ContactModal.scss
+++ b/app/components/Contacts/ContactModal/ContactModal.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .header {
   display: flex;

--- a/app/components/Contacts/ContactsForm/ContactsForm.scss
+++ b/app/components/Contacts/ContactsForm/ContactsForm.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .modal {
   position: absolute;

--- a/app/components/Contacts/Network/Network.scss
+++ b/app/components/Contacts/Network/Network.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .network {
   position: relative;

--- a/app/components/Contacts/SubmitChannelForm/SubmitChannelForm.scss
+++ b/app/components/Contacts/SubmitChannelForm/SubmitChannelForm.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .content {
   padding: 0 40px;

--- a/app/components/Contacts/SuggestedNodes/SuggestedNodes.scss
+++ b/app/components/Contacts/SuggestedNodes/SuggestedNodes.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .container {
   color: $white;

--- a/app/components/Form/Form.scss
+++ b/app/components/Form/Form.scss
@@ -1,4 +1,4 @@
-@import '../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .container {
   position: absolute;

--- a/app/components/Form/Pay/Pay.scss
+++ b/app/components/Form/Pay/Pay.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .container {
   padding: 0 40px;

--- a/app/components/Form/Request/Request.scss
+++ b/app/components/Form/Request/Request.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .container {
   padding: 0 40px;

--- a/app/components/GlobalError/GlobalError.scss
+++ b/app/components/GlobalError/GlobalError.scss
@@ -1,4 +1,4 @@
-@import '../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .container {
   position: absolute;

--- a/app/components/LoadingBolt/LoadingBolt.scss
+++ b/app/components/LoadingBolt/LoadingBolt.scss
@@ -1,4 +1,4 @@
-@import '../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .container {
   z-index: 1000;

--- a/app/components/Onboarding/Alias/Alias.scss
+++ b/app/components/Onboarding/Alias/Alias.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .alias {
   background: transparent;

--- a/app/components/Onboarding/Autopilot/Autopilot.scss
+++ b/app/components/Onboarding/Autopilot/Autopilot.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .container {
   color: $white;

--- a/app/components/Onboarding/BtcPayServer/BtcPayServer.scss
+++ b/app/components/Onboarding/BtcPayServer/BtcPayServer.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .container {
   color: $white;

--- a/app/components/Onboarding/ConnectionConfirm/ConnectionConfirm.scss
+++ b/app/components/Onboarding/ConnectionConfirm/ConnectionConfirm.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .container {
   color: $white;

--- a/app/components/Onboarding/ConnectionDetails/ConnectionDetails.scss
+++ b/app/components/Onboarding/ConnectionDetails/ConnectionDetails.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .container {
   color: $white;

--- a/app/components/Onboarding/ConnectionType/ConnectionType.scss
+++ b/app/components/Onboarding/ConnectionType/ConnectionType.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .container {
   color: $white;

--- a/app/components/Onboarding/FormContainer/FormContainer.scss
+++ b/app/components/Onboarding/FormContainer/FormContainer.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .container {
   position: relative;

--- a/app/components/Onboarding/InitWallet/InitWallet.scss
+++ b/app/components/Onboarding/InitWallet/InitWallet.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .container {
   position: relative;

--- a/app/components/Onboarding/Login/Login.scss
+++ b/app/components/Onboarding/Login/Login.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .container {
   position: relative;

--- a/app/components/Onboarding/NewWalletPassword/NewWalletPassword.scss
+++ b/app/components/Onboarding/NewWalletPassword/NewWalletPassword.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .input:nth-child(2) {
   margin-top: 30px;

--- a/app/components/Onboarding/NewWalletSeed/NewWalletSeed.scss
+++ b/app/components/Onboarding/NewWalletSeed/NewWalletSeed.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .container {
   font-size: 14px;

--- a/app/components/Onboarding/ReEnterSeed/ReEnterSeed.scss
+++ b/app/components/Onboarding/ReEnterSeed/ReEnterSeed.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .seedContainer {
   display: flex;

--- a/app/components/Onboarding/RecoverForm/RecoverForm.scss
+++ b/app/components/Onboarding/RecoverForm/RecoverForm.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .seedContainer {
   position: relative;

--- a/app/components/Onboarding/Signup/Signup.scss
+++ b/app/components/Onboarding/Signup/Signup.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .container {
   color: $white;

--- a/app/components/Onboarding/Syncing/Syncing.scss
+++ b/app/components/Onboarding/Syncing/Syncing.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .container {
   position: relative;

--- a/app/components/Settings/Fiat/Fiat.scss
+++ b/app/components/Settings/Fiat/Fiat.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .submenuHeader {
   padding: 20px;

--- a/app/components/Wallet/ReceiveModal/ReceiveModal.scss
+++ b/app/components/Wallet/ReceiveModal/ReceiveModal.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .container {
   position: relative;

--- a/app/components/Wallet/Wallet.scss
+++ b/app/components/Wallet/Wallet.scss
@@ -1,4 +1,4 @@
-@import '../../styles/variables.scss';
+@import 'styles/variables.scss';
 
 .wallet {
   background: $bluegrey;

--- a/webpack.config.renderer.dev.dll.js
+++ b/webpack.config.renderer.dev.dll.js
@@ -72,7 +72,10 @@ export default merge.smart(baseConfig, {
             }
           },
           {
-            loader: 'sass-loader'
+            loader: 'sass-loader',
+            options: {
+              includePaths: [path.join(__dirname, 'app')]
+            }
           }
         ]
       },
@@ -93,7 +96,10 @@ export default merge.smart(baseConfig, {
             }
           },
           {
-            loader: 'sass-loader'
+            loader: 'sass-loader',
+            options: {
+              includePaths: [path.join(__dirname, 'app')]
+            }
           }
         ]
       },

--- a/webpack.config.renderer.dev.js
+++ b/webpack.config.renderer.dev.js
@@ -115,7 +115,11 @@ export default merge.smart(baseConfig, {
             }
           },
           {
-            loader: 'sass-loader'
+            loader: 'sass-loader',
+            options: {
+              sourceMap: true,
+              includePaths: [path.join(__dirname, 'app')]
+            }
           }
         ]
       },
@@ -136,7 +140,11 @@ export default merge.smart(baseConfig, {
             }
           },
           {
-            loader: 'sass-loader'
+            loader: 'sass-loader',
+            options: {
+              sourceMap: true,
+              includePaths: [path.join(__dirname, 'app')]
+            }
           }
         ]
       },

--- a/webpack.config.renderer.prod.js
+++ b/webpack.config.renderer.prod.js
@@ -59,7 +59,10 @@ export default merge.smart(baseConfig, {
               loader: 'css-loader'
             },
             {
-              loader: 'sass-loader'
+              loader: 'sass-loader',
+              options: {
+                includePaths: [path.join(__dirname, 'app')]
+              }
             }
           ],
           fallback: 'style-loader'
@@ -79,7 +82,10 @@ export default merge.smart(baseConfig, {
               }
             },
             {
-              loader: 'sass-loader'
+              loader: 'sass-loader',
+              options: {
+                includePaths: [path.join(__dirname, 'app')]
+              }
             }
           ]
         })


### PR DESCRIPTION
## Description:

Rather than using relative paths for css imports - which can break when we move files around - add our styles path to the webpack sass-loader loader using the `includePaths` setting.

## Motivation and Context:

Moving files around in the codebase can break css includes.

## How Has This Been Tested?

Build and run app and verify styles load correctly.

## Types of changes:

Enhancement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
