### PR TITLE
fix(home): show connection errors

### DIFF
--- a/app/components/Home/Home.js
+++ b/app/components/Home/Home.js
@@ -23,6 +23,7 @@ class Home extends React.Component {
     activeWalletSettings: PropTypes.object,
     deleteWallet: PropTypes.func.isRequired,
     lndConnect: PropTypes.object,
+    startLndHostError: PropTypes.string,
     lightningGrpcActive: PropTypes.bool.isRequired,
     walletUnlockerGrpcActive: PropTypes.bool.isRequired,
     wallets: PropTypes.array.isRequired,
@@ -31,6 +32,8 @@ class Home extends React.Component {
     setActiveWallet: PropTypes.func.isRequired,
     unlockWallet: PropTypes.func.isRequired,
     setUnlockWalletError: PropTypes.func.isRequired,
+    setStartLndError: PropTypes.func.isRequired,
+    setError: PropTypes.func.isRequired,
     unlockingWallet: PropTypes.bool,
     unlockWalletError: PropTypes.string
   }
@@ -58,9 +61,12 @@ class Home extends React.Component {
       activeWallet,
       deleteWallet,
       startLnd,
+      startLndHostError,
       unlockWallet,
       wallets,
       setActiveWallet,
+      setError,
+      setStartLndError,
       stopLnd,
       lightningGrpcActive,
       walletUnlockerGrpcActive,
@@ -105,6 +111,9 @@ class Home extends React.Component {
                       stopLnd={stopLnd}
                       lightningGrpcActive={lightningGrpcActive}
                       walletUnlockerGrpcActive={walletUnlockerGrpcActive}
+                      startLndHostError={startLndHostError}
+                      setError={setError}
+                      setStartLndError={setStartLndError}
                       deleteWallet={deleteWallet}
                       key={wallet.id}
                     />

--- a/app/components/Home/WalletLauncher.js
+++ b/app/components/Home/WalletLauncher.js
@@ -14,6 +14,9 @@ class WalletLauncher extends React.Component {
     startLnd: PropTypes.func.isRequired,
     lightningGrpcActive: PropTypes.bool.isRequired,
     walletUnlockerGrpcActive: PropTypes.bool.isRequired,
+    startLndHostError: PropTypes.string,
+    setStartLndError: PropTypes.func.isRequired,
+    setError: PropTypes.func.isRequired,
     stopLnd: PropTypes.func.isRequired,
     history: PropTypes.shape({
       push: PropTypes.func.isRequired
@@ -29,7 +32,21 @@ class WalletLauncher extends React.Component {
    * Redirect to the login page when we establish a connection to lnd.
    */
   componentDidUpdate(prevProps) {
-    const { history, lightningGrpcActive, walletUnlockerGrpcActive, wallet } = this.props
+    const {
+      history,
+      lightningGrpcActive,
+      walletUnlockerGrpcActive,
+      startLndHostError,
+      setError,
+      setStartLndError,
+      wallet
+    } = this.props
+
+    // If the wallet unlocker became active, switch to the login screen
+    if (startLndHostError && !prevProps.startLndHostError) {
+      setError(startLndHostError)
+      setStartLndError(null)
+    }
 
     // If the wallet unlocker became active, switch to the login screen
     if (walletUnlockerGrpcActive && !prevProps.walletUnlockerGrpcActive) {

--- a/app/containers/Home.js
+++ b/app/containers/Home.js
@@ -1,6 +1,13 @@
 import { connect } from 'react-redux'
 import { setActiveWallet, walletSelectors, deleteWallet } from 'reducers/wallet'
-import { setUnlockWalletError, stopLnd, startLnd, unlockWallet } from 'reducers/lnd'
+import {
+  setUnlockWalletError,
+  stopLnd,
+  startLnd,
+  unlockWallet,
+  setStartLndError
+} from 'reducers/lnd'
+import { setError } from 'reducers/error'
 import { Home } from 'components/Home'
 
 const mapStateToProps = state => ({
@@ -10,6 +17,7 @@ const mapStateToProps = state => ({
   activeWalletSettings: walletSelectors.activeWalletSettings(state),
   lightningGrpcActive: state.lnd.lightningGrpcActive,
   walletUnlockerGrpcActive: state.lnd.walletUnlockerGrpcActive,
+  startLndHostError: state.lnd.startLndHostError,
   unlockingWallet: state.lnd.unlockingWallet,
   unlockWalletError: state.lnd.unlockWalletError
 })
@@ -17,10 +25,12 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = {
   setActiveWallet,
   setUnlockWalletError,
+  setStartLndError,
   stopLnd,
   startLnd,
   unlockWallet,
-  deleteWallet
+  deleteWallet,
+  setError
 }
 
 export default connect(

--- a/app/reducers/lnd.js
+++ b/app/reducers/lnd.js
@@ -377,9 +377,9 @@ const ACTION_HANDLERS = {
   [SET_START_LND_ERROR]: (state, { errors }) => ({
     ...state,
     startingLnd: false,
-    startLndHostError: errors.host,
-    startLndCertError: errors.cert,
-    startLndMacaroonError: errors.macaroon
+    startLndHostError: errors ? errors.host : '',
+    startLndCertError: errors ? errors.cert : '',
+    startLndMacaroonError: errors ? errors.macaroon : ''
   }),
 
   [SET_WALLET_UNLOCKER_ACTIVE]: state => ({


### PR DESCRIPTION
## Description:

Show a global error if we fail when launching a remote connection.

## Motivation and Context:

Previously, if there was a problem connecting to a saved remote node connection, the error would not be shown to the user and there was no indication that there was a problem.

## How Has This Been Tested?

Disconnect your computers wifi and try connecting to a saved remote wallet.

## Screenshot

![image](https://user-images.githubusercontent.com/200251/50118486-17b6b580-0250-11e9-85a4-dff462654416.png)

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
