### PR TITLE
fix(app): ensure app quits fully on osx

### DIFF
--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -292,7 +292,7 @@ app.on('open-url', (event, protocolUrl) => {
 
 app.on('window-all-closed', () => {
   mainLog.trace('app.window-all-closed')
-  if (os.platform() !== 'darwin') {
+  if (os.platform() !== 'darwin' || mainWindow.forceClose) {
     app.quit()
   }
 })

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -146,6 +146,7 @@ if (!singleInstanceLock) {
  * Initialize Zap as soon as electron is ready.
  */
 app.on('ready', async () => {
+  mainLog.trace('app.ready')
   mainLog.timeEnd('Time until app is ready')
 
   // Get the users preference so that we can:
@@ -194,6 +195,7 @@ app.on('ready', async () => {
 
   // When the window is closed, just hide it unless we are force closing.
   mainWindow.on('close', event => {
+    mainLog.trace('mainWindow.close')
     if (os.platform() === 'darwin' && !mainWindow.forceClose) {
       event.preventDefault()
       mainWindow.hide()
@@ -202,6 +204,7 @@ app.on('ready', async () => {
 
   // Dereference the window object.
   mainWindow.on('closed', () => {
+    mainLog.trace('mainWindow.closed')
     mainWindow = null
     updater.mainWindow = null
     zap.mainWindow = null
@@ -254,6 +257,7 @@ app.on('ready', async () => {
  *  - Stop gRPC and kill lnd process before the app windows are closed and the app quits.
  */
 app.on('before-quit', event => {
+  mainLog.trace('app.before-quit')
   if (!zap.is('terminated')) {
     event.preventDefault()
     zap.terminate()
@@ -264,19 +268,30 @@ app.on('before-quit', event => {
   }
 })
 
+app.on('will-quit', () => {
+  mainLog.trace('app.will-quit')
+})
+
+app.on('quit', () => {
+  mainLog.trace('app.quit')
+})
+
 /**
  * On OS X it's common to re-open a window in the app when the dock icon is clicked.
  */
 app.on('activate', () => {
+  mainLog.trace('app.activate')
   mainWindow.show()
 })
 
 app.on('open-url', (event, protocolUrl) => {
+  mainLog.trace('app.open-url')
   event.preventDefault()
   handleOpenUrl(protocolUrl)
 })
 
 app.on('window-all-closed', () => {
+  mainLog.trace('app.window-all-closed')
   if (os.platform() !== 'darwin') {
     app.quit()
   }
@@ -286,6 +301,7 @@ app.on('window-all-closed', () => {
  * Someone tried to run a second instance, we should focus our window.
  */
 app.on('second-instance', (event, commandLine) => {
+  mainLog.trace('app.second-instance')
   if (os.platform !== 'darwin') {
     const protocolUrl = commandLine && commandLine.slice(1)[0]
     if (protocolUrl) {


### PR DESCRIPTION
## Description:

On mac, when the main window is closed we hide the app instead of triggering the app quit process. When the user actually quits the app (from the menu bar or pressing ctrl+q) we set a `forceClose` property on the window object.

Honour the `forceClose` property in the `window-all-closed` event to ensure the app properly quits on mac as implementing this hook prevents the electron default behaviour of quitting the app.

## Motivation and Context:


We recently implemented the `app.window-all-closed` event to ensure that the app fully exists when closing the window on Windows and Ubuntu. This had a side effect of preventing the app from fully closing on Mac.

## How Has This Been Tested?

Verify that app fully quits on Mac, Linux and Windows.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
