### PR TITLE
fix(wallet): load suggested nodes on Root mount

### DIFF
--- a/app/components/App/App.js
+++ b/app/components/App/App.js
@@ -26,22 +26,15 @@ class App extends React.Component {
     receiveModalProps: PropTypes.object,
     channelFormProps: PropTypes.object,
     fetchInfo: PropTypes.func.isRequired,
-    fetchDescribeNetwork: PropTypes.func.isRequired,
-    fetchSuggestedNodes: PropTypes.func.isRequired
+    fetchDescribeNetwork: PropTypes.func.isRequired
   }
 
   componentDidMount() {
-    const { currentTicker, fetchInfo, fetchSuggestedNodes, fetchDescribeNetwork } = this.props
-
-    // If we don't yet have any ticker information then it must be our first time mounting this component.
-    if (!currentTicker) {
-      // fetch node info.
-      fetchInfo()
-      // fetch suggested nodes list from zap.jackmallers.com/suggested-peers.
-      fetchSuggestedNodes()
-      // fetch LN network from nodes POV.
-      fetchDescribeNetwork()
-    }
+    const { fetchInfo, fetchDescribeNetwork } = this.props
+    // fetch node info.
+    fetchInfo()
+    // fetch LN network from nodes POV.
+    fetchDescribeNetwork()
   }
 
   render() {

--- a/app/components/Contacts/Network/Network.js
+++ b/app/components/Contacts/Network/Network.js
@@ -369,7 +369,9 @@ class Network extends Component {
               })}
           </ul>
         </div>
-        {(loadingChannelPubkeys.length || pending_open_channels.length || channels.length) && (
+        {Boolean(
+          loadingChannelPubkeys.length || pending_open_channels.length || channels.length
+        ) && (
           <footer className={styles.search}>
             <label htmlFor="search" className={`${styles.label} ${styles.input}`}>
               <Search />

--- a/app/containers/Root.js
+++ b/app/containers/Root.js
@@ -10,6 +10,7 @@ import { loadingSelectors, setLoading, setMounted } from 'reducers/loading'
 import { initCurrency, initLocale } from 'reducers/locale'
 import { initTheme, themeSelectors } from 'reducers/theme'
 import { fetchTicker, tickerSelectors } from 'reducers/ticker'
+import { fetchSuggestedNodes } from 'reducers/channels'
 
 import { Page, Titlebar, GlobalStyle } from 'components/UI'
 import GlobalError from 'components/GlobalError'
@@ -33,6 +34,7 @@ class Root extends React.Component {
     currentTicker: PropTypes.object,
     theme: PropTypes.object,
     error: PropTypes.string,
+    fetchSuggestedNodes: PropTypes.func.isRequired,
     fetchTicker: PropTypes.func.isRequired,
     history: PropTypes.object.isRequired,
     initLocale: PropTypes.func.isRequired,
@@ -60,6 +62,7 @@ class Root extends React.Component {
   componentDidMount() {
     const {
       currentTicker,
+      fetchSuggestedNodes,
       fetchTicker,
       initLocale,
       initCurrency,
@@ -78,6 +81,7 @@ class Root extends React.Component {
       initLocale()
       initCurrency()
       fetchTicker()
+      fetchSuggestedNodes()
     }
 
     // Hide the loading screen after a set time.
@@ -135,6 +139,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = {
   clearError,
+  fetchSuggestedNodes,
   fetchTicker,
   initCurrency,
   initLocale,


### PR DESCRIPTION
## Description:

Load the suggested nodes list as early as possible, when the Root container first mounts. Ensure that we display nothing when node list was not loaded.

## Motivation and Context:

Fix #943 

## How Has This Been Tested?

Manually

## Types of changes:

Bug fix

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
