### PR TITLE
fix(sync): progress bar only consider remaining sync

### DIFF
--- a/app/components/Syncing/Syncing.js
+++ b/app/components/Syncing/Syncing.js
@@ -101,11 +101,11 @@ class Syncing extends Component {
     if (syncStatus === 'waiting') {
       syncMessage = intl.formatMessage({ ...messages.waiting_for_peers })
     } else if (syncStatus === 'in-progress') {
-      if (typeof syncPercentage === 'undefined' || Number(syncPercentage) <= 0) {
+      if (typeof syncPercentage === 'undefined') {
         syncMessage = intl.formatMessage({ ...messages.preparing })
         syncMessageDetail = null
         syncMessageExtraDetail = null
-      } else if (syncPercentage) {
+      } else {
         syncMessage = `${syncPercentage}%`
         syncMessageDetail = intl.formatMessage(
           { ...messages.block_progress },


### PR DESCRIPTION
## Description:

Update sync percentage calculator to base its percent on the total data that needs to be synced rather than the total size of the blockchain.

## Motivation and Context:

If I already have 98% of the data synced when I start the wallet, then the bar should go from 0-100 for the remaining 2%, rather than from 98-100

Resyncing an old wallet after this upgrade to 0.5.1 is slow if that wallet is quite old (as it has to resync frrom the wallet birthday), and the bar shows 99% for the entire thing - which looks like it's actually going to take an hour or more in my case

Looking at a sync bar saying 99% for an hour is offputting

## How Has This Been Tested?

Create new wallets and open old ones and verify sync progress bar represents remaining sync only.

## Types of changes:

Enhancement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
