### PR TITLE
fix(channels): display currencyName in network

### DIFF
--- a/app/components/Contacts/Network/Network.js
+++ b/app/components/Contacts/Network/Network.js
@@ -174,16 +174,19 @@ class Network extends Component {
             </h2>
             <span className={styles.channelAmount}>
               {Boolean(balance.channelBalance) && (
-                <Value
-                  value={balance.channelBalance}
-                  currency={ticker.currency}
-                  currentTicker={currentTicker}
-                  fiatTicker={ticker.fiatTicker}
-                />
+                <span>
+                  <Value
+                    value={balance.channelBalance}
+                    currency={ticker.currency}
+                    currentTicker={currentTicker}
+                    fiatTicker={ticker.fiatTicker}
+                  />
+                  <i> {currencyName}</i>
+                </span>
               )}
               {Boolean(fiatAmount) && (
                 <span>
-                  {'≈ '}
+                  {' ≈ '}
                   <FormattedNumber
                     currency={ticker.fiatTicker}
                     style="currency"


### PR DESCRIPTION
## Description:

Display the currency name (BTC/tBTC etc) next to the amount that shows at the top of the network view.

## Motivation and Context:

We weren't showing the currency name, leaving up to the user to guess what the number meant.

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):

**Before:**
<img width="286" alt="screenshot 2018-09-20 15 08 15" src="https://user-images.githubusercontent.com/200251/45820797-e88fb700-bce7-11e8-8814-4ca22f596846.png">


**After:**
<img width="284" alt="screenshot 2018-09-20 15 09 43" src="https://user-images.githubusercontent.com/200251/45820801-ec233e00-bce7-11e8-88ae-71273a75b668.png">


## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
