### PR TITLE
fix(ui): ensure settings menu shows on top

### DIFF
--- a/app/components/Contacts/ChannelForm/ChannelForm.scss
+++ b/app/components/Contacts/ChannelForm/ChannelForm.scss
@@ -3,7 +3,7 @@
 .container {
   position: absolute;
   top: 0;
-  z-index: z("contact-form", "modal");
+  z-index: z('contact-form', 'modal');
   height: 100vh;
   width: 100%;
   background: var(--darkestBackground);

--- a/app/components/Contacts/ConnectManually/ConnectManually.scss
+++ b/app/components/Contacts/ConnectManually/ConnectManually.scss
@@ -3,7 +3,7 @@
 .container {
   position: absolute;
   top: 0;
-  z-index: z("connect-form", "modal");
+  z-index: z('connect-form', 'modal');
   height: 100vh;
   width: 100%;
   background: red;

--- a/app/components/Contacts/Network/Network.scss
+++ b/app/components/Contacts/Network/Network.scss
@@ -83,7 +83,7 @@
         display: block;
         position: absolute;
         margin-top: 0;
-        z-index: z("network-filters", "open");
+        z-index: z('network-filters', 'open');
 
         li {
           margin: 10px 0;

--- a/app/components/Form/Form.scss
+++ b/app/components/Form/Form.scss
@@ -3,7 +3,7 @@
 .container {
   position: absolute;
   top: 0;
-  z-index: z("form", "container");
+  z-index: z('form', 'container');
   height: 100vh;
   width: 100%;
   background: var(--lightestBackground);

--- a/app/components/Settings/Settings.scss
+++ b/app/components/Settings/Settings.scss
@@ -1,10 +1,12 @@
+@import 'styles/variables.scss';
+
 .container {
   background: var(--lightestBackground);
   position: absolute;
   width: 200px;
   top: 30px;
   left: -100px;
-  z-index: z("settings-form", "modal");
+  z-index: z('settings-form', 'modal');
 
   li {
     padding: 20px;

--- a/app/styles/tooltip.scss
+++ b/app/styles/tooltip.scss
@@ -1,3 +1,5 @@
+@import 'styles/variables.scss';
+
 /* Tooltips */
 [data-hint] {
   position: relative;
@@ -11,7 +13,7 @@
   will-change: transform;
   visibility: hidden;
   opacity: 0;
-  z-index: z("tooltip", "after");
+  z-index: z('tooltip', 'after');
   pointer-events: none;
   transition: 0.2s ease;
   transition-delay: 0ms;
@@ -22,7 +24,7 @@
   position: absolute;
   background: transparent;
   border: 6px solid transparent;
-  z-index: z("tooltip", "before");
+  z-index: z('tooltip', 'before');
 }
 
 [data-hint]::after {


### PR DESCRIPTION
## Description:

Ensure that we import styles/variables.scss before attempting to use the z() helper function that it provides.

## Motivation and Context:

Several of our elements were missing z-index property, causing them to display incorrectly in the app.

## How Has This Been Tested?

Manually verify z-index ordering is correct throughout the app.

## Screenshots (if appropriate):

**Before:**

<img width="346" alt="screenshot 2018-10-14 15 12 16" src="https://user-images.githubusercontent.com/200251/46917446-b2341780-cfc7-11e8-8f0d-8e1a860508c1.png">

**After:**

<img width="382" alt="screenshot 2018-10-14 15 37 34" src="https://user-images.githubusercontent.com/200251/46917447-b4967180-cfc7-11e8-8884-812243c28435.png">

## Types of changes:

Bug fix

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
