### PR TITLE
fix(lnd): ensure app notified on lnd disconnect

### DIFF
--- a/app/lib/zap/controller.js
+++ b/app/lib/zap/controller.js
@@ -154,6 +154,7 @@ class ZapController {
       if (this.walletUnlocker && this.walletUnlocker.can('disconnect')) {
         this.walletUnlocker.disconnect()
       }
+      this.sendMessage('lndStopped')
     }
 
     // If we are comming from a running state, stop the Neutrino process.


### PR DESCRIPTION
## Description:

Ensure that we send the `lndStopped` message when we disconnect from a remote lnd node so that the client can resume normal operation.

## Motivation and Context:

Previously, the app could be left in an `LND_STOPPING` state even after we have fully disconnected from the remote node.

## How Has This Been Tested?

1. Start up a remote lnd node but **do not** unlock it.
2. Attempt to connect to the node from zap
3. When prompted to enter the wallet password, navigate away from the wallet unlocker screen (eg, select another wallet or something)
4. Try again to connect to the remote node - this time, the app will not respond and you will not be prompted to login to the wallet. You will not be able to log into any wallet until you quit the app and restart.

## Types of changes:

Bug fix.

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
