### PR TITLE
fix(app): reset onboarding after app refresh

### DIFF
--- a/app/containers/Initializer.js
+++ b/app/containers/Initializer.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router'
+import { appSelectors } from 'reducers/app'
 import { startActiveWallet } from 'reducers/lnd'
 import { initCurrency, initLocale } from 'reducers/locale'
 import { initWallets, walletSelectors } from 'reducers/wallet'
@@ -18,6 +19,7 @@ class Initializer extends React.Component {
     activeWalletSettings: PropTypes.object,
     hasWallets: PropTypes.bool.isRequired,
     isWalletOpen: PropTypes.bool.isRequired,
+    isReady: PropTypes.bool.isRequired,
     lightningGrpcActive: PropTypes.bool.isRequired,
     walletUnlockerGrpcActive: PropTypes.bool.isRequired,
     startLndHostError: PropTypes.string.isRequired,
@@ -48,17 +50,18 @@ class Initializer extends React.Component {
     const {
       activeWallet,
       activeWalletSettings,
+      isReady,
+      isWalletOpen,
       hasWallets,
       history,
-      isWalletOpen,
       lightningGrpcActive,
       startLndHostError,
       walletUnlockerGrpcActive,
       startActiveWallet
     } = this.props
 
-    // If we have just determined that the user has an active wallet, attempt to start it.
-    if (typeof activeWallet !== 'undefined' && activeWallet !== prevProps.activeWallet) {
+    // If the app has just become ready, redirect the user to the most relevant location.
+    if (isReady && !prevProps.isReady) {
       if (activeWalletSettings) {
         if (isWalletOpen) {
           return startActiveWallet()
@@ -66,6 +69,7 @@ class Initializer extends React.Component {
           return history.push(`/home/wallet/${activeWallet}`)
         }
       }
+
       // If we have an at least one wallet send the user to the homepage.
       // Otherwise send them to the onboarding processes.
       return hasWallets ? history.push('/home') : history.push('/onboarding')
@@ -104,7 +108,8 @@ const mapStateToProps = state => ({
   lightningGrpcActive: state.lnd.lightningGrpcActive,
   walletUnlockerGrpcActive: state.lnd.walletUnlockerGrpcActive,
   startLndHostError: state.lnd.startLndHostError,
-  isWalletOpen: state.wallet.isWalletOpen
+  isWalletOpen: state.wallet.isWalletOpen,
+  isReady: appSelectors.isReady(state)
 })
 
 const mapDispatchToProps = {

--- a/app/containers/Logout.js
+++ b/app/containers/Logout.js
@@ -5,6 +5,7 @@ import { withRouter } from 'react-router'
 import { stopLnd } from 'reducers/lnd'
 import { resetApp } from 'reducers/app'
 import { setIsWalletOpen } from 'reducers/wallet'
+import { startOnboarding } from 'reducers/onboarding'
 
 /**
  * Root component that deals with mounting the app and managing top level routing.
@@ -13,6 +14,7 @@ class Logout extends React.Component {
   static propTypes = {
     resetApp: PropTypes.func.isRequired,
     setIsWalletOpen: PropTypes.func.isRequired,
+    startOnboarding: PropTypes.func.isRequired,
     stopLnd: PropTypes.func.isRequired,
     history: PropTypes.shape({
       push: PropTypes.func.isRequired
@@ -20,10 +22,11 @@ class Logout extends React.Component {
   }
 
   async componentDidMount() {
-    const { history, resetApp, setIsWalletOpen, stopLnd } = this.props
+    const { history, resetApp, setIsWalletOpen, startOnboarding, stopLnd } = this.props
     stopLnd()
     setIsWalletOpen(false)
     resetApp()
+    startOnboarding()
     history.push('/')
   }
 
@@ -35,7 +38,8 @@ class Logout extends React.Component {
 const mapDispatchToProps = {
   resetApp,
   stopLnd,
-  setIsWalletOpen
+  setIsWalletOpen,
+  startOnboarding
 }
 
 export default connect(

--- a/app/lib/zap/controller.js
+++ b/app/lib/zap/controller.js
@@ -65,7 +65,6 @@ class ZapController {
    */
   constructor(mainWindow: BrowserWindow) {
     this.fsm = new StateMachine({
-      init: 'onboarding',
       transitions: [
         { name: 'startOnboarding', from: '*', to: 'onboarding' },
         { name: 'startLocalLnd', from: 'onboarding', to: 'running' },
@@ -100,10 +99,13 @@ class ZapController {
       this.mainWindow.loadURL(`file://${__dirname}/dist/index.html`)
     }
 
-    // Show the window as soon as the application has finished loading.
     this.mainWindow.webContents.on('did-finish-load', () => {
+      // Show the window as soon as the application has finished loading.
       this.mainWindow.show()
       this.mainWindow.focus()
+
+      // Start the onboarding process.
+      this.startOnboarding()
     })
   }
 

--- a/app/reducers/app.js
+++ b/app/reducers/app.js
@@ -1,3 +1,5 @@
+import { createSelector } from 'reselect'
+
 // ------------------------------------
 // Initial State
 // ------------------------------------
@@ -51,6 +53,15 @@ const ACTION_HANDLERS = {
 const appSelectors = {}
 appSelectors.isLoading = state => state.app.isLoading
 appSelectors.isMounted = state => state.app.isMounted
+appSelectors.onboarding = state => state.onboarding.onboarding
+appSelectors.isWalletsLoaded = state => state.wallet.isWalletsLoaded
+appSelectors.isReady = createSelector(
+  appSelectors.onboarding,
+  appSelectors.isWalletsLoaded,
+  (onboarding, isWalletsLoaded) => {
+    return Boolean(onboarding && isWalletsLoaded)
+  }
+)
 
 export { appSelectors }
 

--- a/app/reducers/onboarding.js
+++ b/app/reducers/onboarding.js
@@ -245,7 +245,7 @@ export { onboardingSelectors }
 // ------------------------------------
 
 const initialState = {
-  onboarding: true,
+  onboarding: false,
   onboarded: false,
   autopilot: true,
   validatingHost: false,

--- a/app/reducers/wallet.js
+++ b/app/reducers/wallet.js
@@ -7,6 +7,7 @@ import { setError } from './error'
 // Constants
 // ------------------------------------
 export const SET_WALLETS = 'SET_WALLETS'
+export const SET_WALLETS_LOADED = 'SET_WALLETS_LOADED'
 export const SET_ACTIVE_WALLET = 'SET_ACTIVE_WALLET'
 export const SET_IS_WALLET_OPEN = 'SET_IS_WALLET_OPEN'
 export const DELETE_WALLET = 'DELETE_WALLET'
@@ -22,6 +23,12 @@ export function setWallets(wallets) {
   return {
     type: SET_WALLETS,
     wallets
+  }
+}
+
+export function setWalletsLoaded() {
+  return {
+    type: SET_WALLETS_LOADED
   }
 }
 
@@ -108,12 +115,13 @@ export const initWallets = () => async dispatch => {
 
   dispatch(setIsWalletOpen(isWalletOpen))
   dispatch(setActiveWallet(activeWallet))
+  dispatch(setWalletsLoaded(true))
 
   // Fetch wallets from the filesystem.
   const supportedChains = ['bitcoin']
   const supportedNetworks = ['testnet', 'mainnet']
 
-  // Create wallet entry in the datanbase if one doesn't exist already.
+  // Create wallet entry in the database if one doesn't exist already.
   supportedChains.forEach(chain => {
     return supportedNetworks.forEach(async network => {
       const fsWallets = await window.Zap.getLocalWallets(chain, network)
@@ -149,6 +157,7 @@ export const initWallets = () => async dispatch => {
 // ------------------------------------
 const ACTION_HANDLERS = {
   [SET_WALLETS]: (state, { wallets }) => ({ ...state, wallets }),
+  [SET_WALLETS_LOADED]: state => ({ ...state, isWalletsLoaded: true }),
   [SET_ACTIVE_WALLET]: (state, { activeWallet }) => ({ ...state, activeWallet }),
   [SET_IS_WALLET_OPEN]: (state, { isWalletOpen }) => ({ ...state, isWalletOpen })
 }
@@ -177,8 +186,9 @@ export { walletSelectors }
 // ------------------------------------
 
 const initialState = {
+  isWalletsLoaded: false,
   isWalletOpen: false,
-  activeWallet: undefined,
+  activeWallet: null,
   wallets: []
 }
 


### PR DESCRIPTION
## Description:

Only trigger the onboarding process to start once the app is ready. This means waiting until we have loaded all the available wallet data and the onboarding process has been triggered from the main process.

## Motivation and Context:

This ensures that we do not attempt to start the onboarding process until the main process has been fully reset (disconnect / stop lnd) and prevents us from trying to start lnd when it is already started after a window refresh.

This is a more comprehensive fix for https://github.com/LN-Zap/zap-desktop/issues/1108 which doesn't have the sideeffect of breaking app reload.

## How Has This Been Tested?

Connect to a wallet, and then trigger a window reload (cmd+r). Previously this would result in a blank screen and an error about trying to start lnd in an invalid state on the terminal. With this patch it should work as expected.

## Screenshots (if appropriate):

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
