### PR TITLE
fix(network): always show channel balances

### DIFF
--- a/app/components/Contacts/Network/Network.js
+++ b/app/components/Contacts/Network/Network.js
@@ -175,23 +175,23 @@ class Network extends Component {
           </Flex>
 
           <Box mx={3}>
-            {Boolean(balance.channelBalance) && (
-              <Text>
-                <Value
-                  value={balance.channelBalance}
-                  currency={ticker.currency}
-                  currentTicker={currentTicker}
-                  fiatTicker={ticker.fiatTicker}
-                />
-                <i> {currencyName}</i>
-              </Text>
-            )}
-            {Boolean(fiatAmount) && (
-              <Text color="gray">
-                {' ≈ '}
-                <FormattedNumber currency={ticker.fiatTicker} style="currency" value={fiatAmount} />
-              </Text>
-            )}
+            <Text>
+              <Value
+                value={balance.channelBalance || 0}
+                currency={ticker.currency}
+                currentTicker={currentTicker}
+                fiatTicker={ticker.fiatTicker}
+              />
+              <i> {currencyName}</i>
+            </Text>
+            <Text color="gray">
+              {' ≈ '}
+              <FormattedNumber
+                currency={ticker.fiatTicker}
+                style="currency"
+                value={fiatAmount || 0}
+              />
+            </Text>
           </Box>
 
           <Bar my={3} borderColor="gray" css={{ opacity: 0.3 }} />


### PR DESCRIPTION
## Description:

Always show channel balances at the top of the network tab.

## Motivation and Context:

Previously, we were only showing the channel balance if it was non zero. This made the UI feel a little inconsistent as sometimes the header of the network pane would show a the channel balance, and at other times it would not.

Also, when a user has some open channels, but no value in them it feels like a bug that we don't tell them that they have $0 in their channels and just completely hide the current balance.

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):

**Before:**

![image](https://user-images.githubusercontent.com/200251/49934784-98338a00-fecf-11e8-886d-767288e5a982.png)


**After:**

![image](https://user-images.githubusercontent.com/200251/49934719-6b7f7280-fecf-11e8-9407-ea89eb4b2766.png)

## Types of changes:

Enhancement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
