### PR TITLE
fix(notifications): disable channel notifications

### DIFF
--- a/app/reducers/channels.js
+++ b/app/reducers/channels.js
@@ -1,7 +1,6 @@
 import { createSelector } from 'reselect'
 import { ipcRenderer } from 'electron'
 import { btc } from 'lib/utils'
-import { showNotification } from 'lib/utils/notifications'
 import { requestSuggestedNodes } from 'lib/utils/api'
 import db from 'store/db'
 import { setError } from './error'
@@ -301,15 +300,6 @@ export const channelGraphData = (event, data) => (dispatch, getState) => {
         // this channel has to do with the user, lets fetch a new channel list for them
         // TODO: full fetch is probably not necessary
         dispatch(fetchChannels())
-
-        // Construct the notification
-        const otherParty =
-          info.data.identity_pubkey === advertising_node ? connecting_node : advertising_node
-        const notifBody = `No new friends, just new channels. Your channel with ${otherParty}`
-        const notifTitle = 'New channel detected'
-
-        // HTML 5 notification for channel updates involving our node
-        showNotification(notifTitle, notifBody)
       }
     }
   }


### PR DESCRIPTION
## Description:

Disable the desktop notification for when a new channel opens or closes.

## Motivation and Context:

Desktop notifications every time a channel opens or closes is noisy and not really necessary. Most users will use autopilot for channel management and should not care too much when it opens or closes a channel.

Fix #879

## How Has This Been Tested?

Manually

## Types of changes:

Bug fix / enhancement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
