### PR TITLE
feat(rest): enable LND restlisten

### DIFF
--- a/resources/lnd.conf
+++ b/resources/lnd.conf
@@ -86,13 +86,13 @@
 ; Specify the interfaces to listen on for REST connections.  One listen
 ; address per line.
 ; All ipv4 interfaces on port 8080:
-;   restlisten=0.0.0.0:8080
+restlisten=0.0.0.0:8086
 ; On ipv4 localhost port 80 and 443:
 ;   restlisten=localhost:80
 ;   restlisten=localhost:443
 ; On an Unix socket:
 ;   restlisten=unix:///var/run/lnd-restlistener.sock
-restlisten=0
+;restlisten=0
 
 ; Adding an external IP will advertise your node to the network. This signals
 ; that your node is available to accept incoming channels. If you don't wish to


### PR DESCRIPTION
Enable LND `restlisten` in default mode

## Description:

Change `restlisten=0.0.0.0:8086` in `resources/lnd.conf`

## Motivation and Context:

There are folks building lapps that rely on an already running node for users, some relying on LNDs REST interface being enabled, most recently the Joule browser plugin.

A nice setup would be Zap desktop with neutrino and using these other applications on top of it

## How Has This Been Tested?

Manually