### PR TITLE
fix(channels): use currencyName in req_limit

### DIFF
--- a/app/components/Contacts/Network/Network.js
+++ b/app/components/Contacts/Network/Network.js
@@ -339,7 +339,7 @@ class Network extends Component {
                               currentTicker={currentTicker}
                               fiatTicker={ticker.fiatTicker}
                             />
-                            <i>{ticker.currency.toUpperCase()}</i>
+                            <i> {currencyName}</i>
                           </p>
                         </section>
                       </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:

Use `currencyName` in the req limit
<!--- Describe your changes in detail -->

## Motivation and Context:

The req limit was using capitalized `SATS`, `BITS` and `BTC` which is old and not used by the rest of the app
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes:

<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

