### PR TITLE
Remove package.json keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,17 +155,6 @@
   "bugs": {
     "url": "https://github.com/LN-Zap/zap-desktop/issues"
   },
-  "keywords": [
-    "electron",
-    "boilerplate",
-    "react",
-    "redux",
-    "flow",
-    "sass",
-    "webpack",
-    "hot",
-    "reload"
-  ],
   "homepage": "https://github.com/LN-Zap/zap-desktop#readme",
   "jest": {
     "collectCoverageFrom": [


### PR DESCRIPTION
I was just looking through the source and spotted this.

The keywords aren't relevant to the project, it looks like they were left in from a boilerplate generator.

I just removed the whole `keywords` property because this isn't a package published to npm to there's no need for them at all.