### PR TITLE
feat(network): show connected peers first

### DIFF
--- a/app/components/App/App.js
+++ b/app/components/App/App.js
@@ -25,11 +25,12 @@ class App extends React.Component {
     channelFormProps: PropTypes.object,
     setIsWalletOpen: PropTypes.func.isRequired,
     fetchInfo: PropTypes.func.isRequired,
+    fetchPeers: PropTypes.func.isRequired,
     fetchDescribeNetwork: PropTypes.func.isRequired
   }
 
   componentDidMount() {
-    const { fetchInfo, fetchDescribeNetwork, setIsWalletOpen } = this.props
+    const { fetchInfo, fetchDescribeNetwork, fetchPeers, setIsWalletOpen } = this.props
 
     // Set wallet open state.
     setIsWalletOpen(true)
@@ -39,6 +40,9 @@ class App extends React.Component {
 
     // fetch LN network from nodes POV.
     fetchDescribeNetwork()
+
+    // Fetch information about connected peers.
+    fetchPeers()
   }
 
   render() {

--- a/app/components/App/App.js
+++ b/app/components/App/App.js
@@ -11,7 +11,21 @@ import ActivityModal from 'components/Activity/ActivityModal'
 import Activity from 'containers/Activity'
 import { MainContent, Sidebar } from 'components/UI'
 
+// Initial refetch after 2 seconds.
+const INITIAL_REFETCH_INTERVAL = 2000
+
+// Fetch node data no less than once every 10 minutes.
+const MAX_REFETCH_INTERVAL = 1000 * 60 * 10
+
+// Amount to increment refetch timer by after each fetch.
+const BACKOFF_SCHEDULE = 1.5
+
 class App extends React.Component {
+  state = {
+    timer: null,
+    nextFetchIn: INITIAL_REFETCH_INTERVAL
+  }
+
   static propTypes = {
     form: PropTypes.object.isRequired,
     formProps: PropTypes.object.isRequired,
@@ -30,17 +44,44 @@ class App extends React.Component {
   }
 
   componentDidMount() {
-    const { fetchInfo, fetchDescribeNetwork, fetchPeers, setIsWalletOpen } = this.props
+    const { setIsWalletOpen } = this.props
 
     // Set wallet open state.
     setIsWalletOpen(true)
 
     // fetch node info.
-    fetchInfo()
+    this.fetchData()
+  }
 
+  componentWillUnmount() {
+    const { timer } = this.state
+    clearTimeout(timer)
+  }
+
+  /**
+   * Fetch node data on an expontially incrementing backoff schedule so that when the app is first mounted, we fetch
+   * node data quite frequently but as time goes on the frequency is reduced down to a maximum of MAX_REFETCH_INTERVAL
+   */
+  fetchData = () => {
+    const { nextFetchIn } = this.state
+    const next = Math.round(Math.min(nextFetchIn * BACKOFF_SCHEDULE, MAX_REFETCH_INTERVAL))
+
+    // Fetch data.
+    this.initNode()
+
+    // Schedule next fetch.
+    const timer = setTimeout(this.fetchData, nextFetchIn)
+
+    // Increment the next fetch interval.
+    this.setState({ timer, nextFetchIn: next })
+  }
+
+  initNode = () => {
+    const { fetchInfo, fetchDescribeNetwork, fetchPeers } = this.props
+    // fetch node info.
+    fetchInfo()
     // fetch LN network from nodes POV.
     fetchDescribeNetwork()
-
     // Fetch information about connected peers.
     fetchPeers()
   }

--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -7,7 +7,7 @@ import { btc } from 'lib/utils'
 import { themeSelectors } from 'reducers/theme'
 import { setCurrency, tickerSelectors } from 'reducers/ticker'
 import { closeWalletModal } from 'reducers/address'
-import { fetchInfo, infoSelectors } from 'reducers/info'
+import { fetchInfo } from 'reducers/info'
 import { setFormType } from 'reducers/form'
 import { createInvoice, fetchInvoice } from 'reducers/invoice'
 import { lndSelectors } from 'reducers/lnd'
@@ -38,6 +38,7 @@ import {
   updateManualFormErrors
 } from 'reducers/contactsform'
 import { fetchBalance } from 'reducers/balance'
+import { fetchPeers } from 'reducers/peers'
 import { fetchDescribeNetwork } from 'reducers/network'
 import { clearError } from 'reducers/error'
 import { hideActivityModal, activitySelectors } from 'reducers/activity'
@@ -54,6 +55,7 @@ const mapDispatchToProps = {
   fetchInvoice,
   clearError,
   fetchBalance,
+  fetchPeers,
   fetchChannels,
   fetchSuggestedNodes,
   openChannel,
@@ -100,8 +102,7 @@ const mapStateToProps = state => ({
   wallet: state.wallet,
 
   isLoading:
-    infoSelectors.infoLoading(state) ||
-    tickerSelectors.tickerLoading(state) ||
+    !tickerSelectors.currentTicker(state) ||
     !tickerSelectors.currencyName(state) ||
     state.balance.channelBalance === null ||
     state.balance.walletBalance === null,

--- a/app/reducers/ticker.js
+++ b/app/reducers/ticker.js
@@ -112,7 +112,16 @@ tickerSelectors.currentTicker = createSelector(
   cryptoSelector,
   bitcoinTickerSelector,
   litecoinTickerSelector,
-  (crypto, btcTicker, ltcTicker) => (crypto === 'bitcoin' ? btcTicker : ltcTicker)
+  (crypto, btcTicker, ltcTicker) => {
+    switch (crypto) {
+      case 'bitcoin':
+        return btcTicker
+      case 'litecoin':
+        return ltcTicker
+      default:
+        return null
+    }
+  }
 )
 
 tickerSelectors.cryptoName = createSelector(cryptoSelector, crypto => cryptoNames[crypto])

--- a/package.json
+++ b/package.json
@@ -318,6 +318,7 @@
     "javascript-state-machine": "3.1.0",
     "jstimezonedetect": "1.0.6",
     "lodash.get": "4.4.2",
+    "lodash.partition": "4.6.0",
     "lodash.pick": "4.4.0",
     "lodash.throttle": "4.1.1",
     "prop-types": "15.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11072,6 +11072,11 @@ lodash.omit@4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
   integrity sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=
 
+lodash.partition@4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.partition/-/lodash.partition-4.6.0.tgz#a38e46b73469e0420b0da1212e66d414be364ba4"
+  integrity sha1-o45GtzRp4EILDaEhLmbUFL42S6Q=
+
 lodash.pick@4.4.0, lodash.pick@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"


### PR DESCRIPTION
## Description:

Show list of nodes in network search list when no search criteria have been entered. Sort list with connected peers at the top of the list.

Additionally, refetch node and network info on an exponential backoff schedule to ensure that node data is available when users need it. This starts off fetching every 2 seconds and increases by a factor of 1.5 until a maximum of a 10 minute refetch schedule is reached, where it remains until the app is unmounted.

## Motivation and Context:

Make the network list more useful.

Rebase and update https://github.com/LN-Zap/zap-desktop/pull/340 to work with latest codebase

## How Has This Been Tested?

1. Spin up a new local node.
2. As soon as it has finished syncing, click the `Add channel` button.
3. You will see an empty node list.
4. Within a few seconds, the list should start to fill up with node data.

Connected peers sill show at the top of the list

## Types of changes:

Enhancement

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
