### PR TITLE
perf(devtools): strip large data from devtools

### DIFF
--- a/app/reducers/network.js
+++ b/app/reducers/network.js
@@ -136,8 +136,8 @@ export const fetchDescribeNetwork = () => dispatch => {
 }
 
 // Receive IPC event for describeNetwork
-export const receiveDescribeNetwork = (event, { nodes }) => dispatch =>
-  dispatch({ type: RECEIVE_DESCRIBE_NETWORK, nodes })
+export const receiveDescribeNetwork = (event, { nodes, edges }) => dispatch =>
+  dispatch({ type: RECEIVE_DESCRIBE_NETWORK, nodes, edges })
 
 export const queryRoutes = (pubkey, amount) => dispatch => {
   dispatch(getQueryRoutes(pubkey))
@@ -166,10 +166,11 @@ export const receiveInvoiceAndQueryRoutes = (event, { routes }) => dispatch =>
 // ------------------------------------
 const ACTION_HANDLERS = {
   [GET_DESCRIBE_NETWORK]: state => ({ ...state, networkLoading: true }),
-  [RECEIVE_DESCRIBE_NETWORK]: (state, { nodes }) => ({
+  [RECEIVE_DESCRIBE_NETWORK]: (state, { nodes, edges }) => ({
     ...state,
     networkLoading: false,
-    nodes
+    nodes,
+    edges
   }),
 
   [GET_QUERY_ROUTES]: (state, { pubkey }) => ({
@@ -303,6 +304,7 @@ export { networkSelectors }
 const initialState = {
   networkLoading: false,
   nodes: [],
+  edges: [],
   selectedChannel: {},
   selectedNode: {},
 


### PR DESCRIPTION
## Description:

Avoid excessive use of memory and CPU in redux devtools by stripping out large objects and replacing with placeholders.

This PR reverts the changes from #985 and reimplements in a different way by using [actionSanitizers](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md#actionsanitizer--statesanitizer) to strip out large data and replace with placeholders.

## Motivation and Context:

This reduces the size of the state data propagated to devtools from about 30k lines to 3k lines.

## How Has This Been Tested?

Start up the app and view the redux state in redux devtools.

## Types of changes:

Performance enhancement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
