### PR TITLE
fix(wallet): display correct amount on send button

### DIFF
--- a/app/components/Pay/Pay.js
+++ b/app/components/Pay/Pay.js
@@ -637,7 +637,7 @@ class Pay extends React.Component {
           const showBack = currentStep !== 'address'
           const showSubmit = currentStep !== 'address' || (isOnchain || isLn)
 
-          let amountInSatoshis = formState.values.amountCrypto
+          let amountInSatoshis = convert(cryptoCurrency, 'sats', formState.values.amountCrypto)
           if (isLn) {
             amountInSatoshis =
               invoice.satoshis || convert(cryptoCurrency, 'sats', formState.values.amountCrypto)


### PR DESCRIPTION
## Description:

Ensure that the correct amount is displayed on the Pay form send button as per the selected currency unit display.

## Motivation and Context:

Value was incorrect on the send button on the pay form when switching between the different btc units.

## How Has This Been Tested?

Manually - try different combinations of currency before and after moving to the pay summary page.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
