### PR TITLE
style(network): clean up network list

### DIFF
--- a/app/components/Contacts/Network/Network.js
+++ b/app/components/Contacts/Network/Network.js
@@ -155,9 +155,9 @@ class Network extends Component {
     )
 
     return (
-      <Panel>
-        <Panel.Header>
-          <Flex justifyContent="space-between" mx={3} mt={3}>
+      <Panel pt={3}>
+        <Panel.Header pt={2}>
+          <Flex justifyContent="space-between" mx={3}>
             <Heading.h4 fontWeight="normal" mb={3}>
               <FormattedMessage {...messages.title} />
             </Heading.h4>

--- a/app/components/Wallet/Wallet.js
+++ b/app/components/Wallet/Wallet.js
@@ -43,9 +43,9 @@ const Wallet = ({
   )
 
   return (
-    <Box pt={4} px={5} pb={3} bg="secondaryColor">
-      <Flex as="header" justifyContent="space-between">
-        <Flex as="section" alignItems="center" mt={3}>
+    <Box pt={3} px={5} pb={3} bg="secondaryColor">
+      <Flex as="header" justifyContent="space-between" pt={2}>
+        <Flex as="section" alignItems="center" mt={4}>
           <ZapLogo width="70px" height="32px" />
           {info.data.testnet && (
             <Text color="superGreen" fontSize={1} ml={2}>


### PR DESCRIPTION
## Description:

Clean up network list:

 - Fix padding at top of the window so it aligns with the wallet header
 - Make search result rows clickable rather than just the `connect` button.
 - Apply hover styles to rows rather than just the `connect` button.
 - Adjust font sizes and colors
 - Truncate long node names with ellipsis

## Motivation and Context:

Improve style of the network list

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):

**No results**
![image](https://user-images.githubusercontent.com/200251/49806457-1e2cc500-fd58-11e8-8624-a2a0856c2ca8.png)

**Results list:**
![image](https://user-images.githubusercontent.com/200251/49806395-f3427100-fd57-11e8-8057-de1ae446096a.png)

## Types of changes:

Style updates

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
