### PR TITLE
fix(wallet): hide zero channel balance

### DIFF
--- a/app/components/Contacts/Network/Network.js
+++ b/app/components/Contacts/Network/Network.js
@@ -173,12 +173,14 @@ class Network extends Component {
               <FormattedMessage {...messages.title} />
             </h2>
             <span className={styles.channelAmount}>
-              <Value
-                value={balance.channelBalance}
-                currency={ticker.currency}
-                currentTicker={currentTicker}
-                fiatTicker={ticker.fiatTicker}
-              />
+              {Boolean(balance.channelBalance) && (
+                <Value
+                  value={balance.channelBalance}
+                  currency={ticker.currency}
+                  currentTicker={currentTicker}
+                  fiatTicker={ticker.fiatTicker}
+                />
+              )}
               {Boolean(fiatAmount) && (
                 <span>
                   {'≈ '}


### PR DESCRIPTION
## Description:

If the total channel balance is zero, do not show the channel balance at the top of the network view as the zero doesn't convey any useful information and looks strange.

## How Has This Been Tested?

Manually test app

## Screenshots (if appropriate):

**Before:**
<img width="284" alt="screenshot 2018-09-19 18 52 03" src="https://user-images.githubusercontent.com/200251/45768617-ac078100-bc3d-11e8-8313-2090f9e14488.png">

**After:**
<img width="283" alt="screenshot 2018-09-19 18 51 43" src="https://user-images.githubusercontent.com/200251/45768603-a316af80-bc3d-11e8-92fc-a110cd807b08.png">

## Types of changes:

UX improvement

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
