### PR TITLE
fix(ui): set global error z-index to 99999

### DIFF
--- a/app/components/GlobalError/GlobalError.js
+++ b/app/components/GlobalError/GlobalError.js
@@ -32,7 +32,7 @@ class GlobalError extends React.Component {
         {show =>
           show &&
           (springStyles => (
-            <Box mt="22px" px={3} width={1} css={{ position: 'absolute', 'z-index': '100' }}>
+            <Box mt="22px" px={3} width={1} css={{ position: 'absolute', 'z-index': '99999' }}>
               <animated.div style={springStyles}>
                 <Notification variant="error" onClick={clearError}>
                   {errorToUserFriendly(error)}


### PR DESCRIPTION
Fixes #1200.

I set the `z-index` property on for the `GlobalError` component to `99999` from `100`. The bug was caused by the modal having a higher z-index value than the error (`999` vs `100`).

This bug is fixed for now, however, a more robust solution needs to be implemented to avoid these types of bugs in the future. See this post for some ideas: [https://css-tricks.com/handling-z-index/](https://css-tricks.com/handling-z-index/).

Also, there might be a bug somewhere in the `componentDidUpdate` because I noticed that the timeout of `10000` doesn't always apply. If you trigger an error, wait a bit, close it and then quickly trigger another error you will see that the new error disappears in much less than 10 seconds.
