### PR TITLE
fix(utils): dont pass non-whole num to toBitcoin()

### DIFF
--- a/app/lib/utils/btc.js
+++ b/app/lib/utils/btc.js
@@ -54,7 +54,10 @@ export function bitsToFiat(bits, price) {
 export function satoshisToBtc(satoshis) {
   if (satoshis === undefined || satoshis === null || satoshis === '') return null
 
-  const btcAmount = sb.toBitcoin(satoshis).toFixed(8)
+  // Make sure we are not passing a non-whole number to sb.toBitcoin(). If the number isn't whole we round up
+  const numSats = satoshis % 1 === 0 ? satoshis : Math.ceil(satoshis)
+
+  const btcAmount = sb.toBitcoin(numSats).toFixed(8)
   return btcAmount > 0 ? btcAmount : btcAmount * -1
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:

Fix an app crash where the user had inputted some non-whole amount in BTC then tried to switch to satoshi. We fix this crash by rounding up if the number is not whole before calling `toBitcoin()`

<!--- Describe your changes in detail -->

## Motivation and Context:
Before this commit the app would crash if a user switched to satoshis while there was an input amount of some non-whole number (for example `0.1`)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
You can verify the big in master by clicking into the pay form, setting the amount to 0.1 BTC, exiting the form and changing the app to satoshis. The app will crash. 

Then you can checkout to this PR and verify it no longer crashes 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes:

<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
