### PR TITLE
build(webpack): copy empty.html to final build

### DIFF
--- a/internals/webpack/webpack.config.renderer.prod.js
+++ b/internals/webpack/webpack.config.renderer.prod.js
@@ -8,6 +8,7 @@ import HtmlWebpackPlugin from 'html-webpack-plugin'
 import CspHtmlWebpackPlugin from 'csp-html-webpack-plugin'
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer'
 import CleanWebpackPlugin from 'clean-webpack-plugin'
+import CopyWebpackPlugin from 'copy-webpack-plugin'
 import merge from 'webpack-merge'
 import baseConfig, { rootDir } from './webpack.config.base'
 
@@ -94,6 +95,8 @@ export default merge.smart(baseConfig, {
     new HtmlWebpackPlugin({
       template: path.join('app', 'app.html')
     }),
+
+    new CopyWebpackPlugin([path.join('app', 'empty.html')]),
 
     new CspHtmlWebpackPlugin({
       'default-src': "'self'",


### PR DESCRIPTION
## Description:

Ensure that empty.html file is copied over to the production build.

## Motivation and Context:

When the app first boots up, we load a blank html page into a hidden browser window in order to access the indexeddb database and fetch the user preferences as early as possible.

This file was missing and that was preventing the user settings from being properly fetched on a production build.

## How Has This Been Tested?

Run the app in production mode with debugging enabled:

```
DEBUG=zap* DEBUG_LEVEL=debug yarn start
```

Notice the error in the console:

```
  zap:main [DBG]  Fetching user settings from indexedDb (using database "ZapDesktop.production") +72ms
  zap:main [WRN]  Unable to determine user locale and theme [object Object]
  zap:main ___Inspected object #1___
  zap:main { __ELECTRON_SERIALIZED_ERROR__: true,
  zap:main   message:
  zap:main    'Failed to execute \'open\' on \'IDBFactory\': access to the Indexed Database API is denied in this context.',
  zap:main   name: 'SecurityError',
  zap:main   stack:
  zap:main    'Error: Failed to execute \'open\' on \'IDBFactory\': access to the Indexed Database API is denied in this context.\n    at Promise (<anonymous>:3:46)\n    at new Promise (<anonymous>)\n    at <anonymous>:2:7\n    at EventEmitter.electron.ipcRenderer.on (/Users/tom/workspace/zap-desktop/node_modules/electron/dist/Electron.app/Contents/Resources/electron.asar/renderer/web-frame-init.js:36:30)\n    at EventEmitter.emit (events.js:182:13)' } +592ms
```

Apply this patch and try again - error is should be gone and user settings correctly fetched on boot.

```
  zap:main [DBG]  Fetching user settings from indexedDb (using database "ZapDesktop.production") +35ms
  zap:main [DBG]  Got user settings: [ { key: 'activeWallet', value: 2 }, { key: 'isWalletOpen', value: true }, { key: 'locale', value: 'en' }, { key: 'theme', value: 'dark' } ] +330ms
```

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
