### PR TITLE
feat(lndconnect): basic support for lndconnect links

### DIFF
--- a/app/components/Onboarding/Steps/ConnectionDetails.js
+++ b/app/components/Onboarding/Steps/ConnectionDetails.js
@@ -48,6 +48,16 @@ class ConnectionDetails extends React.Component {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    const { props } = this
+    const fields = ['connectionHost', 'connectionCert', 'connectionMacaroon']
+    fields.forEach(field => {
+      if (props[field] !== prevProps[field]) {
+        this.formApi.setValue(field, props[field])
+      }
+    })
+  }
+
   handleConnectionHostChange = () => {
     const formState = this.formApi.getState()
     delete formState.asyncErrors.connectionHost

--- a/app/reducers/ipc.js
+++ b/app/reducers/ipc.js
@@ -48,7 +48,7 @@ import {
 
 import { receiveDescribeNetwork, receiveQueryRoutes, receiveInvoiceAndQueryRoutes } from './network'
 
-import { startOnboarding } from './onboarding'
+import { lndconnectUri, startOnboarding } from './onboarding'
 
 // Import all receiving IPC event handlers and pass them into createIpc
 const ipc = createIpc({
@@ -111,6 +111,7 @@ const ipc = createIpc({
   receiveQueryRoutes,
   receiveInvoiceAndQueryRoutes,
 
+  lndconnectUri,
   startOnboarding,
   startLndError,
   lndStopped,

--- a/app/reducers/onboarding.js
+++ b/app/reducers/onboarding.js
@@ -174,6 +174,12 @@ export const startOnboarding = () => dispatch => {
   dispatch(onboardingStarted())
 }
 
+export const lndconnectUri = (event, { host, cert, macaroon }) => dispatch => {
+  dispatch(setConnectionHost(host))
+  dispatch(setConnectionMacaroon(macaroon))
+  dispatch(setConnectionCert(cert))
+}
+
 // ------------------------------------
 // Action Handlers
 // ------------------------------------


### PR DESCRIPTION
## Description:

Add basic support for `lndconnect` links.

`lndconnect` is an updated version of https://github.com/LN-Zap/zap-iOS/blob/master/docs/zap_connect_uri.md

## Motivation and Context:

Provide ability to populate custom connection fields (host, cert, macaroon) from a url.

## How Has This Been Tested?

1. Open the `Create new wallet` onboarding process
2. Select `Connect your own node`
3. Open your browser and access an `lndconnect` url

The form fields should be filled out for you automatically

example `lndconnect` link
```
lndconnect:?cert=~/.lnd/thedeathnode/tls.cert&macaroon=~/.lnd/thedeathnode/admin.macaroon&host=thedeathnode:10009
```

## Types of changes:

New feature

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
