### PR TITLE
chore(deps): remove react-addons-test-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -261,7 +261,6 @@
     "node-sass": "^4.9.3",
     "per-env": "^1.0.2",
     "prettier": "^1.14.2",
-    "react-addons-test-utils": "^15.6.2",
     "react-test-renderer": "^16.5.1",
     "redux-logger": "^3.0.6",
     "rimraf": "^2.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10214,10 +10214,6 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-addons-test-utils@^15.6.2:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.6.2.tgz#c12b6efdc2247c10da7b8770d185080a7b047156"
-
 react-dom@^16.5.1:
   version "16.5.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.5.1.tgz#29d0c5a01ed3b6b4c14309aa91af6ec4eb4f292c"


### PR DESCRIPTION
## Description:

react-addons-test-utils is depreciated, no longer used by us, and produces warnings on install.
