### PR TITLE
ci(jest): set maxWorkers to 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "start-main-dev": "cross-env HOT=1 NODE_ENV=development electron -r babel-register ./app/main.dev",
     "start-renderer-dev": "node --trace-warnings -r babel-register ./node_modules/webpack-serve/lib/cli.js --config internals/webpack/webpack.config.renderer.dev.js",
     "test": "npm run lint && npm run lint-styles && npm run flow && npm run build && npm run test-unit && npm run test-e2e",
-    "test-base": "cross-env NODE_ENV=test BABEL_DISABLE_CACHE=true ELECTRON_DISABLE_SECURITY_WARNINGS=true node --trace-warnings ./node_modules/jest/bin/jest --forceExit",
+    "test-base": "cross-env NODE_ENV=test BABEL_DISABLE_CACHE=true ELECTRON_DISABLE_SECURITY_WARNINGS=true node --trace-warnings ./node_modules/jest/bin/jest --maxWorkers=2",
     "test-unit": "npm run test-base -- --coverage ./test/unit",
     "test-e2e": "npm run test-base -- ./test/e2e",
     "test-ci": "npm run test-e2e && npm run test-unit"

--- a/test/e2e/e2e.spec.js
+++ b/test/e2e/e2e.spec.js
@@ -16,9 +16,9 @@ describe('main window', function spec() {
     await this.app.client.waitUntilWindowLoaded()
   })
 
-  afterAll(() => {
+  afterAll(async () => {
     if (this.app && this.app.isRunning()) {
-      return this.app.stop()
+      await this.app.stop()
     }
   })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:

Jest process doesn’t quit after last test completes. This can cause our tests to fail sometimes, particularly on on Appveyor.

As an attempt to get past this previously we had set `--forceExit` in our jest cli options, but this doesn't always work either.

Further research suggests that setting ``--maxWorkers=2` could resolve the issue.

See
 - https://github.com/facebook/jest/issues/1456#issuecomment-424356243
 - https://github.com/facebook/jest/blob/master/docs/Troubleshooting.md

Fix #774, Fix #773

## How Has This Been Tested?

Run e2e tests locally and on CI.

## Types of changes:

CI improvement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
