### PR TITLE
fix(i18n): parse fiat amounts to number type

### DIFF
--- a/app/lib/utils/btc.js
+++ b/app/lib/utils/btc.js
@@ -2,12 +2,6 @@
 
 import sb from 'satoshi-bitcoin'
 
-////////////////
-// Helpers /////
-////////////////
-
-const numberWithCommas = x => x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
-
 //////////////////////
 // BTC to things /////
 /////////////////////
@@ -24,8 +18,9 @@ export function btcToBits(btc) {
 }
 
 export function btcToFiat(btc, price) {
-  const amount = parseFloat(btc * price).toFixed(2)
-  return btc > 0 && amount <= 0 ? '< 0.01' : numberWithCommas(amount)
+  if (btc === undefined || btc === null || btc === '') return null
+
+  return parseFloat(btc * price)
 }
 
 ////////////////////////////


### PR DESCRIPTION
## Description:

We need to pass a number to `<FormattedNumber>` for it to properly display the currency values. In some cases we were passing a pre-formatted string which was causing some currency amount to render as NaN.

## Motivation and Context:

Currency values showing as `NaN`

## How Has This Been Tested?

Manually test app

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
