### PR TITLE
perf(grpc): throttle calls to fetch channels

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,7 +174,8 @@
       "\\.(css|less|sass|scss)$": "identity-obj-proxy"
     },
     "moduleFileExtensions": [
-      "js", "json"
+      "js",
+      "json"
     ],
     "moduleDirectories": [
       "app",
@@ -313,9 +314,9 @@
     "is-electron-renderer": "2.0.1",
     "javascript-state-machine": "3.1.0",
     "jstimezonedetect": "1.0.6",
-    "lodash.debounce": "4.0.8",
     "lodash.get": "4.4.2",
     "lodash.pick": "4.4.0",
+    "lodash.throttle": "4.1.1",
     "prop-types": "15.6.2",
     "qrcode.react": "0.8.0",
     "rc-menu": "7.4.20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10696,7 +10696,7 @@ lodash.clonedeep@^4.3.2:
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
-lodash.debounce@4.0.8, lodash.debounce@^4.0.8:
+lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
@@ -10815,7 +10815,7 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "~3.0.0"
 
-lodash.throttle@^4.1.1:
+lodash.throttle@4.1.1, lodash.throttle@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
   integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=


### PR DESCRIPTION
## Description:

This is a follow up to #1040 which fixes some issues with the implementation. Now we use `throttle` rather than `debounce` to ensure the frequency of the call to fetch channels (throttled to once per second).

## Motivation and Context:

debounce implementation was not working as expected with errors being logged in the console.

## How Has This Been Tested?

Manually

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
