### PR TITLE
fix(pay): allow sending without route info

### DIFF
--- a/app/components/Pay/Pay.js
+++ b/app/components/Pay/Pay.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { Box, Flex } from 'rebass'
 import { animated, Keyframes, Transition } from 'react-spring'
 import { FormattedMessage, injectIntl } from 'react-intl'
-import { decodePayReq, getMinFee, getMaxFee, getFeeRange, isOnchain, isLn } from 'lib/utils/crypto'
+import { decodePayReq, getMinFee, getMaxFee, isOnchain, isLn } from 'lib/utils/crypto'
 import { convert } from 'lib/utils/btc'
 import {
   Bar,
@@ -624,15 +624,6 @@ class Pay extends React.Component {
           const showBack = currentStep !== 'address'
           const showSubmit = currentStep !== 'address' || (isOnchain || isLn)
 
-          // Determine wether we have a route to the sender.
-          let hasRoute = true
-          if (isLn && currentStep === 'summary') {
-            const { min, max } = getFeeRange(routes || [])
-            if (min === null || max === null) {
-              hasRoute = false
-            }
-          }
-
           // Determine wether we have enough funds available.
           let hasEnoughFunds = true
           if (isLn && invoice) {
@@ -683,14 +674,6 @@ class Pay extends React.Component {
                   {styles => (
                     <Box style={styles}>
                       {currentStep === 'summary' &&
-                        !isQueryingRoutes &&
-                        !hasRoute && (
-                          <Message variant="error" justifyContent="center" mb={2}>
-                            <FormattedMessage {...messages.error_no_route} />
-                          </Message>
-                        )}
-
-                      {currentStep === 'summary' &&
                         !hasEnoughFunds && (
                           <Message variant="error" justifyContent="center" mb={2}>
                             <FormattedMessage {...messages.error_not_enough_funds} />
@@ -702,7 +685,7 @@ class Pay extends React.Component {
                           formState.pristine ||
                           formState.invalid ||
                           isProcessing ||
-                          (currentStep === 'summary' && (!hasRoute || !hasEnoughFunds))
+                          (currentStep === 'summary' && !hasEnoughFunds)
                         }
                         nextButtonText={nextButtonText}
                         processing={isProcessing}

--- a/app/components/Pay/messages.js
+++ b/app/components/Pay/messages.js
@@ -4,7 +4,6 @@ import { defineMessages } from 'react-intl'
 export default defineMessages({
   calculating: 'calculating',
   current_balance: 'Your current balance',
-  error_no_route: 'We were unable to find a route to your destination. Please try again later.',
   error_not_enough_funds: 'You do not have enough funds available to make this payment.',
   request_label_combined: 'Payment Request or Address',
   request_label_offchain: 'Payment Request',

--- a/app/translations/af-ZA.json
+++ b/app/translations/af-ZA.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/ar-SA.json
+++ b/app/translations/ar-SA.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/bg-BG.json
+++ b/app/translations/bg-BG.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/ca-ES.json
+++ b/app/translations/ca-ES.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/cs-CZ.json
+++ b/app/translations/cs-CZ.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/da-DK.json
+++ b/app/translations/da-DK.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/de-DE.json
+++ b/app/translations/de-DE.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/el-GR.json
+++ b/app/translations/el-GR.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "calculating",
   "components.Pay.current_balance": "Your current balance",
   "components.Pay.description": "You can send Bitcoin (BTC) through the Lightning Network or make a On-Chain Transaction. Just paste your Lightning Payment Request or the Bitcoin Address in the field below. Zap will guide you to the process.",
-  "components.Pay.error_no_route": "We were unable to find a route to your destination. Please try again later.",
   "components.Pay.error_not_enough_funds": "You do not have enough funds available to make this payment.",
   "components.Pay.fee": "Fee",
   "components.Pay.fee_less_than_1": "less than 1 satoshi",

--- a/app/translations/es-ES.json
+++ b/app/translations/es-ES.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/fi-FI.json
+++ b/app/translations/fi-FI.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/fr-FR.json
+++ b/app/translations/fr-FR.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/ga-IE.json
+++ b/app/translations/ga-IE.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/he-IL.json
+++ b/app/translations/he-IL.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/hi-IN.json
+++ b/app/translations/hi-IN.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/hr-HR.json
+++ b/app/translations/hr-HR.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/hu-HU.json
+++ b/app/translations/hu-HU.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/it-IT.json
+++ b/app/translations/it-IT.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/ja-JP.json
+++ b/app/translations/ja-JP.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/ko-KR.json
+++ b/app/translations/ko-KR.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/nl-NL.json
+++ b/app/translations/nl-NL.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/no-NO.json
+++ b/app/translations/no-NO.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/pl-PL.json
+++ b/app/translations/pl-PL.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/pt-BR.json
+++ b/app/translations/pt-BR.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/pt-PT.json
+++ b/app/translations/pt-PT.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/ro-RO.json
+++ b/app/translations/ro-RO.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/ru-RU.json
+++ b/app/translations/ru-RU.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/sr-SP.json
+++ b/app/translations/sr-SP.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/sv-SE.json
+++ b/app/translations/sv-SE.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/tr-TR.json
+++ b/app/translations/tr-TR.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/uk-UA.json
+++ b/app/translations/uk-UA.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/vi-VN.json
+++ b/app/translations/vi-VN.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/zh-CN.json
+++ b/app/translations/zh-CN.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",

--- a/app/translations/zh-TW.json
+++ b/app/translations/zh-TW.json
@@ -170,7 +170,6 @@
   "components.Pay.calculating": "",
   "components.Pay.current_balance": "",
   "components.Pay.description": "",
-  "components.Pay.error_no_route": "",
   "components.Pay.error_not_enough_funds": "",
   "components.Pay.fee": "",
   "components.Pay.fee_less_than_1": "",


### PR DESCRIPTION
## Description:

Do not disable the pay form submit button if we were unable to find a route. 

## Motivation and Context:

This is a hack to work around the fact that queryroutes doesn't currently support private channels yet we do want to allow sending along private channels.

Fix #1048

## How Has This Been Tested?

Create an invoice, and then try to pay yourself (or find another way to get an invoice that queryroutes can't route to)

## Types of changes:

Enhancement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
