### PR TITLE
fix(channels): fetch in activity mount not app

### DIFF
--- a/app/components/Activity/Activity.js
+++ b/app/components/Activity/Activity.js
@@ -28,12 +28,19 @@ class Activity extends Component {
   }
 
   componentWillMount() {
-    const { fetchPayments, fetchInvoices, fetchTransactions, fetchBalance } = this.props
+    const {
+      fetchPayments,
+      fetchInvoices,
+      fetchTransactions,
+      fetchBalance,
+      fetchChannels
+    } = this.props
 
     fetchBalance()
     fetchPayments()
     fetchInvoices()
     fetchTransactions()
+    fetchChannels()
   }
 
   renderActivity(activity) {
@@ -231,6 +238,7 @@ Activity.propTypes = {
   fetchInvoices: PropTypes.func.isRequired,
   fetchTransactions: PropTypes.func.isRequired,
   fetchBalance: PropTypes.func.isRequired,
+  fetchChannels: PropTypes.func.isRequired,
 
   ticker: PropTypes.object.isRequired,
   currentTicker: PropTypes.object.isRequired,

--- a/app/components/App/App.js
+++ b/app/components/App/App.js
@@ -16,25 +16,14 @@ import styles from './App.scss'
 
 class App extends Component {
   componentWillMount() {
-    const {
-      fetchTicker,
-      fetchInfo,
-      fetchChannels,
-      fetchSuggestedNodes,
-      fetchBalance,
-      fetchDescribeNetwork
-    } = this.props
+    const { fetchTicker, fetchInfo, fetchSuggestedNodes, fetchDescribeNetwork } = this.props
 
     // fetch price ticker
     fetchTicker()
     // fetch node info
     fetchInfo()
-    // fetch nodes channels
-    fetchChannels()
     // fetch suggested nodes list from zap.jackmallers.com/suggested-peers
     fetchSuggestedNodes()
-    // fetch nodes balance
-    fetchBalance()
     // fetch LN network from nides POV
     fetchDescribeNetwork()
   }
@@ -104,8 +93,6 @@ App.propTypes = {
   fetchInfo: PropTypes.func.isRequired,
   fetchTicker: PropTypes.func.isRequired,
   clearError: PropTypes.func.isRequired,
-  fetchChannels: PropTypes.func.isRequired,
-  fetchBalance: PropTypes.func.isRequired,
   fetchDescribeNetwork: PropTypes.func.isRequired,
   fetchSuggestedNodes: PropTypes.func.isRequired,
 

--- a/app/containers/Activity.js
+++ b/app/containers/Activity.js
@@ -2,6 +2,7 @@ import { connect } from 'react-redux'
 import { setLocale } from 'reducers/locale'
 import { setCurrency, setFiatTicker, tickerSelectors } from 'reducers/ticker'
 import { fetchBalance } from 'reducers/balance'
+import { fetchChannels } from 'reducers/channels'
 import { fetchInvoices, setInvoice, invoiceSelectors } from 'reducers/invoice'
 import { setPayment, fetchPayments, paymentSelectors } from 'reducers/payment'
 import { fetchTransactions } from 'reducers/transaction'
@@ -43,6 +44,7 @@ const mapDispatchToProps = {
   walletAddress,
   openWalletModal,
   fetchBalance,
+  fetchChannels,
   updateSearchActive,
   updateSearchText,
   setFormType,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:

Call `fetchChannels` from the `Activity` `componentWillMount` not in the `App.js` callback 
<!--- Describe your changes in detail -->

## Motivation and Context:

`App.js` `componentWillMount` callback gets called before we signal to the state machine that we are fully synced. `Activity.js` callback is where we call for all other app related user node data and only renders afterwards. In this PR we move the `fetchChannels` call to `Activity.js` so that it can be received by `ipcMain` and return us channel data.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Run the app on master and see the issue, run this PR and see it's fixed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes:

<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
