### PR TITLE
fix(onboarding): launch onboarding if no wallets

### DIFF
--- a/app/containers/Initializer.js
+++ b/app/containers/Initializer.js
@@ -16,9 +16,10 @@ class Initializer extends React.Component {
     history: PropTypes.object.isRequired,
     activeWallet: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     activeWalletSettings: PropTypes.object,
-    isWalletOpen: PropTypes.bool,
-    lightningGrpcActive: PropTypes.bool,
-    walletUnlockerGrpcActive: PropTypes.bool,
+    hasWallets: PropTypes.bool.isRequired,
+    isWalletOpen: PropTypes.bool.isRequired,
+    lightningGrpcActive: PropTypes.bool.isRequired,
+    walletUnlockerGrpcActive: PropTypes.bool.isRequired,
     startActiveWallet: PropTypes.func.isRequired,
     fetchSuggestedNodes: PropTypes.func.isRequired,
     fetchTicker: PropTypes.func.isRequired,
@@ -44,9 +45,10 @@ class Initializer extends React.Component {
    */
   componentDidUpdate(prevProps) {
     const {
-      history,
       activeWallet,
       activeWalletSettings,
+      hasWallets,
+      history,
       isWalletOpen,
       lightningGrpcActive,
       walletUnlockerGrpcActive,
@@ -62,10 +64,9 @@ class Initializer extends React.Component {
           return history.push(`/home/wallet/${activeWallet}`)
         }
       }
-      // If we have an active wallet set, but can't find it's settings then send the user to the homepage.
-      else {
-        return history.push('/home')
-      }
+      // If we have an at least one wallet send the user to the homepage.
+      // Otherwise send them to the onboarding processes.
+      return hasWallets ? history.push('/home') : history.push('/onboarding')
     }
 
     // If the wallet unlocker became active, switch to the login screen
@@ -92,6 +93,7 @@ const mapStateToProps = state => ({
   onboarding: state.onboarding.onboarding,
   activeWallet: walletSelectors.activeWallet(state),
   activeWalletSettings: walletSelectors.activeWalletSettings(state),
+  hasWallets: walletSelectors.hasWallets(state),
   lightningGrpcActive: state.lnd.lightningGrpcActive,
   walletUnlockerGrpcActive: state.lnd.walletUnlockerGrpcActive,
   isWalletOpen: state.wallet.isWalletOpen


### PR DESCRIPTION
## Description:

Ensure that we boot into the onboarding process if the user doesn't have any saved wallets.

## Motivation and Context:

This fixes a bug that caused the app to launch into the homepage for new users that launch the app for the first time, rather than into the onboarding process.

## How Has This Been Tested?

1. Move your Electron user data directory out of the way (you can find the path for this here: https://electronjs.org/docs/api/app#appgetpathname)and launch the app in order to simulate a new user that has never opened the app before. Verify that the app launches into the onboarding process.
2. Log out of the wallet, quit the app, and relaunch. Verify that you start on the homepage this time.
3. Log out, delete your wallet, and relaunch the app. Verify that you start on the onboarding process again, as if you were opening the app for the first time.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
