### PR TITLE
fix(channels): fetch balance on receiving channels

### DIFF
--- a/app/reducers/channels.js
+++ b/app/reducers/channels.js
@@ -4,6 +4,7 @@ import { btc } from 'lib/utils'
 import { requestSuggestedNodes } from 'lib/utils/api'
 import db from 'store/db'
 import { setError } from './error'
+import { fetchBalance } from './balance'
 
 // ------------------------------------
 // Constants
@@ -174,8 +175,10 @@ export const fetchChannels = () => async dispatch => {
 }
 
 // Receive IPC event for channels
-export const receiveChannels = (event, { channels, pendingChannels }) => dispatch =>
+export const receiveChannels = (event, { channels, pendingChannels }) => dispatch => {
   dispatch({ type: RECEIVE_CHANNELS, channels, pendingChannels })
+  dispatch(fetchBalance())
+}
 
 // Send IPC event for opening a channel
 export const openChannel = ({ pubkey, host, local_amt }) => async (dispatch, getState) => {


### PR DESCRIPTION
## Description:

Always fetch channel balances after receiving channel data.

## Motivation and Context:

Fix #939

## How Has This Been Tested?

Manually

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
