### PR TITLE
build(flow): ignore config-chain/test/broken.json

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -7,6 +7,7 @@
 <PROJECT_ROOT>/dll/.*
 <PROJECT_ROOT>/release/.*
 <PROJECT_ROOT>/.git/.*
+.*/node_modules/config-chain/test/broken.json
 
 [include]
 


### PR DESCRIPTION
## Description:

Ignore invalid json files in flow config to prevent expected failures from producing errors.

See https://github.com/facebook/flow/issues/869

## Motivation and Context:

We are getting this error when running flow:
```
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ node_modules/npm/node_modules/config-chain/test/broken.json:11:3

Unexpected string

      8│     "url": "https://github.com/dominictarr/config-chain.git"
      9│   }
     10│   //missing , and then this comment. this json is intensionally invalid
     11│   "dependencies": {
     12│     "proto-list": "1",
     13│     "ini": "~1.0.2"
     14│   },
```

See https://github.com/facebook/flow/issues/2364

## How Has This Been Tested?

run `yarn flow` and verify error is no longer produced,

## Screenshots (if appropriate):

## Types of changes:

Bug fix

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
