### PR TITLE
test(coverage): coverage only for unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test": "npm run lint && npm run lint-styles && npm run flow && npm run build && npm run test-unit && npm run test-e2e",
     "test-base": "cross-env NODE_ENV=test BABEL_DISABLE_CACHE=true ELECTRON_DISABLE_SECURITY_WARNINGS=true node --trace-warnings ./node_modules/jest/bin/jest --forceExit",
     "test-unit": "npm run test-base -- ./test/unit",
+    "test-unit": "npm run test-base -- --coverage ./test/unit",
     "test-e2e": "npm run test-base -- ./test/e2e",
     "test-ci": "npm run test-e2e && npm run test-unit"
   },
@@ -160,7 +161,6 @@
   ],
   "homepage": "https://github.com/LN-Zap/zap-desktop#readme",
   "jest": {
-    "collectCoverage": true,
     "collectCoverageFrom": [
       "app/**/*.js",
       "!app/dist/**",


### PR DESCRIPTION
## Description:

Coverage tests are only relevant for the unit tests and do not work in the context of the e2e test suite. Only generate coverage reports for the unit tests.

## Motivation and Context:

Coverage reports take some time to generate so there is no point in trying to generate them for the e2e tests since that is not supported.

## How Has This Been Tested?

- Run e2e tests and verify coverage reports are not generated.
- Run unit tests and verify coverage reports are generated.

## Types of changes:

Test improvements

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
