### PR TITLE
build(electron): set autoupdate channel to "beta"

### DIFF
--- a/app/lib/zap/updater.js
+++ b/app/lib/zap/updater.js
@@ -6,6 +6,14 @@ import { updaterLog } from '../utils/log'
 autoUpdater.logger = updaterLog
 
 /**
+ * Update Channel
+ * supported channels are 'alpha', 'beta' and 'latest'
+ * Refer electron-builder docs
+ */
+autoUpdater.channel = process.env.AUTOUPDATE_CHANNEL || 'beta'
+autoUpdater.allowDowngrade = false
+
+/**
  * @class ZapController
  *
  * The ZapUpdater class manages the electron auto update process.


### PR DESCRIPTION
## Description:

Set the update channel to `beta` so that users will be only be upgraded to "beta" or "latest" versions of the app automatically. Allow overriding the update channel by starting the app with the `AUTOUPDATE_CHANNEL` environment variable set.

## Motivation and Context:

This frees up the alpha channel to be used by developers or users that specifically enable it. 

## Types of changes:

Electron build change

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
