### PR TITLE
fix(ui): strip trailing zeros from currency values

### DIFF
--- a/app/components/Value/Value.js
+++ b/app/components/Value/Value.js
@@ -10,7 +10,7 @@ const Value = ({ value, currency, currentTicker, fiatTicker }) => {
   if (currency === 'fiat') {
     price = currentTicker[fiatTicker].last
   }
-  return <i>{convert('sats', currency, value, price)}</i>
+  return <i>{Number(convert('sats', currency, value, price))}</i>
 }
 
 Value.propTypes = {


### PR DESCRIPTION
## Description:

Do not display insignificant trailing zero decimal places when displaying BTC currency amounts.

## Motivation and Context:

The additional trailing zeros make numbers unnecessarily long and harder to read.

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):

**Before:**
<img width="619" alt="screenshot 2018-11-02 11 06 10" src="https://user-images.githubusercontent.com/200251/47909382-0f690d80-de90-11e8-8237-167f8f02c13d.png">


**After:**
<img width="621" alt="screenshot 2018-11-02 11 05 37" src="https://user-images.githubusercontent.com/200251/47909377-0bd58680-de90-11e8-82a4-d5a0e5dc6f93.png">


## Types of changes:

UI enhancement

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
