### PR TITLE
feat(ui): add warning about keeping seed private

### DIFF
--- a/app/components/Icon/Warning.js
+++ b/app/components/Icon/Warning.js
@@ -1,6 +1,15 @@
 import React from 'react'
-import FaExclamationCircle from 'react-icons/lib/fa/exclamation-circle'
 
-const SystemIcon = props => <FaExclamationCircle style={{ verticalAlign: 'inherit' }} {...props} />
+const SvgWarning = props => (
+  <svg width="1em" height="1em" viewBox="0 0 15 14" {...props}>
+    <defs>
+      <path
+        id="warning_svg__a"
+        d="M9.264 1.682l5.105 9.36A2 2 0 0 1 12.613 14H2.403a2 2 0 0 1-1.757-2.958l5.106-9.36a2 2 0 0 1 3.512 0zm-1.689 8.434a.706.706 0 1 0 0 1.412.706.706 0 0 0 0-1.412zm0-5.297a.706.706 0 0 0-.706.706V8.35a.706.706 0 1 0 1.412 0V5.525a.706.706 0 0 0-.706-.706z"
+      />
+    </defs>
+    <use fill="currentColor" fillRule="evenodd" xlinkHref="#warning_svg__a" />
+  </svg>
+)
 
-export default SystemIcon
+export default SvgWarning

--- a/app/components/Onboarding/Steps/SeedView.js
+++ b/app/components/Onboarding/Steps/SeedView.js
@@ -3,7 +3,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { FormattedMessage, injectIntl } from 'react-intl'
 import { Flex } from 'rebass'
-import { Bar, Form, Header, Spinner, Text } from 'components/UI'
+import { Bar, Form, Header, Message, Spinner, Text } from 'components/UI'
 import messages from './messages'
 
 const SeedWord = ({ index, word }) => (
@@ -71,28 +71,33 @@ class SeedView extends React.Component {
         )}
         {!fetchingSeed &&
           seed.length > 0 && (
-            <Flex justifyContent="space-between">
-              <Flex flexDirection="column" as="ul">
-                {seed.slice(0, 6).map((word, index) => (
-                  <SeedWord key={index} index={index + 1} word={word} />
-                ))}
+            <>
+              <Flex justifyContent="space-between" mb={3}>
+                <Flex flexDirection="column" as="ul">
+                  {seed.slice(0, 6).map((word, index) => (
+                    <SeedWord key={index} index={index + 1} word={word} />
+                  ))}
+                </Flex>
+                <Flex flexDirection="column" as="ul">
+                  {seed.slice(6, 12).map((word, index) => (
+                    <SeedWord key={index} index={index + 7} word={word} />
+                  ))}
+                </Flex>
+                <Flex flexDirection="column" as="ul">
+                  {seed.slice(12, 18).map((word, index) => (
+                    <SeedWord key={index} index={index + 13} word={word} />
+                  ))}
+                </Flex>
+                <Flex flexDirection="column" as="ul">
+                  {seed.slice(18, 24).map((word, index) => (
+                    <SeedWord key={index} index={index + 19} word={word} />
+                  ))}
+                </Flex>
               </Flex>
-              <Flex flexDirection="column" as="ul">
-                {seed.slice(6, 12).map((word, index) => (
-                  <SeedWord key={index} index={index + 7} word={word} />
-                ))}
-              </Flex>
-              <Flex flexDirection="column" as="ul">
-                {seed.slice(12, 18).map((word, index) => (
-                  <SeedWord key={index} index={index + 13} word={word} />
-                ))}
-              </Flex>
-              <Flex flexDirection="column" as="ul">
-                {seed.slice(18, 24).map((word, index) => (
-                  <SeedWord key={index} index={index + 19} word={word} />
-                ))}
-              </Flex>
-            </Flex>
+              <Message variant="warning" justifyContent="center">
+                <FormattedMessage {...messages.seed_warning} />
+              </Message>
+            </>
           )}
       </Form>
     )

