### PR TITLE
fix(lnd): use static ports for production builds

### DIFF
--- a/resources/lnd.conf
+++ b/resources/lnd.conf
@@ -82,17 +82,18 @@
 ;   rpclisten=[::1]:10010
 ; On an Unix socket:
 ;   rpclisten=unix:///var/run/lnd/lnd-rpclistener.sock
+rpclisten=0
 
 ; Specify the interfaces to listen on for REST connections.  One listen
 ; address per line.
 ; All ipv4 interfaces on port 8080:
-restlisten=0.0.0.0:8086
+;   restlisten=0.0.0.0:8080
 ; On ipv4 localhost port 80 and 443:
 ;   restlisten=localhost:80
 ;   restlisten=localhost:443
 ; On an Unix socket:
 ;   restlisten=unix:///var/run/lnd-restlistener.sock
-;restlisten=0
+restlisten=0
 
 ; Adding an external IP will advertise your node to the network. This signals
 ; that your node is available to accept incoming channels. If you don't wish to


### PR DESCRIPTION
## Description:

Use port 11009 (rpc) and 8180 (rest) for lnd when running in production mode.  When running in dev mode, user a random range bound port for both rpc and rest.

## Motivation and Context:

This ensures that users have a consistent port that they can connect to.

## How Has This Been Tested?

Manually - run app in dev mode and production mode, at same time.

## Types of changes:

Enhancement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
