### PR TITLE
perf(redux): don't store channel edges

### DIFF
--- a/app/reducers/network.js
+++ b/app/reducers/network.js
@@ -136,8 +136,8 @@ export const fetchDescribeNetwork = () => dispatch => {
 }
 
 // Receive IPC event for describeNetwork
-export const receiveDescribeNetwork = (event, { nodes, edges }) => dispatch =>
-  dispatch({ type: RECEIVE_DESCRIBE_NETWORK, nodes, edges })
+export const receiveDescribeNetwork = (event, { nodes }) => dispatch =>
+  dispatch({ type: RECEIVE_DESCRIBE_NETWORK, nodes })
 
 export const queryRoutes = (pubkey, amount) => dispatch => {
   dispatch(getQueryRoutes(pubkey))
@@ -166,11 +166,10 @@ export const receiveInvoiceAndQueryRoutes = (event, { routes }) => dispatch =>
 // ------------------------------------
 const ACTION_HANDLERS = {
   [GET_DESCRIBE_NETWORK]: state => ({ ...state, networkLoading: true }),
-  [RECEIVE_DESCRIBE_NETWORK]: (state, { nodes, edges }) => ({
+  [RECEIVE_DESCRIBE_NETWORK]: (state, { nodes }) => ({
     ...state,
     networkLoading: false,
-    nodes,
-    edges
+    nodes
   }),
 
   [GET_QUERY_ROUTES]: (state, { pubkey }) => ({
@@ -304,7 +303,6 @@ export { networkSelectors }
 const initialState = {
   networkLoading: false,
   nodes: [],
-  edges: [],
   selectedChannel: {},
   selectedNode: {},
 


### PR DESCRIPTION
## Description:

Do not store details of channel edges in redux. 
<!--- Describe your changes in detail -->

## Motivation and Context:

We are seeing an error in the console warning of excessive memory usage. It links to https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/Troubleshooting.md#excessive-use-of-memory-and-cpu

This is caused by us trying to store all of the `edges` data from the network in redux. The edges data is massive and given that we aren't using it there is no need to store it in redux.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes:

Performance improvement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
