### PR TITLE
fix(home): do not mutate autopilot allocation

### DIFF
--- a/app/components/Home/WalletSettingsFormLocal.js
+++ b/app/components/Home/WalletSettingsFormLocal.js
@@ -32,15 +32,12 @@ class WalletSettingsFormLocal extends React.Component {
     }
   }
 
-  preSubmit = values => {
-    if (values.autopilotAllocation) {
-      values.autopilotAllocation = values.autopilotAllocation / 100
-    }
-    return values
-  }
-
   onSubmit = async values => {
     const { startLnd } = this.props
+
+    // Lnd expects the autopilot allocation to be a decimal.
+    values.autopilotAllocation = values.autopilotAllocation / 100
+
     return startLnd(values)
   }
 
@@ -54,7 +51,6 @@ class WalletSettingsFormLocal extends React.Component {
     return (
       <Form
         getApi={this.setFormApi}
-        preSubmit={this.preSubmit}
         onSubmit={this.onSubmit}
         {...rest}
         initialValues={wallet}


### PR DESCRIPTION
## Description:

Modify autopilotAllocation in `onSubmit` handler rather than `preSubmit` as preSubmit mutates the data in the form state which can result in the field being populated with an invalid value in the case that lnd fails to start.

For example, if the allocation field is set to `60` and an attempt to start a local wallet fails, the field will now have the value `0.6`, which is invalid according to the field validation rules and this will prevent you from submitting the form again until you correct the error (changing 0.6 to 60)

See https://github.com/joepuzzo/informed/pull/118

## Motivation and Context:

Autopilot allocation field populated with invalid data after failed attempt to launch lnd.

## How Has This Been Tested?

Verify that lnd starts correctly, with the correct autopilot setting.

Trigger a failure to start lnd and verify that the autopilot allocation field retains its value from before the failed submission.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
