### PR TITLE
test(coverage): disable text coverage reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,6 @@
     "coverageReporters": [
       "json",
       "lcov",
-      "text",
       "html"
     ],
     "moduleNameMapper": {


### PR DESCRIPTION
## Description:

We already have the html reporter setup and an npm script to enable easy viewing of the data (`yarn coverage`) so the text reporter isn't adding anything useful.

## Motivation and Context:

The text coverage reporter generates a lot of output that makes it hard to see the actual test results without scrolling up a lot first.

## How Has This Been Tested?

- Run tests
- Verify that test coverage output only show summary report and not full details.
- Verify that full coverage report can be accessed by running `yarn coverage`

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes:

Test improvements

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
