### PR TITLE
fix(wallet): dereference window after closing

### DIFF
--- a/app/lib/zap/controller.js
+++ b/app/lib/zap/controller.js
@@ -112,6 +112,12 @@ class ZapController {
         this.mainWindow.hide()
       }
     })
+
+    // Dereference the window object, usually you would store windows in an array if your app supports multi windows,
+    // this is the time when you should delete the corresponding element.
+    this.mainWindow.on('closed', () => {
+      this.mainWindow = null
+    })
   }
 
   // ------------------------------------

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -109,7 +109,9 @@ app.on('ready', () => {
       event.preventDefault()
       zap.terminate()
     } else {
-      zap.mainWindow.forceClose = true
+      if (zap.mainWindow) {
+        zap.mainWindow.forceClose = true
+      }
     }
   })
 


### PR DESCRIPTION
## Description:

Dereference the main window after it has been closed in order to prevent messages from being set to it when it no longer exists.

## Motivation and Context:

On windows / Linux, if a message is sent to the mainWindow after it has been closed it causes an error to pop up in the users face.

## How Has This Been Tested?

Manually on Linux

## Types of changes:

Bug fix

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
