### PR TITLE
test(jest): run jest with --forceExit flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "start-main-dev": "cross-env HOT=1 NODE_ENV=development electron -r babel-register ./app/main.dev",
     "start-renderer-dev": "node --trace-warnings -r babel-register ./node_modules/webpack-serve/lib/cli.js --config internals/webpack/webpack.config.renderer.dev.js",
     "test": "npm run lint && npm run lint-styles && npm run flow && npm run build && npm run test-unit && npm run test-e2e",
-    "test-base": "cross-env NODE_ENV=test BABEL_DISABLE_CACHE=true ELECTRON_DISABLE_SECURITY_WARNINGS=true node --trace-warnings ./node_modules/jest/bin/jest",
+    "test-base": "cross-env NODE_ENV=test BABEL_DISABLE_CACHE=true ELECTRON_DISABLE_SECURITY_WARNINGS=true node --trace-warnings ./node_modules/jest/bin/jest --forceExit",
     "test-unit": "npm run test-base -- ./test/unit",
     "test-e2e": "npm run test-base -- ./test/e2e",
     "test-ci": "npm run test-e2e && npm run test-unit"


### PR DESCRIPTION
## Description:

Run jest with --forceExit flag to prevent stuck builds on CI.

## Motivation and Context:

Jest is sometimes unable to detect when tests have completed which can result in tests hanging indefinitely, which breaks our CI builds on Appveyor.

This is a known issue in jest and they added a `forceExit` in order to help users facing this issue.

See https://github.com/facebook/jest/issues/1456

## Types of changes:

CI improvement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
