### PR TITLE
style: fix spelling of "default" in Onboarding menu

### DIFF
--- a/app/components/Onboarding/Steps/messages.js
+++ b/app/components/Onboarding/Steps/messages.js
@@ -32,7 +32,7 @@ export default defineMessages({
   custom: 'Custom',
   default: 'Default',
   default_description:
-    'By selecting the defualt mode we will do everything for you. Just click and go!',
+    'By selecting the default mode we will do everything for you. Just click and go!',
   disable: 'Disable Autopilot',
   enable: 'Enable Autopilot',
   help: 'Need Help?',

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -139,7 +139,7 @@
   "components.Onboarding.Steps.create_wallet_password_title": "Welcome!",
   "components.Onboarding.Steps.custom": "Custom",
   "components.Onboarding.Steps.default": "Default",
-  "components.Onboarding.Steps.default_description": "By selecting the defualt mode we will do everything for you. Just click and go!",
+  "components.Onboarding.Steps.default_description": "By selecting the default mode we will do everything for you. Just click and go!",
   "components.Onboarding.Steps.disable": "Disable Autopilot",
   "components.Onboarding.Steps.enable": "Enable Autopilot",
   "components.Onboarding.Steps.generating_seed": "Generating Seed...",


### PR DESCRIPTION
Caught this on the Onboarding screen and couldn't help myself 😄. 

<img width="818" alt="screen shot 2018-12-21 at 1 11 44 am" src="https://user-images.githubusercontent.com/5483853/50327616-d88d9c00-04bd-11e9-8f7e-f86bf3e8fe60.png">
