### PR TITLE
style(panel): explicitly enable panel scroll bars

### DIFF
--- a/app/components/Activity/Activity.js
+++ b/app/components/Activity/Activity.js
@@ -267,7 +267,7 @@ class Activity extends Component {
           </Flex>
         </Panel.Header>
 
-        <Panel.Body py={3}>
+        <Panel.Body py={3} css={{ 'overflow-y': 'auto' }}>
           <Box as="section" mx={5} mt={3}>
             {this.renderActivityList()}
           </Box>

--- a/app/components/Contacts/AddChannel/AddChannel.js
+++ b/app/components/Contacts/AddChannel/AddChannel.js
@@ -129,7 +129,7 @@ const AddChannel = ({
 
       <Bar my={3} borderColor="gray" css={{ opacity: 0.3 }} />
 
-      <Panel.Body>
+      <Panel.Body css={{ 'overflow-y': 'auto' }}>
         {filteredNetworkNodes.length > 0 &&
           filteredNetworkNodes.map(node => {
             const canConnectToNode = canConnect(node)

--- a/app/components/Contacts/Network/Network.js
+++ b/app/components/Contacts/Network/Network.js
@@ -217,7 +217,7 @@ class Network extends Component {
           )}
         </Panel.Header>
 
-        <Panel.Body>
+        <Panel.Body css={{ 'overflow-y': 'auto' }}>
           {!hasChannels && <SuggestedNodes {...suggestedNodesProps} py={3} mx={3} />}
 
           {hasChannels && (

--- a/app/components/Pay/Pay.js
+++ b/app/components/Pay/Pay.js
@@ -361,9 +361,9 @@ class Pay extends React.Component {
         native
         items={currentStep === 'address'}
         from={{ opacity: 0, height: 0 }}
-        enter={{ opacity: 1, height: 'auto' }}
+        enter={{ opacity: 1, height: 80 }}
         leave={{ opacity: 0, height: 0 }}
-        initial={{ opacity: 1, height: 'auto' }}
+        initial={{ opacity: 1, height: 80 }}
       >
         {show =>
           show &&
@@ -675,17 +675,11 @@ class Pay extends React.Component {
                 <Bar pt={2} />
               </Panel.Header>
 
-              <Panel.Body py={3} css={{ overflow: 'hidden' }}>
-                <Box width={1} css={{ position: 'relative' }}>
-                  {this.renderHelpText()}
-                  <Box width={1} css={{ position: 'absolute' }}>
-                    {this.renderAddressField()}
-                    {this.renderAmountFields()}
-                  </Box>
-                  <Box width={1} css={{ position: 'absolute' }}>
-                    {this.renderSummary()}
-                  </Box>
-                </Box>
+              <Panel.Body py={3}>
+                {this.renderHelpText()}
+                {this.renderAddressField()}
+                {this.renderAmountFields()}
+                {this.renderSummary()}
               </Panel.Body>
               <Panel.Footer>
                 <ShowHideButtons state={showBack || showSubmit ? 'show' : 'show'}>

--- a/app/components/Request/Request.js
+++ b/app/components/Request/Request.js
@@ -323,7 +323,7 @@ class Request extends React.Component {
                 />
                 <Bar pt={2} />
               </Panel.Header>
-              <Panel.Body py={3} css={{ overflow: 'visible' }}>
+              <Panel.Body py={3}>
                 {currentStep == 'form' ? (
                   <React.Fragment>
                     {this.renderHelpText()}

--- a/app/components/Syncing/Syncing.js
+++ b/app/components/Syncing/Syncing.js
@@ -144,7 +144,7 @@ class Syncing extends Component {
           <Bar my={3} />
         </Panel.Header>
 
-        <Panel.Body width={9 / 16} mx="auto" mb={3} css={{ overflow: 'hidden' }}>
+        <Panel.Body width={9 / 16} mx="auto" mb={3}>
           {hasSynced === false &&
             address &&
             address.length && (

--- a/app/components/UI/Modal.js
+++ b/app/components/UI/Modal.js
@@ -61,7 +61,7 @@ class Modal extends React.Component {
             </Flex>
           )}
         </Panel.Header>
-        <Panel.Body px={4} pb={4} {...rest} css={{ overflow: 'hidden' }}>
+        <Panel.Body px={4} pb={4} {...rest}>
           {' '}
           {children}
         </Panel.Body>

--- a/app/components/UI/Panel.js
+++ b/app/components/UI/Panel.js
@@ -10,17 +10,7 @@ const PanelHeader = ({ children, ...rest }) => (
 PanelHeader.propTypes = { children: PropTypes.node }
 
 const PanelBody = ({ children, css, ...rest }) => (
-  <Box
-    {...rest}
-    as="section"
-    css={Object.assign(
-      {
-        flex: 1,
-        'overflow-y': 'auto'
-      },
-      css
-    )}
-  >
+  <Box {...rest} as="section" css={Object.assign({ flex: 1 }, css)}>
     {children}
   </Box>
 )

--- a/test/unit/components/UI/__snapshots__/Modal.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Modal.spec.js.snap
@@ -24,8 +24,6 @@ exports[`component.UI.Modal should render correctly 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-  overflow-y: auto;
-  overflow: hidden;
 }
 
 .c0 {

--- a/test/unit/components/UI/__snapshots__/Panel.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Panel.spec.js.snap
@@ -5,7 +5,6 @@ exports[`component.UI.Panel should render correctly 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-  overflow-y: auto;
 }
 
 .c2 {


### PR DESCRIPTION
## Description:

Explicitly enable scroll bars on `<Pane.Body>` elements when needed, rather than assuming it as a default.

There are only a couple of specific places where we want scroll bars to appear, so enable there only rather than enabling by default and disabling everywhere where we don't want them.

## Motivation and Context:

Unwanted scroll bars appearing when using app with a small window size. 

## How Has This Been Tested?

Manually. Navigate all app pages and  ensure that unwanted scrollbars don't appear as you resize the screen.

You can reproduce an instance of unwanted scrollbars (prior to this patch) by starting up the app, leaving the window size at the default size, and go through the onboarding process. Scroll bars will flicker on and off as you navigate between pages.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
