### PR TITLE
fix(lnd): show error on problem connecting to lnd

### DIFF
--- a/app/containers/Root.js
+++ b/app/containers/Root.js
@@ -4,6 +4,9 @@ import { ConnectedRouter } from 'react-router-redux'
 import { Switch, Route } from 'react-router'
 import PropTypes from 'prop-types'
 import { hot } from 'react-hot-loader'
+import GlobalError from 'components/GlobalError'
+
+import { clearError } from 'reducers/error'
 
 import {
   setConnectionType,
@@ -40,6 +43,7 @@ import App from './App'
 import Activity from './Activity'
 
 const mapDispatchToProps = {
+  clearError,
   setConnectionType,
   setConnectionString,
   setConnectionHost,
@@ -73,6 +77,7 @@ const mapStateToProps = state => ({
   theme: state.settings.theme,
   balance: state.balance,
   currentTicker: tickerSelectors.currentTicker(state),
+  error: state.error,
   syncPercentage: lndSelectors.syncPercentage(state),
   passwordIsValid: onboardingSelectors.passwordIsValid(state),
   passwordMinCharsError: onboardingSelectors.passwordMinCharsError(state),
@@ -218,7 +223,16 @@ class Root extends Component {
   }
 
   render() {
-    const { balance, currentTicker, history, lnd, onboardingProps, syncingProps } = this.props
+    const {
+      balance,
+      clearError,
+      currentTicker,
+      error: { error },
+      history,
+      lnd,
+      onboardingProps,
+      syncingProps
+    } = this.props
 
     if (!onboardingProps.onboarding.onboarded) {
       return (
@@ -227,6 +241,7 @@ class Root extends Component {
             theme={onboardingProps.theme}
             visible={!onboardingProps.onboarding.onboarding}
           />
+          <GlobalError error={error} clearError={clearError} />
           <Onboarding {...onboardingProps} />
           <Syncing {...syncingProps} />
         </div>
@@ -267,6 +282,8 @@ class Root extends Component {
 
 Root.propTypes = {
   balance: PropTypes.object.isRequired,
+  clearError: PropTypes.func.isRequired,
+  error: PropTypes.object.isRequired,
   fetchTicker: PropTypes.func.isRequired,
   currentTicker: PropTypes.object,
   history: PropTypes.object.isRequired,

--- a/app/reducers/onboarding.js
+++ b/app/reducers/onboarding.js
@@ -2,6 +2,7 @@ import { createSelector } from 'reselect'
 import { ipcRenderer } from 'electron'
 import get from 'lodash.get'
 import { fetchInfo } from './info'
+import { setError } from './error'
 
 // ------------------------------------
 // Constants
@@ -292,14 +293,19 @@ export const startOnboarding = (event, lndConfig = {}) => dispatch => {
 
 // Listener for errors connecting to LND gRPC
 export const startLndError = (event, errors) => (dispatch, getState) => {
-  dispatch(setStartLndError(errors))
   const connectionType = connectionTypeSelector(getState())
 
   switch (connectionType) {
+    case 'local':
+      dispatch(setError(errors))
+      dispatch({ type: CHANGE_STEP, step: 0.1 })
+      break
     case 'custom':
+      dispatch(setStartLndError(errors))
       dispatch({ type: CHANGE_STEP, step: 0.2 })
       break
     case 'btcpayserver':
+      dispatch(setStartLndError(errors))
       dispatch({ type: CHANGE_STEP, step: 0.3 })
       break
   }


### PR DESCRIPTION
## Description:

If there is a problem connecting to the Lightning interface on a local lnd instance, return the user to the onboarding screen and show the user the error message.

## Motivation and Context:

Previously, the app would hang on an infinite loading screen.

## How Has This Been Tested?

Simulate a problem connecting to the Lightning interface when using the local lnd by changing the connection deadline from 20 seconds to 0 seconds here https://github.com/LN-Zap/zap-desktop/blob/master/app/lib/lnd/lightning.js#L102 and trying to start up zap in the default mode.

You should be returned to the onboarding screen with the error message shown as a global error.

## Screenshots (if appropriate):

<img width="962" alt="screen shot 2018-10-01 at 10 30 21" src="https://user-images.githubusercontent.com/200251/46278932-fbb44980-c567-11e8-8963-c37cc8da895f.png">

## Types of changes:

Bug fix

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
