### PR TITLE
fix(unit tests): clean up some warning messages

### DIFF
--- a/test/unit/components/UI/Countdown.spec.js
+++ b/test/unit/components/UI/Countdown.spec.js
@@ -5,7 +5,7 @@ import { Countdown } from 'components/UI'
 
 describe('component.UI.Countdown', () => {
   it('should render correctly with default props', () => {
-    const wrapper = shallow(<Countdown />)
+    const wrapper = shallow(<Countdown date={new Date('2009-01-03T18:15:05+00:00')} />)
     expect(toJSON(wrapper)).toMatchSnapshot()
   })
 })

--- a/test/unit/components/UI/LightningInvoiceInput.spec.js
+++ b/test/unit/components/UI/LightningInvoiceInput.spec.js
@@ -10,7 +10,7 @@ describe('component.UI.LightningInvoiceInput', () => {
   it('should render correctly', () => {
     const tree = renderer
       .create(
-        <IntlProvider>
+        <IntlProvider locale="en">
           <ThemeProvider theme={dark}>
             <Form>
               <LightningInvoiceInput field="name" chain="bitcoin" network="mainnet" theme={dark} />

--- a/test/unit/components/UI/__snapshots__/Countdown.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Countdown.spec.js.snap
@@ -13,7 +13,7 @@ exports[`component.UI.Countdown should render correctly with default props 1`] =
   <FormattedRelative
     style="best fit"
     updateInterval={1000}
-    value={Date { NaN }}
+    value={2009-01-03T18:15:05.000Z}
   />
 </Text>
 `;


### PR DESCRIPTION
Fix #1201.

This doesn't clean up all warnings but cleans up some of them. 

I couldn't figure out how to fix one of them (incorrect ref usage `Select.js`). 

The other one that I left as is would involve changing the `size` prop passed to a `Code` component in `QRCode.js` to 112 (a number) instead of "80%" (string) since the prop type for this component require `size` to be a number. I wasn't sure if this was an acceptable change so I didn't do it.