### PR TITLE
fix(redux): dont mutate network data

### DIFF
--- a/app/store/configureStore.dev.js
+++ b/app/store/configureStore.dev.js
@@ -61,14 +61,14 @@ export const configureStore = initialState => {
                     nodes:
                       network.nodes.length > MAX_NODES
                         ? [
-                            ...network.nodes.splice(0, MAX_NODES),
+                            ...network.nodes.slice(0, MAX_NODES),
                             `<<${network.nodes.length - MAX_NODES}_MORE_NODES>>`
                           ]
                         : network.nodes,
                     edges:
                       network.edges.length > MAX_EDGES
                         ? [
-                            ...network.edges.splice(0, MAX_EDGES),
+                            ...network.edges.slice(0, MAX_EDGES),
                             `<<${network.edges.length - MAX_EDGES}_MORE_NODES>>`
                           ]
                         : network.edges


### PR DESCRIPTION
## Description:

This fixes an issue where we were mutating redux state in our redux devtools `stateSanitizer` which was causing the network node data to be resanitized different after every update to the redux state.

## Motivation and Context:

Look at the state diff in the redux action log - every single update contains changes to `network.nodes` and `network.edges`. This should only happen once rather than every state change.

## How Has This Been Tested?

Monitor the state diffs in redux dev tools.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
