### PR TITLE
fix(boot): redirect to launchpad on failed connect

### DIFF
--- a/app/components/Home/WalletLauncher.js
+++ b/app/components/Home/WalletLauncher.js
@@ -24,8 +24,14 @@ class WalletLauncher extends React.Component {
   }
 
   componentDidMount() {
-    const { stopLnd } = this.props
+    const { stopLnd, startLndHostError, setError, setStartLndError } = this.props
     stopLnd()
+
+    // If the wallet unlocker became active, switch to the login screen
+    if (startLndHostError) {
+      setError(startLndHostError)
+      setStartLndError(null)
+    }
   }
 
   /**

--- a/app/containers/Initializer.js
+++ b/app/containers/Initializer.js
@@ -20,6 +20,7 @@ class Initializer extends React.Component {
     isWalletOpen: PropTypes.bool.isRequired,
     lightningGrpcActive: PropTypes.bool.isRequired,
     walletUnlockerGrpcActive: PropTypes.bool.isRequired,
+    startLndHostError: PropTypes.string.isRequired,
     startActiveWallet: PropTypes.func.isRequired,
     fetchSuggestedNodes: PropTypes.func.isRequired,
     fetchTicker: PropTypes.func.isRequired,
@@ -51,6 +52,7 @@ class Initializer extends React.Component {
       history,
       isWalletOpen,
       lightningGrpcActive,
+      startLndHostError,
       walletUnlockerGrpcActive,
       startActiveWallet
     } = this.props
@@ -69,7 +71,12 @@ class Initializer extends React.Component {
       return hasWallets ? history.push('/home') : history.push('/onboarding')
     }
 
-    // If the wallet unlocker became active, switch to the login screen
+    // If there wad a problem starting lnd, swich to the wallet launcher.
+    if (startLndHostError && !prevProps.startLndHostError) {
+      return history.push(`/home/wallet/${activeWallet}`)
+    }
+
+    // If the wallet unlocker became active, switch to the login screen.
     if (walletUnlockerGrpcActive && !prevProps.walletUnlockerGrpcActive) {
       return history.push(`/home/wallet/${activeWallet}/unlock`)
     }
@@ -96,6 +103,7 @@ const mapStateToProps = state => ({
   hasWallets: walletSelectors.hasWallets(state),
   lightningGrpcActive: state.lnd.lightningGrpcActive,
   walletUnlockerGrpcActive: state.lnd.walletUnlockerGrpcActive,
+  startLndHostError: state.lnd.startLndHostError,
   isWalletOpen: state.wallet.isWalletOpen
 })
 

--- a/app/containers/Root.js
+++ b/app/containers/Root.js
@@ -127,7 +127,7 @@ const mapStateToProps = state => ({
   hasWallets: walletSelectors.hasWallets(state),
   error: errorSelectors.getErrorState(state),
   theme: themeSelectors.currentThemeSettings(state),
-  isLoading: appSelectors.isLoading(state),
+  isLoading: appSelectors.isLoading(state) || state.lnd.startingLnd,
   isMounted: appSelectors.isMounted(state)
 })
 


### PR DESCRIPTION
## Description:

If there is a failure connecting to the active wallet when the app first starts up, redirect the user to the wallet launcher and show an error message.

## Motivation and Context:

Previously, the app would hang indefinitely at the Initializer component.

Fix #1173

## How Has This Been Tested?

1. Start the app and connect to a remote wallet
2. Quit the app
3. Disconnect your internet connection
4. Start the app again

Without this patch it will hang on a blank screen.

With this patch it will show the loading screen for up to 20 seconds whilst we try to connect to lnd and then redirect to the wallet launcher with an error message indicating that the connection failed.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
