### PR TITLE
fix(wallet): increase invoice fetch count to 1000

### DIFF
--- a/app/lib/lnd/methods/invoicesController.js
+++ b/app/lib/lnd/methods/invoicesController.js
@@ -26,7 +26,7 @@ export function addInvoice(lnd, { memo, value, private: privateInvoice }) {
  */
 export function listInvoices(lnd) {
   return new Promise((resolve, reject) => {
-    lnd.listInvoices({}, (err, data) => {
+    lnd.listInvoices({ num_max_invoices: 1000 }, (err, data) => {
       if (err) {
         return reject(err)
       }


### PR DESCRIPTION
## Description:

By default, lnd only returns the latest 100 invoices. Ideally we would implement pagination, but until then here is a quick fix to increase the max number of invoices returned by lnd to 1000.

## Motivation and Context:

Fix #911

## How Has This Been Tested?

Generate over 100 invoices with lnd and verify they all show in the app.

## Types of changes:

Bug fix / Enhancement

## Checklist:


- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
