### PR TITLE
feat(lnd): use free port for lnd

### DIFF
--- a/app/lib/zap/controller.js
+++ b/app/lib/zap/controller.js
@@ -353,7 +353,7 @@ class ZapController {
       this.sendMessage('lndCfilterHeight', Number(height))
     })
 
-    this.neutrino.start()
+    return this.neutrino.start()
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -292,6 +292,7 @@
     "electron-is-dev": "^0.3.0",
     "electron-store": "^2.0.0",
     "font-awesome": "^4.7.0",
+    "get-port": "^4.0.0",
     "history": "^4.7.2",
     "javascript-state-machine": "^3.1.0",
     "jstimezonedetect": "^1.0.6",

--- a/test/unit/lnd/neutrino.spec.js
+++ b/test/unit/lnd/neutrino.spec.js
@@ -179,9 +179,9 @@ describe('Neutrino', function() {
 
   describe('.start', () => {
     describe('called when neutrino is not running', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         this.neutrino = new Neutrino(new LndConfig())
-        this.neutrino.start()
+        await this.neutrino.start()
       })
       it('should set the subprocess object on the `process` property', () => {
         expect(this.neutrino.process.pid).toBeDefined()
@@ -193,10 +193,10 @@ describe('Neutrino', function() {
         this.neutrino = new Neutrino(new LndConfig())
         this.neutrino.process = mockSpawn()
       })
-      it('should throw an error', () => {
-        expect(() => {
-          this.neutrino.start()
-        }).toThrow()
+      it('should throw an error', async () => {
+        await expect(this.neutrino.start()).rejects.toThrowErrorMatchingInlineSnapshot(
+          `"Neutrino process with PID \${this.process.pid} already exists."`
+        )
       })
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5571,6 +5571,10 @@ get-port@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-3.2.0.tgz#dd7ce7de187c06c8bf353796ac71e099f0980ebc"
 
+get-port@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/get-port/-/get-port-4.0.0.tgz#373c85960138ee20027c070e3cb08019fea29816"
+
 get-stdin@5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"


### PR DESCRIPTION
## Description:

Select free ports for lnd from a pool of options. By default we will use the standard lnd ports (10009 and 9735) but if those are not available then we will search for free ports in a nearby range.

## Motivation and Context:

This allows us to have multiple instances of the wallet running and avoids possible conflicts with other instances of lnd that the user may be running.

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):

## Types of changes:

Enhancement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
