### PR TITLE
fix(logout): reset app state on logout

### DIFF
--- a/app/containers/Initializer.js
+++ b/app/containers/Initializer.js
@@ -2,30 +2,48 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router'
-import { walletSelectors } from 'reducers/wallet'
 import { startActiveWallet } from 'reducers/lnd'
+import { initCurrency, initLocale } from 'reducers/locale'
+import { initWallets, walletSelectors } from 'reducers/wallet'
+import { fetchTicker } from 'reducers/ticker'
+import { fetchSuggestedNodes } from 'reducers/channels'
 
 /**
  * Root component that deals with mounting the app and managing top level routing.
  */
 class Initializer extends React.Component {
   static propTypes = {
-    onboarding: PropTypes.bool,
     history: PropTypes.object.isRequired,
     activeWallet: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     activeWalletSettings: PropTypes.object,
     isWalletOpen: PropTypes.bool,
     lightningGrpcActive: PropTypes.bool,
     walletUnlockerGrpcActive: PropTypes.bool,
-    startActiveWallet: PropTypes.func.isRequired
+    startActiveWallet: PropTypes.func.isRequired,
+    fetchSuggestedNodes: PropTypes.func.isRequired,
+    fetchTicker: PropTypes.func.isRequired,
+    initLocale: PropTypes.func.isRequired,
+    initCurrency: PropTypes.func.isRequired,
+    initWallets: PropTypes.func.isRequired
   }
 
   /**
-   * Redirect to the correct page when we establish a connection to lnd.
+   * Initialise app state.
+   */
+  componentDidMount() {
+    const { fetchSuggestedNodes, fetchTicker, initLocale, initCurrency, initWallets } = this.props
+    initLocale()
+    initCurrency()
+    initWallets()
+    fetchTicker()
+    fetchSuggestedNodes()
+  }
+
+  /**
+   * Redirect to the correct page once we establish where that should be.
    */
   componentDidUpdate(prevProps) {
     const {
-      onboarding,
       history,
       activeWallet,
       activeWalletSettings,
@@ -35,37 +53,32 @@ class Initializer extends React.Component {
       startActiveWallet
     } = this.props
 
-    // Wait unti we are onboarding before doing anything.
-    if (!onboarding) {
-      return
-    }
-
     // If we have just determined that the user has an active wallet, attempt to start it.
     if (typeof activeWallet !== 'undefined') {
       if (activeWalletSettings) {
         if (isWalletOpen) {
           startActiveWallet()
         } else {
-          history.push(`/home/wallet/${activeWallet}`)
+          return history.push(`/home/wallet/${activeWallet}`)
         }
       }
       // If we have an active wallet set, but can't find it's settings then send the user to the homepage.
       else {
-        history.push('/home')
+        return history.push('/home')
       }
     }
 
     // If the wallet unlocker became active, switch to the login screen
     if (walletUnlockerGrpcActive && !prevProps.walletUnlockerGrpcActive) {
-      history.push(`/home/wallet/${activeWallet}/unlock`)
+      return history.push(`/home/wallet/${activeWallet}/unlock`)
     }
 
     // If an active wallet connection has been established, switch to the app.
     if (lightningGrpcActive && !prevProps.lightningGrpcActive) {
       if (activeWalletSettings.type === 'local') {
-        history.push('/syncing')
+        return history.push('/syncing')
       } else {
-        history.push('/app')
+        return history.push('/app')
       }
     }
   }
@@ -85,7 +98,12 @@ const mapStateToProps = state => ({
 })
 
 const mapDispatchToProps = {
-  startActiveWallet
+  startActiveWallet,
+  fetchSuggestedNodes,
+  fetchTicker,
+  initCurrency,
+  initLocale,
+  initWallets
 }
 
 export default connect(

--- a/app/containers/Logout.js
+++ b/app/containers/Logout.js
@@ -2,7 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router'
-import { restart } from 'reducers/lnd'
+import { stopLnd } from 'reducers/lnd'
+import { resetApp } from 'reducers/app'
 import { setIsWalletOpen } from 'reducers/wallet'
 
 /**
@@ -10,17 +11,20 @@ import { setIsWalletOpen } from 'reducers/wallet'
  */
 class Logout extends React.Component {
   static propTypes = {
-    lightningGrpcActive: PropTypes.bool,
-    walletUnlockerGrpcActive: PropTypes.bool,
-    restart: PropTypes.func.isRequired
+    resetApp: PropTypes.func.isRequired,
+    setIsWalletOpen: PropTypes.func.isRequired,
+    stopLnd: PropTypes.func.isRequired,
+    history: PropTypes.shape({
+      push: PropTypes.func.isRequired
+    })
   }
 
-  componentDidMount() {
-    const { lightningGrpcActive, walletUnlockerGrpcActive, restart } = this.props
-    if (lightningGrpcActive || walletUnlockerGrpcActive) {
-      setIsWalletOpen(false)
-      restart()
-    }
+  async componentDidMount() {
+    const { history, resetApp, setIsWalletOpen, stopLnd } = this.props
+    stopLnd()
+    setIsWalletOpen(false)
+    resetApp()
+    history.push('/')
   }
 
   render() {
@@ -28,17 +32,13 @@ class Logout extends React.Component {
   }
 }
 
-const mapStateToProps = state => ({
-  lightningGrpcActive: state.lnd.lightningGrpcActive,
-  walletUnlockerGrpcActive: state.lnd.walletUnlockerGrpcActive
-})
-
 const mapDispatchToProps = {
-  restart,
+  resetApp,
+  stopLnd,
   setIsWalletOpen
 }
 
 export default connect(
-  mapStateToProps,
+  null,
   mapDispatchToProps
 )(withRouter(Logout))

--- a/app/containers/Root.js
+++ b/app/containers/Root.js
@@ -6,12 +6,9 @@ import { ConnectedRouter } from 'connected-react-router'
 import { ThemeProvider } from 'styled-components'
 
 import { clearError, errorSelectors } from 'reducers/error'
-import { loadingSelectors, setLoading, setMounted } from 'reducers/loading'
-import { initCurrency, initLocale } from 'reducers/locale'
 import { initTheme, themeSelectors } from 'reducers/theme'
-import { initWallets, walletSelectors } from 'reducers/wallet'
-import { fetchTicker, tickerSelectors } from 'reducers/ticker'
-import { fetchSuggestedNodes } from 'reducers/channels'
+import { walletSelectors } from 'reducers/wallet'
+import { setLoading, setMounted, appSelectors } from 'reducers/app'
 
 import { Page, Titlebar, GlobalStyle, Modal } from 'components/UI'
 import GlobalError from 'components/GlobalError'
@@ -36,64 +33,35 @@ class Root extends React.Component {
   static propTypes = {
     hasWallets: PropTypes.bool,
     clearError: PropTypes.func.isRequired,
-    currentTicker: PropTypes.object,
     theme: PropTypes.object,
     error: PropTypes.string,
-    fetchSuggestedNodes: PropTypes.func.isRequired,
-    fetchTicker: PropTypes.func.isRequired,
     history: PropTypes.object.isRequired,
-    initLocale: PropTypes.func.isRequired,
-    initCurrency: PropTypes.func.isRequired,
-    initTheme: PropTypes.func.isRequired,
-    initWallets: PropTypes.func.isRequired,
     isLoading: PropTypes.bool.isRequired,
+
+    initTheme: PropTypes.func.isRequired,
     isMounted: PropTypes.bool.isRequired,
-    setLoading: PropTypes.func.isRequired,
-    setMounted: PropTypes.func.isRequired
+    setMounted: PropTypes.func.isRequired,
+    setLoading: PropTypes.func.isRequired
   }
 
-  /**
-   * Initialise component state props.
-   */
-  constructor(props) {
-    super(props)
-    this.state = {
-      timer: null
-    }
+  state = {
+    timer: null
   }
 
   /**
    * // Show the loading bold briefly before showing the user the app.
    */
   componentDidMount() {
-    const {
-      currentTicker,
-      fetchSuggestedNodes,
-      fetchTicker,
-      initLocale,
-      initCurrency,
-      initTheme,
-      initWallets,
-      isLoading,
-      isMounted,
-      setLoading,
-      setMounted,
-      theme
-    } = this.props
+    const { initTheme, isLoading, isMounted, setLoading, setMounted, theme } = this.props
 
     // If this is the first time the app has mounted, initialise things.
     if (!isMounted) {
       setMounted(true)
       initTheme()
-      initLocale()
-      initCurrency()
-      initWallets()
-      fetchTicker()
-      fetchSuggestedNodes()
     }
 
     // Hide the loading screen after a set time.
-    if (isLoading || !currentTicker || !theme) {
+    if (isLoading || !theme) {
       const timer = setTimeout(() => setLoading(false), SPLASH_SCREEN_TIME)
       this.setState({ timer })
     }
@@ -157,21 +125,16 @@ class Root extends React.Component {
 
 const mapStateToProps = state => ({
   hasWallets: walletSelectors.hasWallets(state),
-  currentTicker: tickerSelectors.currentTicker(state),
-  theme: themeSelectors.currentThemeSettings(state),
   error: errorSelectors.getErrorState(state),
-  isLoading: loadingSelectors.isLoading(state),
-  isMounted: loadingSelectors.isMounted(state)
+  theme: themeSelectors.currentThemeSettings(state),
+  isLoading: appSelectors.isLoading(state),
+  isMounted: appSelectors.isMounted(state)
 })
 
 const mapDispatchToProps = {
   clearError,
-  fetchSuggestedNodes,
-  fetchTicker,
-  initCurrency,
-  initLocale,
+
   initTheme,
-  initWallets,
   setLoading,
   setMounted
 }

--- a/app/lib/lnd/subscribe/channelgraph.js
+++ b/app/lib/lnd/subscribe/channelgraph.js
@@ -10,10 +10,10 @@ export default function subscribeToChannelGraph() {
       this.mainWindow.send('channelGraphData', { channelGraphData })
     }
   })
-  call.on('end', () => mainLog.info('end'))
+  call.on('end', () => mainLog.info('CHANNELGRAPH END'))
   call.on('error', error => error.code !== status.CANCELLED && mainLog.error(error))
   call.on('status', channelGraphStatus => {
-    mainLog.debug('CHANNELGRAPHSTATUS:', channelGraphStatus)
+    mainLog.debug('CHANNELGRAPH STATUS:', channelGraphStatus)
     if (this.mainWindow) {
       this.mainWindow.send('channelGraphStatus', { channelGraphStatus })
     }

--- a/app/lib/lnd/subscribe/invoices.js
+++ b/app/lib/lnd/subscribe/invoices.js
@@ -10,7 +10,7 @@ export default function subscribeToInvoices() {
       this.mainWindow.send('invoiceUpdate', { invoice })
     }
   })
-  call.on('end', () => mainLog.info('end'))
+  call.on('end', () => mainLog.info('INVOICE END'))
   call.on('error', error => error.code !== status.CANCELLED && mainLog.error(error))
   call.on('status', status => mainLog.info('INVOICE STATUS:', status))
 

--- a/app/lib/lnd/subscribe/transactions.js
+++ b/app/lib/lnd/subscribe/transactions.js
@@ -10,7 +10,7 @@ export default function subscribeToTransactions() {
       this.mainWindow.send('newTransaction', { transaction })
     }
   })
-  call.on('end', () => mainLog.info('end'))
+  call.on('end', () => mainLog.info('TRANSACTION END'))
   call.on('error', error => error.code !== status.CANCELLED && mainLog.error(error))
   call.on('status', status => mainLog.info('TRANSACTION STATUS: ', status))
 

--- a/app/lib/zap/controller.js
+++ b/app/lib/zap/controller.js
@@ -70,7 +70,6 @@ class ZapController {
         { name: 'startLocalLnd', from: 'onboarding', to: 'running' },
         { name: 'startRemoteLnd', from: 'onboarding', to: 'connected' },
         { name: 'stopLnd', from: '*', to: 'onboarding' },
-        { name: 'restart', from: '*', to: 'onboarding' },
         { name: 'terminate', from: '*', to: 'terminated' }
       ],
       methods: {
@@ -79,7 +78,6 @@ class ZapController {
         onBeforeStartLocalLnd: this.onBeforeStartLocalLnd.bind(this),
         onBeforeStartRemoteLnd: this.onBeforeStartRemoteLnd.bind(this),
         onBeforeStopLnd: this.onBeforeStopLnd.bind(this),
-        onBeforeRestart: this.onBeforeRestart.bind(this),
         onTerminated: this.onTerminated.bind(this),
         onTerminate: this.onTerminate.bind(this)
       }
@@ -141,9 +139,6 @@ class ZapController {
   stopLnd(...args: any[]) {
     return this.fsm.stopLnd(...args)
   }
-  restart(...args: any[]) {
-    return this.fsm.restart(...args)
-  }
   terminate(...args: any[]) {
     return this.fsm.terminate(...args)
   }
@@ -184,12 +179,6 @@ class ZapController {
 
     // Give the grpc connections a chance to be properly closed out.
     await new Promise(resolve => setTimeout(resolve, 200))
-
-    this.sendMessage('lndStopped')
-
-    if (lifecycle.transition === 'restart') {
-      this.mainWindow.reload()
-    }
   }
 
   onStartOnboarding() {
@@ -255,11 +244,6 @@ class ZapController {
 
   onBeforeStopLnd() {
     mainLog.debug('[FSM] onBeforeStopLnd...')
-  }
-
-  onBeforeRestart() {
-    mainLog.debug('[FSM] onBeforeRestart...')
-    // this.mainWindow.reload()
   }
 
   async onTerminated(lifecycle: any) {
@@ -509,7 +493,6 @@ class ZapController {
       })
     )
     ipcMain.on('stopLnd', () => this.stopLnd())
-    ipcMain.on('restart', () => this.restart())
   }
 
   /**
@@ -518,7 +501,6 @@ class ZapController {
   _removeIpcListeners() {
     ipcMain.removeAllListeners('startLnd')
     ipcMain.removeAllListeners('stopLnd')
-    ipcMain.removeAllListeners('restart')
     ipcMain.removeAllListeners('startLightningWallet')
     ipcMain.removeAllListeners('walletUnlocker')
     ipcMain.removeAllListeners('lnd')

--- a/app/reducers/app.js
+++ b/app/reducers/app.js
@@ -11,6 +11,7 @@ const initialState = {
 // ------------------------------------
 export const SET_LOADING = 'SET_LOADING'
 export const SET_MOUNTED = 'SET_MOUNTED'
+export const RESET_APP = 'RESET_APP'
 
 // ------------------------------------
 // Actions
@@ -29,6 +30,12 @@ export function setMounted(isMounted) {
   }
 }
 
+export function resetApp() {
+  return {
+    type: RESET_APP
+  }
+}
+
 // ------------------------------------
 // Action Handlers
 // ------------------------------------
@@ -41,11 +48,11 @@ const ACTION_HANDLERS = {
 // Selectors
 // ------------------------------------
 
-const loadingSelectors = {}
-loadingSelectors.isLoading = state => state.loading.isLoading
-loadingSelectors.isMounted = state => state.loading.isMounted
+const appSelectors = {}
+appSelectors.isLoading = state => state.app.isLoading
+appSelectors.isMounted = state => state.app.isMounted
 
-export { loadingSelectors }
+export { appSelectors }
 
 // ------------------------------------
 // Reducer

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -3,6 +3,7 @@ import { connectRouter } from 'connected-react-router'
 import { intlReducer as intl } from 'react-intl-redux'
 import locale from './locale'
 import theme from './theme'
+import app from './app'
 import onboarding from './onboarding'
 import lnd from './lnd'
 import ticker from './ticker'
@@ -20,12 +21,11 @@ import transaction from './transaction'
 import activity from './activity'
 import network from './network'
 import error from './error'
-import loading from './loading'
 import settings from './settings'
 import wallet from './wallet'
 
-export default history =>
-  combineReducers({
+export default history => {
+  const appReducer = combineReducers({
     // Third party reducers.
     intl,
     locale,
@@ -33,6 +33,7 @@ export default history =>
     theme,
 
     // Custom reducers
+    app,
     onboarding,
     lnd,
     ticker,
@@ -50,7 +51,16 @@ export default history =>
     activity,
     network,
     error,
-    loading,
     settings,
     wallet
   })
+
+  return (state, action) => {
+    // Reset all reducers except for the app and theme reducers.
+    if (action.type === 'RESET_APP') {
+      const { app, theme } = state
+      return appReducer({ app, theme }, action)
+    }
+    return appReducer(state, action)
+  }
+}

--- a/app/reducers/lnd.js
+++ b/app/reducers/lnd.js
@@ -194,10 +194,6 @@ export const unlockWallet = password => async dispatch => {
   })
 }
 
-export const restart = () => () => {
-  ipcRenderer.send('restart')
-}
-
 /**
  * As soon as we have an active connection to a WalletUnlocker service, attempt to generate a new seed which kicks off
  * the process of creating or unlocking a wallet.

--- a/app/reducers/wallet.js
+++ b/app/reducers/wallet.js
@@ -21,28 +21,6 @@ export function setWallets(wallets) {
   }
 }
 
-export function setIsWalletOpen(isWalletOpen) {
-  db.settings.put({
-    key: 'isWalletOpen',
-    value: isWalletOpen
-  })
-  return {
-    type: SET_IS_WALLET_OPEN,
-    isWalletOpen
-  }
-}
-
-export function setActiveWallet(activeWallet) {
-  db.settings.put({
-    key: 'activeWallet',
-    value: activeWallet
-  })
-  return {
-    type: SET_ACTIVE_WALLET,
-    activeWallet
-  }
-}
-
 export const getWallets = () => async dispatch => {
   let wallets
   try {
@@ -52,6 +30,28 @@ export const getWallets = () => async dispatch => {
   }
   dispatch(setWallets(wallets))
   return wallets
+}
+
+export const setActiveWallet = activeWallet => async dispatch => {
+  await db.settings.put({
+    key: 'activeWallet',
+    value: activeWallet
+  })
+  dispatch({
+    type: SET_ACTIVE_WALLET,
+    activeWallet
+  })
+}
+
+export const setIsWalletOpen = isWalletOpen => async dispatch => {
+  await db.settings.put({
+    key: 'isWalletOpen',
+    value: isWalletOpen
+  })
+  dispatch({
+    type: SET_IS_WALLET_OPEN,
+    isWalletOpen
+  })
 }
 
 export const putWallet = wallet => async dispatch => {
@@ -65,8 +65,8 @@ export const deleteWallet = walletId => async dispatch => {
   dispatch({ type: DELETE_WALLET, walletId })
   await db.wallets.delete(walletId)
   const wallets = await dispatch(getWallets())
-  dispatch(setActiveWallet(wallets[0].id))
-  setIsWalletOpen(false)
+  await dispatch(setActiveWallet(wallets[0].id))
+  await setIsWalletOpen(false)
 }
 
 export const initWallets = () => async dispatch => {
@@ -121,8 +121,8 @@ export const initWallets = () => async dispatch => {
     activeWallet = null
     isWalletOpen = false
   }
-  dispatch(setIsWalletOpen(isWalletOpen))
-  dispatch(setActiveWallet(activeWallet))
+  await dispatch(setIsWalletOpen(isWalletOpen))
+  await dispatch(setActiveWallet(activeWallet))
 }
 
 // ------------------------------------


### PR DESCRIPTION
## Description:

Stop lnd and reset the app state on logout rather than doing a full reload of the app. 

## Motivation and Context:

This makes the transition between the wallet and the homepage much faster and smoother when logging out of a wallet.

Fix #944

## How Has This Been Tested?

Manually - log in and out of wallets.

## Types of changes:

Enhancement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
