### PR TITLE
feat(migration): import wallets from fs

### DIFF
--- a/app/containers/Initializer.js
+++ b/app/containers/Initializer.js
@@ -48,8 +48,10 @@ class Initializer extends React.Component {
         } else {
           history.push(`/home/wallet/${activeWallet}`)
         }
-      } else {
-        history.push('/onboarding')
+      }
+      // If we have an active wallet set, but can't find it's settings then send the user to the homepage.
+      else {
+        history.push('/home')
       }
     }
 

--- a/app/preload.js
+++ b/app/preload.js
@@ -1,4 +1,9 @@
-const { shell } = require('electron')
+const { remote, shell } = require('electron')
+const { readdir } = require('fs')
+const { join } = require('path')
+const { promisify } = require('util')
+
+const fsReaddir = promisify(readdir)
 
 init()
 
@@ -8,11 +13,26 @@ function init() {
   // !CAREFUL! do not expose any functionality or APIs that could compromise the
   // user's computer. E.g. don't directly expose core Electron (even IPC) or node.js modules.
   window.Zap = {
-    openHelpPage
+    openHelpPage,
+    getLocalWallets
   }
 }
 
-// Open the help page in a new browser window,.
+/**
+ * Open the help page in a new browser window.
+ */
 function openHelpPage() {
   shell.openExternal('https://ln-zap.github.io/zap-tutorials/zap-desktop-getting-started')
+}
+
+/**
+ * Get a list of local wallets from the filesystem.
+ */
+async function getLocalWallets(chain = 'bitcoin', network = 'testnet') {
+  const walletDir = join(remote.app.getPath('userData'), 'lnd', chain, network)
+  try {
+    return await fsReaddir(walletDir)
+  } catch (err) {
+    return []
+  }
 }

--- a/app/reducers/wallet.js
+++ b/app/reducers/wallet.js
@@ -73,10 +73,48 @@ export const initWallets = () => async dispatch => {
   let activeWallet
   let isWalletOpen
   try {
-    await dispatch(getWallets())
+    // Fetch wallets from db.
+    const dbWallets = await dispatch(getWallets())
+
+    // Fetch wallets from the filesystem.
+    const supportedChains = ['bitcoin']
+    const supportedNetworks = ['testnet', 'mainnet']
+
+    // Create wallet entry in the datanbase if one doesn't exist already.
+    await supportedChains.forEach(async chain => {
+      return supportedNetworks.forEach(async network => {
+        const fsWallets = await window.Zap.getLocalWallets(chain, network)
+        return fsWallets.filter(wallet => wallet !== 'wallet-tmp').forEach(async wallet => {
+          if (
+            !dbWallets.find(
+              w =>
+                w.type === 'local' &&
+                w.chain === chain &&
+                w.network === network &&
+                w.wallet === wallet
+            )
+          ) {
+            const walletDetails = {
+              type: 'local',
+              chain,
+              network,
+              wallet
+            }
+            const id = Number(wallet.split('-')[1])
+            if (id && !Number.isNaN(id)) {
+              walletDetails.id = id
+            }
+            await dispatch(putWallet(walletDetails))
+          }
+        })
+      })
+    })
+
+    // Fetch the current active wallet.
     activeWallet = await db.settings.get({ key: 'activeWallet' })
     activeWallet = activeWallet.value || null
 
+    // Fetch the current isWalletOpen setting.
     isWalletOpen = await db.settings.get({ key: 'isWalletOpen' })
     isWalletOpen = isWalletOpen.value
   } catch (e) {

--- a/app/store/db.js
+++ b/app/store/db.js
@@ -17,12 +17,6 @@ db.version(1).stores({
   nodes: 'id'
 })
 
-// Wallet with ID 1 will always be a local bitcoin wallet.
-// This ensures that useres upgrading from older versions do not loose their initial wallet.
-db.on('populate', () => {
-  db.wallets.add({ type: 'local', currency: 'bitcoin' })
-})
-
 /**
  * @class Wallet
  * Wallet helper class.


### PR DESCRIPTION
## Description:

When starting up the app, scan the local filesystem for wallet directories. If we find a directory without a corresponding entry in indexeddb, create a new database entry so that the wallet becomes available within the app.

## Motivation and Context:

- Ensure that users upgrading from an old version of Zap (pre indexeddb) have their wallets continue to be available.
- Make it possible to import wallets simply by moving them to an expected location on the filesystem and then starting the app

## How Has This Been Tested?

Manually -

1. Check out an old version of Zap (prior to the implementation of  indexeddb) and create a local wallet (check out the `0.2.2-beta` tag)
2. Quit Zap, Update the codebase to the `next` branch and restart the wallet.

You should find that your old wallet is now visible in the new home screen.

You can also test by deleting one of your db entries from indexeddb and restarting zap - the wallet entry should get recreated for you in indexeddb automatically and become available from the home screen.

## Types of changes:

Enhancement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
