### PR TITLE
fix(wallet): ensure describe network on timer

### DIFF
--- a/app/components/App/App.js
+++ b/app/components/App/App.js
@@ -73,7 +73,7 @@ class App extends React.Component {
     fetchDescribeNetwork()
 
     // Schedule refetching of network info.
-    const timer = setTimeout(this.fetchDescribeNetwork, nextFetchIn)
+    const timer = setTimeout(fetchDescribeNetwork, nextFetchIn)
 
     // Increment the next fetch interval.
     this.setState({ timer, nextFetchIn: next })


### PR DESCRIPTION
## Description:

Ensure that `fetchDescribeNetwork` is called correctly in App `componentDidMount()`

## Motivation and Context:

We were incorrectly calling fetchDescribeNetwork within a setInterval() which was resulting in an unsafe-eval CSP warning.

## How Has This Been Tested?

Make a production build:
```
yarn package --mac
````
and start it with `PROD_DEBUG` enabled:
```
DEBUG_LEVEL=debug DEBUG=zap* DEBUG_PROD=true ./release/mac/ZapDesktop.app/Contents/MacOS/ZapDesktop
```

Login to one of your wallets. You will see an error like:

> Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "default-src 'self' blob: filesystem: chrome-extension-resource:". Note that 'script-src' was not explicitly set, so 'default-src' is used as a fallback.

Apply this patch, rebuild your app `yarn package --mac` and again run with `DEBUG_PROD=1` - the error should be cone and the network will correctly be fetched on a timer.

**NOTE: This required the fix from #1109 which fixes an issue that was preventing DEBUG_PROD from working.**

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
