### PR TITLE
fix(startup-fetch-activity): fetch activity history when grpc is ready Fix #1193

### DIFF
--- a/app/components/Activity/Activity.js
+++ b/app/components/Activity/Activity.js
@@ -80,10 +80,6 @@ class Activity extends Component {
     refreshing: false
   }
 
-  componentDidMount() {
-    this.refreshClicked()
-  }
-
   refreshClicked = () => {
     const { fetchPayments, fetchInvoices, fetchTransactions, fetchBalance } = this.props
     // turn the spinner on

--- a/app/components/Contacts/Network/Network.js
+++ b/app/components/Contacts/Network/Network.js
@@ -28,11 +28,6 @@ class Network extends Component {
     refreshing: false
   }
 
-  componentDidMount() {
-    const { fetchChannels } = this.props
-    fetchChannels()
-  }
-
   componentDidUpdate(prevProps) {
     const { refreshing } = this.state
     const { channels } = this.props

--- a/app/reducers/activity.js
+++ b/app/reducers/activity.js
@@ -1,6 +1,10 @@
 import { createSelector } from 'reselect'
 import { decodePayReq } from 'lib/utils/crypto'
 
+import { fetchTransactions } from './transaction'
+import { fetchPayments } from './payment'
+import { fetchInvoices } from './invoice'
+import { fetchBalance } from './balance'
 // ------------------------------------
 // Initial State
 // ------------------------------------
@@ -73,6 +77,20 @@ export function toggleExpiredRequests() {
   return {
     type: TOGGLE_EXPIRED_REQUESTS
   }
+}
+
+/**
+ * Fetches user activity history. Which includes:
+ * Balance
+ * Payments
+ * Invoices
+ * Transactions
+ */
+export const fetchActivityHistory = () => dispatch => {
+  dispatch(fetchBalance())
+  dispatch(fetchPayments())
+  dispatch(fetchInvoices())
+  dispatch(fetchTransactions())
 }
 
 // ------------------------------------

--- a/app/reducers/lnd.js
+++ b/app/reducers/lnd.js
@@ -7,9 +7,7 @@ import { fetchInfo, setHasSynced, infoSelectors } from './info'
 import { putWallet, setActiveWallet, walletSelectors } from './wallet'
 import { onboardingFinished, setSeed } from './onboarding'
 import { fetchChannels } from './channels'
-import { fetchTransactions } from './transaction'
-import { fetchPayments } from './payment'
-import { fetchInvoices } from './invoice'
+import { fetchActivityHistory } from './activity'
 
 // ------------------------------------
 // Constants
@@ -107,20 +105,6 @@ export const lightningGrpcActive = (event, lndConfig) => async dispatch => {
   //fetch user data. channels, balances, payments, invoices and transactions
   dispatch(fetchChannels())
   dispatch(fetchActivityHistory())
-}
-
-/**
- * Fetches user activity history. Which includes:
- * Balance
- * Payments
- * Invoices
- * Transactions
- */
-export const fetchActivityHistory = () => dispatch => {
-  dispatch(fetchBalance())
-  dispatch(fetchPayments())
-  dispatch(fetchInvoices())
-  dispatch(fetchTransactions())
 }
 
 // Connected to WalletUnlocker gRPC interface (lnd is ready to unlock or create wallet)

--- a/app/reducers/lnd.js
+++ b/app/reducers/lnd.js
@@ -6,6 +6,10 @@ import { fetchBalance } from './balance'
 import { fetchInfo, setHasSynced, infoSelectors } from './info'
 import { putWallet, setActiveWallet, walletSelectors } from './wallet'
 import { onboardingFinished, setSeed } from './onboarding'
+import { fetchChannels } from './channels'
+import { fetchTransactions } from './transaction'
+import { fetchPayments } from './payment'
+import { fetchInvoices } from './invoice'
 
 // ------------------------------------
 // Constants
@@ -100,6 +104,23 @@ export const lightningGrpcActive = (event, lndConfig) => async dispatch => {
 
   // Let the onboarding process know that the wallet has started.
   dispatch(onboardingFinished())
+  //fetch user data. channels, balances, payments, invoices and transactions
+  dispatch(fetchChannels())
+  dispatch(fetchActivityHistory())
+}
+
+/**
+ * Fetches user activity history. Which includes:
+ * Balance
+ * Payments
+ * Invoices
+ * Transactions
+ */
+export const fetchActivityHistory = () => dispatch => {
+  dispatch(fetchBalance())
+  dispatch(fetchPayments())
+  dispatch(fetchInvoices())
+  dispatch(fetchTransactions())
 }
 
 // Connected to WalletUnlocker gRPC interface (lnd is ready to unlock or create wallet)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Fetch user balance and activity history after LND grpc is ready
<!--- Describe your changes in detail -->

## Motivation and Context:
Under some circumstances there is a race condition between establishing grpc connection and loading user balance\activity when unlocking a wallet. In particular when connecting to a locked remote node. It results in `SET_LIGHTNING_WALLET_ACTIVE ` being dispatched after `fetchChannels` action. This results in app being stuck on the loading screen because app is unable to handle a response from the LND via IPC. This happens due to IPC handler being added only after `SET_LIGHTNING_WALLET_ACTIVE ` is dispatched. The solution applied also fixes [#1193](https://github.com/LN-Zap/zap-desktop/issues/1193)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
N/a
## Types of changes:
Explicit loading of user balance and activity history has been added after grpc is ready to avoid race condition
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [v] My code follows the code style of this project.
- [v] I have reviewed and updated the documentation accordingly.
- [v] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
