### PR TITLE
fix(channels): fetch channels after peer connections

### DIFF
--- a/app/components/Activity/Activity.js
+++ b/app/components/Activity/Activity.js
@@ -41,6 +41,9 @@ class Activity extends Component {
     fetchInvoices()
     fetchTransactions()
     fetchChannels()
+
+    // HACK: wait 10 seconds and fetch channels again, allowing the node to establish connections with the remote party
+    setTimeout(() => fetchChannels(), 10000)
   }
 
   renderActivity(activity) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
[HACK] Call `fetchChannels` again after a 10 second timeout giving the node time to establish connections to the remote parties of its channels

<!--- Describe your changes in detail -->

`setTimeout` 10 second `fetchChannels` call

## Motivation and Context:
Local nodes would have their channel view look like they have a bunch of offline channels as we fetch the channels before the node can connect to channel peers. This is a for-the-time-being hack so that the channel list is more accurate
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes:

<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
