### PR TITLE
fix(ui): make modal scrollable

### DIFF
--- a/app/components/UI/Modal.js
+++ b/app/components/UI/Modal.js
@@ -61,7 +61,7 @@ class Modal extends React.Component {
             </Flex>
           )}
         </Panel.Header>
-        <Panel.Body px={4} pb={4} {...rest}>
+        <Panel.Body px={4} pb={4} {...rest} css={{ 'overflow-y': 'auto' }}>
           {' '}
           {children}
         </Panel.Body>

--- a/test/unit/components/UI/__snapshots__/Modal.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Modal.spec.js.snap
@@ -24,6 +24,7 @@ exports[`component.UI.Modal should render correctly 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
+  overflow-y: auto;
 }
 
 .c0 {


### PR DESCRIPTION
## Description:

Make modal's scrollable. Always keep the modal header (close button) visible, but scroll the rest of the content.

## Motivation and Context:

When viewing the app with a small window size, or when viewing a modal with long content that doesn't all fit above the fold, there is no way to see the bottom of the content.

Making the modal ensures that you can can always access all of the content, regardless of it's length.

## How Has This Been Tested?

Open up the Pay or Request modal, and make the window as short as possible. Verify that you can scroll the modal to access the bottom of the content.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
