### PR TITLE
ci(appveyor): remove node/yarn caches

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,11 +8,9 @@ environment:
     - nodejs_version: LTS
 
 cache:
-  - '%APPDATA%\npm-cache'
-  - "%LOCALAPPDATA%/Yarn"
   - node_modules -> package.json
-  - flow-typed
   - app/node_modules -> app/package.json
+  - flow-typed
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
## Description:

Remove the node and yarn caches on travis/appveyor They are rarely ever used and take several minutes to restore and unzip at the start of every build

## Motivation and Context:

If package.json changes that will trigger a rebuild of the node_modules. package.json changes fairly infrequently. Caching node_modules is enough and we don't also need to cache the npm/yarn caches in addition.

Caching npm and yarn caches adds a lot of extra time to builds unnecessarily. It takes several minutes to restore these directories from the cache and unzip them into place and they are not used 90% of the time. The only time they would be used is if package.json changed and that was triggering a rebuild of node_modules, in which case installing with a clean npm/yarn cache may be preferable to using an old npm/yarn cache.

## How Has This Been Tested?

Ensure builds pass on ci and compare builds times before/after

## Types of changes:

CI improvements

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
