### PR TITLE
style(sync): vertically centre sync page title

### DIFF
--- a/app/components/Onboarding/Syncing/Syncing.js
+++ b/app/components/Onboarding/Syncing/Syncing.js
@@ -96,7 +96,7 @@ class Syncing extends Component {
           </header>
 
           {hasSynced === true && (
-            <div>
+            <div className={styles.hasNotSynced}>
               <div className={styles.title}>
                 <h1>
                   <FormattedMessage {...messages.sync_title} />
@@ -105,14 +105,11 @@ class Syncing extends Component {
                   <FormattedMessage {...messages.sync_description} />
                 </p>
               </div>
-              <div className={styles.loading}>
-                <div className={styles.spinner} />
-              </div>
             </div>
           )}
 
           {hasSynced === false && (
-            <div>
+            <div className={styles.hasSynced}>
               <div className={styles.title}>
                 <h1>
                   <FormattedMessage {...messages.fund_title} />

--- a/app/components/Onboarding/Syncing/Syncing.scss
+++ b/app/components/Onboarding/Syncing/Syncing.scss
@@ -24,9 +24,6 @@
   }
 
   .title {
-    margin: 30px;
-    background: var(--darkestBackground);
-
     h1 {
       font-size: 20px;
       margin-bottom: 20px;
@@ -35,6 +32,14 @@
     p {
       font-size: 12px;
     }
+  }
+
+  .hasNotSynced .title {
+    margin: 95px;
+  }
+
+  .hasSynced .title {
+    margin: 30px;
   }
 
   .address {


### PR DESCRIPTION
## Description:

If we are syncing after having already completed the initial sync we do not show the funding address QR code. In this case, adjust the title padding so that the page title is better centred.

## Motivation and Context:

The sync page looks a little off when syncing a wallet that has already synced at least once.

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):

**Before:**
![loginwindow-before](https://user-images.githubusercontent.com/200251/45865653-83d36b80-bd7e-11e8-9d10-7a4005af8478.png)

**After:**
![loginwindow-after](https://user-images.githubusercontent.com/200251/45865660-8930b600-bd7e-11e8-99c7-ffe7f9cc9f58.png)

## Types of changes:

Style adjustment

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
