### PR TITLE
fix(migrate): migrate old wallets early

### DIFF
--- a/app/store/db.js
+++ b/app/store/db.js
@@ -17,6 +17,24 @@ db.version(1).stores({
   nodes: 'id'
 })
 
+// Set initial active wallet.
+db.on('populate', async function() {
+  // If there are already some bitcoin testnet wallet before the database has been created, import them into the
+  // database and set the active wallet as wallet 1. This is for users upgrading from versions prior to 0.3.0.
+  const fsWallets = await window.Zap.getLocalWallets('bitcoin', 'testnet')
+  if (fsWallets.length > 0) {
+    await fsWallets.filter(wallet => wallet !== 'wallet-tmp').forEach(async wallet => {
+      await db.wallets.add({
+        type: 'local',
+        chain: 'bitcoin',
+        network: 'testnet',
+        wallet
+      })
+    })
+    await db.settings.add({ key: 'activeWallet', value: 1 })
+  }
+})
+
 /**
  * @class Wallet
  * Wallet helper class.


### PR DESCRIPTION
## Description:

When first creating the database, scan testnet wallets on the file system. If found, create in the database and set the active wallet.

## Motivation and Context:

This ensures that users upgrading from pre 0.3.0 have their old wallets available immediately.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