--- a/app/components/Onboarding/Steps/messages.js
+++ b/app/components/Onboarding/Steps/messages.js
@@ -62,6 +62,8 @@ export default defineMessages({
   save_seed_description:
     'Please save these 24 words securely! This will allow you to recover your wallet in the future',
   save_seed_title: 'Save your wallet seed',
+  seed_warning:
+    'Keep this private! If someone gains access to this list they can steal your money.',
   signup_create: 'Create new wallet',
   signup_description: 'Would you like to create a new wallet or import an existing one?',
   signup_import: 'Import existing wallet',

--- a/app/components/UI/Message.js
+++ b/app/components/UI/Message.js
@@ -9,7 +9,7 @@ import styled from 'styled-components'
 import { variant } from 'styled-system'
 
 const messageStyle = variant({ key: 'messages' })
-const StyledMessage = styled(Flex)(messageStyle)
+const StyledMessage = styled(Text)(messageStyle)
 
 /**
  * @render react
@@ -37,14 +37,14 @@ class Message extends React.Component {
   }
 
   render() {
-    const { children, variant, ...rest } = this.props
+    const { children, justifyContent, variant, ...rest } = this.props
     return (
-      <Text fontSize="s" fontWeight="normal" {...rest}>
-        <StyledMessage variant={variant} alignItems="center">
+      <StyledMessage fontSize="s" fontWeight="normal" variant={variant} {...rest}>
+        <Flex alignItems="center" justifyContent={justifyContent}>
           {this.renderIcon()}
-          {children}
-        </StyledMessage>
-      </Text>
+          <Box>{children}</Box>
+        </Flex>
+      </StyledMessage>
     )
   }
 }

--- a/app/icons/warning.svg
+++ b/app/icons/warning.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="15" height="14" viewBox="0 0 15 14">
+    <defs>
+        <path id="a" d="M9.264 1.682l5.105 9.36A2 2 0 0 1 12.613 14H2.403a2 2 0 0 1-1.757-2.958l5.106-9.36a2 2 0 0 1 3.512 0zm-1.689 8.434a.706.706 0 1 0 0 1.412.706.706 0 0 0 0-1.412zm0-5.297a.706.706 0 0 0-.706.706V8.35a.706.706 0 1 0 1.412 0V5.525a.706.706 0 0 0-.706-.706z"/>
+    </defs>
+    <use fill="currentColor" fill-rule="evenodd" xlink:href="#a"/>
+</svg>

--- a/app/styles/variables.scss
+++ b/app/styles/variables.scss
@@ -8,6 +8,7 @@
   --primaryColor: #242633;
   --secondaryColor: #373947;
   --tertiaryColor: #313340;
+  --warningColor: #fcc419;
   --primaryText: #fff;
   --highlight: #353745;
   --gradient: linear-gradient(270deg, #868b9f 0%, #333c5e 100%);

--- a/app/translations/af-ZA.json
+++ b/app/translations/af-ZA.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "",

--- a/app/translations/ar-SA.json
+++ b/app/translations/ar-SA.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "",

--- a/app/translations/bg-BG.json
+++ b/app/translations/bg-BG.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "Създай нов портфейл",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "Възстановяване на съществуващ портфейл",

--- a/app/translations/ca-ES.json
+++ b/app/translations/ca-ES.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "",

--- a/app/translations/cs-CZ.json
+++ b/app/translations/cs-CZ.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "Vytvořit novou peněženku",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "Importovat existující peněženku",

--- a/app/translations/da-DK.json
+++ b/app/translations/da-DK.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "",

--- a/app/translations/de-DE.json
+++ b/app/translations/de-DE.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "Neues Wallet erstellen",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "Bestehendes Wallet importieren",

--- a/app/translations/el-GR.json
+++ b/app/translations/el-GR.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "Δημιουργήστε νέο πορτοφόλι",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "Εισαγωγή υπάρχουσας πορτοφόλι",

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "Retype your seed",
   "components.Onboarding.Steps.save_seed_description": "Please save these 24 words securely! This will allow you to recover your wallet in the future",
   "components.Onboarding.Steps.save_seed_title": "Save your wallet seed",
+  "components.Onboarding.Steps.seed_warning": "Keep this private! If someone gains access to this list they can steal your money.",
   "components.Onboarding.Steps.signup_create": "Create new wallet",
   "components.Onboarding.Steps.signup_description": "Would you like to create a new wallet or import an existing one?",
   "components.Onboarding.Steps.signup_import": "Import existing wallet",

--- a/app/translations/es-ES.json
+++ b/app/translations/es-ES.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "Crear nueva cartera",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "Importar cartera existente",

--- a/app/translations/fi-FI.json
+++ b/app/translations/fi-FI.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "",

--- a/app/translations/fr-FR.json
+++ b/app/translations/fr-FR.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "Créer un nouveau portefeuille",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "Importer un portefeuille existant",

--- a/app/translations/ga-IE.json
+++ b/app/translations/ga-IE.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "Déan sparán nua",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "Iompórtáil sparán reatha",

--- a/app/translations/he-IL.json
+++ b/app/translations/he-IL.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "",

--- a/app/translations/hi-IN.json
+++ b/app/translations/hi-IN.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "",

--- a/app/translations/hr-HR.json
+++ b/app/translations/hr-HR.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "Stvori novi novčanik",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "Uvezi postojeći novčanik",

--- a/app/translations/hu-HU.json
+++ b/app/translations/hu-HU.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "",

--- a/app/translations/it-IT.json
+++ b/app/translations/it-IT.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "",

--- a/app/translations/ja-JP.json
+++ b/app/translations/ja-JP.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "新しいウォレットを作成します。",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "既存のウォレットをインポートします。",

--- a/app/translations/ko-KR.json
+++ b/app/translations/ko-KR.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "",

--- a/app/translations/nl-NL.json
+++ b/app/translations/nl-NL.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "Maak een nieuwe portemonnee aan",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "Importeer een bestaande portefeuille",

--- a/app/translations/no-NO.json
+++ b/app/translations/no-NO.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "",

--- a/app/translations/pl-PL.json
+++ b/app/translations/pl-PL.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "",

--- a/app/translations/pt-BR.json
+++ b/app/translations/pt-BR.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "Criar nova carteira",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "Importar carteira existente",

--- a/app/translations/pt-PT.json
+++ b/app/translations/pt-PT.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "",

--- a/app/translations/ro-RO.json
+++ b/app/translations/ro-RO.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "Creeaza un nou portofel",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "Importa un portofel existent",

--- a/app/translations/ru-RU.json
+++ b/app/translations/ru-RU.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "Создать новый кошелёк",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "Импорт существующего кошелька",

--- a/app/translations/sr-SP.json
+++ b/app/translations/sr-SP.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "",

--- a/app/translations/sv-SE.json
+++ b/app/translations/sv-SE.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "Skapa ny wallet",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "Importera befintlig wallet",

--- a/app/translations/tr-TR.json
+++ b/app/translations/tr-TR.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "Yeni cüzdan oluştur",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "Varolan cüzdanı geri yükle",

--- a/app/translations/uk-UA.json
+++ b/app/translations/uk-UA.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "Створити новий гаманець",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "Імпортувати наявний гаманець",

--- a/app/translations/vi-VN.json
+++ b/app/translations/vi-VN.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "",

--- a/app/translations/zh-CN.json
+++ b/app/translations/zh-CN.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "创建钱包",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "导入现有钱包",

--- a/app/translations/zh-TW.json
+++ b/app/translations/zh-TW.json
@@ -145,6 +145,7 @@
   "components.Onboarding.Steps.retype_seed_title": "",
   "components.Onboarding.Steps.save_seed_description": "",
   "components.Onboarding.Steps.save_seed_title": "",
+  "components.Onboarding.Steps.seed_warning": "",
   "components.Onboarding.Steps.signup_create": "创建钱包",
   "components.Onboarding.Steps.signup_description": "",
   "components.Onboarding.Steps.signup_import": "导入现有钱包",

--- a/test/unit/components/UI/__snapshots__/Message.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Message.spec.js.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`component.UI.Message should render correctly with default props 1`] = `
-<Styled(styled.div)
+<Styled(Styled(styled.div))
   fontSize="s"
   fontWeight="normal"
 >
-  <Styled(Styled(styled.div))
+  <Styled(styled.div)
     alignItems="center"
   >
     <styled.div
@@ -17,7 +17,9 @@ exports[`component.UI.Message should render correctly with default props 1`] = `
       mr={1}
       width="14px"
     />
-    A message
-  </Styled(Styled(styled.div))>
-</Styled(styled.div)>
+    <styled.div>
+      A message
+    </styled.div>
+  </Styled(styled.div)>
+</Styled(Styled(styled.div))>
 `;


### PR DESCRIPTION
## Description:
Added a warning message in the `SeedView` onboarding component.

This is a rebase and update of #908 to use our existing `Message` component.

## Motivation and Context:

Address issue in #522 

## How Has This Been Tested?

- in Storybook, navigate to the `Onboarding / SeedView` component.
- In the app, create a new local wallet.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/200251/49516919-102ffd80-f89b-11e8-9f0b-c92d6af434a0.png)

## Types of changes:

Enhancement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
