### PR TITLE
fix(windows): ensure yarn dev works on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prestart": "npm run build",
     "start": "cross-env NODE_ENV=production electron ./app/",
     "start-main-dev": "cross-env HOT=1 NODE_ENV=development electron -r @babel/register ./app/main.dev",
-    "start-renderer-dev": "node --trace-warnings -r @babel/register ./node_modules/.bin/webpack-dev-server --config internals/webpack/webpack.config.renderer.dev.js  --progress",
+    "start-renderer-dev": "webpack-dev-server -r @babel/register --config internals/webpack/webpack.config.renderer.dev.js  --progress",
     "storybook": "start-storybook -p 6006",
     "storybook:build": "build-storybook",
     "storybook:deploy": "npm run storybook:build && gh-pages -t -d storybook-static -o origin -b gh-pages",


### PR DESCRIPTION
## Description:

Ensure that `yarn dev` works correctly on Windows machines.

## Motivation and Context:

`yarn dev` would produce an error, making it impossible to run the app in dev mode on Windows.

## How Has This Been Tested?

Run `yarn dev` on windows and verify that app starts up in dev mode.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
