### PR TITLE
fix(style): ensure modal covers full page

### DIFF
--- a/app/components/UI/Modal.js
+++ b/app/components/UI/Modal.js
@@ -31,7 +31,14 @@ class Modal extends React.Component {
     return (
       <Panel
         width={1}
-        css={{ height: '100vh', 'z-index': '999', position: 'absolute', top: 0 }}
+        css={{
+          'z-index': '999',
+          position: 'absolute',
+          top: 0,
+          bottom: 0,
+          left: 0,
+          right: 0
+        }}
         bg="primaryColor"
         color="primaryText"
       >

--- a/app/components/UI/Page.js
+++ b/app/components/UI/Page.js
@@ -13,6 +13,7 @@ const Page = ({ css, ...rest }) => (
     as="article"
     css={Object.assign(
       {
+        position: 'relative',
         height: '100%',
         overflow: 'hidden',
         'min-width': '900px',

--- a/test/unit/components/UI/__snapshots__/Modal.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Modal.spec.js.snap
@@ -30,10 +30,12 @@ exports[`component.UI.Modal should render correctly 1`] = `
   width: 100%;
   color: primaryText;
   background-color: primaryColor;
-  height: 100vh;
   z-index: 999;
   position: absolute;
   top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/test/unit/components/UI/__snapshots__/Page.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Page.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`component.UI.Page should render correctly 1`] = `
 .c0 {
   background-color: primaryColor;
+  position: relative;
   height: 100%;
   overflow: hidden;
   min-width: 900px;


### PR DESCRIPTION
## Description:

Give positioning properties to the `Page` element (by setting `display: relative`) and ensure that the `<Modal>` component covers the full width and height of its container.

## Motivation and Context:

Fix display glitch with modal window.

## How Has This Been Tested?

Manually

1. `yarn storybook` and navigate to `Components/UI/Modal`. Compare before and after the patch.
2. Test all modal windows in the app.

## Screenshots (if appropriate):

**Before:**
Before the patch, the Modal was not bound to the Page element.

<img width="1142" alt="screenshot 2019-01-02 00 00 26" src="https://user-images.githubusercontent.com/200251/50577161-22fa0b80-0e22-11e9-88fa-d60e5b84e73e.png">

**After:**
With this change, the Modal will fill the containing Page element and not break outside of it.

<img width="1144" alt="screenshot 2019-01-02 00 02 35" src="https://user-images.githubusercontent.com/200251/50577163-28efec80-0e22-11e9-9576-7e8dc21e4ef5.png">

## Types of changes:

<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
