### PR TITLE
fix(pay): ensure lightning: links validate

### DIFF
--- a/app/components/Pay/Pay.js
+++ b/app/components/Pay/Pay.js
@@ -298,20 +298,6 @@ class Pay extends React.Component {
   }
 
   /**
-   * Handle the case when the form is mountedwith an initialPayReq.
-   * This is the earliest possibleplace we can do this because the form is not initialised in ComponentDidMount.
-   */
-  handleChange = formState => {
-    const { initialPayReq } = this.props
-    const { currentStep, previousStep } = this.state
-    // If this is the first time the address page is showing and we have an initialPayReq, process the request
-    // as if the user had entered it themselves.
-    if (currentStep === 'address' && !previousStep && initialPayReq && formState.values.payReq) {
-      this.handlePayReqChange()
-    }
-  }
-
-  /**
    * set the amountFiat field whenever the crypto amount changes.
    */
   handleAmountCryptoChange = e => {
@@ -631,7 +617,6 @@ class Pay extends React.Component {
         css={{ height: '100%' }}
         {...rest}
         getApi={this.setFormApi}
-        onChange={this.handleChange}
         onSubmit={this.onSubmit}
       >
         {({ formState }) => {

--- a/app/reducers/pay.js
+++ b/app/reducers/pay.js
@@ -50,8 +50,14 @@ export function setPayReq(payReq) {
 }
 
 export const lightningPaymentUri = (event, { payReq }) => dispatch => {
-  dispatch(setPayReq(payReq))
+  // First, clear the payment form.
+  dispatch(setFormType(null))
+
+  // Then load it fresh and set the payment request.
   dispatch(setFormType('PAY_FORM'))
+  dispatch(setPayReq(payReq))
+
+  // Finally, clear the payment request.
   dispatch(setPayReq(null))
 }
 


### PR DESCRIPTION
## Description:

Reset the pay form and ensure validation and form submission is triggered immediately when a lightning: link is used.

## Motivation and Context:

Fix #1006

## How Has This Been Tested?

Manually - test various `lightning:` links in various different app states (modal already open, modal not already open, pay form already partially filled etc)

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
