### PR TITLE
perf(grpc): debounce channel fetching

### DIFF
--- a/app/reducers/channels.js
+++ b/app/reducers/channels.js
@@ -1,5 +1,6 @@
 import { createSelector } from 'reselect'
 import { ipcRenderer } from 'electron'
+import { debounce } from 'lodash.debounce'
 import { btc } from 'lib/utils'
 import { requestSuggestedNodes } from 'lib/utils/api'
 import db from 'store/db'
@@ -306,7 +307,10 @@ export const channelGraphData = (event, data) => (dispatch, getState) => {
 
   // if our node or any of our chanels were involved in this update, fetch an updated channel list.
   if (hasUpdates) {
-    dispatch(fetchChannels())
+    // We can receive a lot of channel updates from channel graph subscription in a short space of time. If these
+    // nvolve our our channels we make a call to fetchChannels and then fetchBalances in order to refresh our channel
+    // and balance data. Debounce these calls so that we don't fire too many times in quick succession.
+    debounce(() => dispatch(fetchChannels), 1000, { leading: true, trailing: true, maxWait: 3000 })
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -313,6 +313,7 @@
     "is-electron-renderer": "2.0.1",
     "javascript-state-machine": "3.1.0",
     "jstimezonedetect": "1.0.6",
+    "lodash.debounce": "4.0.8",
     "lodash.get": "4.4.2",
     "lodash.pick": "4.4.0",
     "prop-types": "15.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10696,7 +10696,7 @@ lodash.clonedeep@^4.3.2:
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
-lodash.debounce@^4.0.8:
+lodash.debounce@4.0.8, lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=


### PR DESCRIPTION
## Description:

We can receive a lot of channel updates from channel graph subscription in a short space of time. If these involve our our channels we make a call to `fetchChannels` and then `fetchBalances` in order to refresh our channel and balance data.

## Motivation and Context:

Debounce these calls so that we don't fire too many times in quick succession.

## Types of changes:

Performance enhancement

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have reviewed and updated the documentation accordingly.
- [ ] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [ ] My commits have been squashed into a concise set of changes.
