### PR TITLE
fix(wallet): hide expired toggle for empty wallet

### DIFF
--- a/app/components/Activity/Activity.js
+++ b/app/components/Activity/Activity.js
@@ -218,17 +218,18 @@ class Activity extends Component {
                 </ul>
               </li>
             ))}
-            {showExpiredToggle && (
-              <li>
-                <div className={styles.toggleExpired} onClick={toggleExpiredRequests}>
-                  {showExpiredRequests ? (
-                    <FormattedMessage {...messages.hide_expired} />
-                  ) : (
-                    <FormattedMessage {...messages.show_expired} />
-                  )}
-                </div>
-              </li>
-            )}
+            {showExpiredToggle &&
+              currentActivity.length > 0 && (
+                <li>
+                  <div className={styles.toggleExpired} onClick={toggleExpiredRequests}>
+                    {showExpiredRequests ? (
+                      <FormattedMessage {...messages.hide_expired} />
+                    ) : (
+                      <FormattedMessage {...messages.show_expired} />
+                    )}
+                  </div>
+                </li>
+              )}
           </ul>
         </div>
       </div>


### PR DESCRIPTION
## Description:

Hide the "show / hide expired" toggle for new users with no previous activity.

## Motivation and Context:

For new users with an empty wallet it doesn't make any sense that in middle of the activity list there is a toggle button to show/hide expired requests, since we know the user has no requests.

## How Has This Been Tested?

Manually

## Types of changes:

UI/UX improvement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
