### PR TITLE
fix(pay): update bolt11 to support millisatoshis

### DIFF
--- a/package.json
+++ b/package.json
@@ -303,7 +303,7 @@
     "axios": "0.18.0",
     "bip39-en": "1.1.1",
     "bitcoinjs-lib": "4.0.2",
-    "bolt11": "LN-Zap/bolt11#7872de0f53a420d2b9c99c7022f7e94339d80682",
+    "bolt11": "LN-Zap/bolt11#7fe8d5c7b643067bb109fac3cd557e231f62f1c1",
     "coininfo": "cryptocoinjs/coininfo.git#c7e003b2fc0db165b89e6f98f6d6360ad22616b2",
     "connected-react-router": "5.0.1",
     "copy-to-clipboard": "3.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4110,9 +4110,9 @@ body-parser@1.18.3:
     raw-body "2.3.3"
     type-is "~1.6.16"
 
-bolt11@LN-Zap/bolt11#7872de0f53a420d2b9c99c7022f7e94339d80682:
-  version "1.0.0"
-  resolved "https://codeload.github.com/LN-Zap/bolt11/tar.gz/7872de0f53a420d2b9c99c7022f7e94339d80682"
+bolt11@LN-Zap/bolt11#7fe8d5c7b643067bb109fac3cd557e231f62f1c1:
+  version "1.2.0"
+  resolved "https://codeload.github.com/LN-Zap/bolt11/tar.gz/7fe8d5c7b643067bb109fac3cd557e231f62f1c1"
   dependencies:
     bech32 "^1.1.2"
     bitcoinjs-lib "^3.3.1"


### PR DESCRIPTION
## Description:

Merge latest changes from the bolt11 library into our fork in order to add support for deciding invoices that include milisat amounts.

See https://github.com/bitcoinjs/bolt11/issues/9

## Motivation and Context:

Fix #1166

## How Has This Been Tested?

Try to pay various ln invoices, including one from the blockstream store.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
