### PR TITLE
Ci/prevent duplicate builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,10 @@ script:
   - yarn test-ci || travis_terminate 1
   - yarn coveralls || travis_terminate 1
 
+branches:
+  only:
+    - master
+
 jobs:
   include:
     - stage: deploy

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,8 @@ shallow_clone: true
 
 clone_depth: 1
 
+skip_branch_with_pr: true
+
 install:
   - ps: Install-Product node $env:nodejs_version
   - set CI=true


### PR DESCRIPTION
## Description:

Ensure that PRs do not trigger duplicate builds when created from a branch on the primary/LN-Zap repo.

## Motivation and Context:

When raising a PR from a branch on the LN-Zap repo we get duplicate builds happening on travis/appveyor. One for the branch, and then another for the PR.

## Types of changes:

CI improvement

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
