### PR TITLE
fix(onboarding): handle host/cert errors on boot

### DIFF
--- a/app/components/GlobalError/GlobalError.js
+++ b/app/components/GlobalError/GlobalError.js
@@ -7,7 +7,7 @@ import { Notification } from 'components/UI'
 
 class GlobalError extends React.Component {
   static propTypes = {
-    error: PropTypes.string,
+    error: PropTypes.oneOfType([PropTypes.string, PropTypes.array, PropTypes.object]),
     clearError: PropTypes.func.isRequired
   }
 
@@ -20,6 +20,20 @@ class GlobalError extends React.Component {
 
   render() {
     const { error, clearError } = this.props
+
+    let errors = []
+
+    if (error) {
+      if (Array.isArray(error)) {
+        errors = error
+      } else if (typeof error === 'string') {
+        errors.push(error)
+      } else if (typeof error === 'object') {
+        Object.keys(error).forEach(key => {
+          errors.push(`${key}: ${error[key]}`)
+        })
+      }
+    }
 
     return (
       <Transition
@@ -34,9 +48,11 @@ class GlobalError extends React.Component {
           (springStyles => (
             <Box mt="22px" px={3} width={1} css={{ position: 'absolute', 'z-index': '99999' }}>
               <animated.div style={springStyles}>
-                <Notification variant="error" onClick={clearError}>
-                  {errorToUserFriendly(error)}
-                </Notification>
+                {errors.map(error => (
+                  <Notification key={error} variant="error" onClick={clearError}>
+                    {errorToUserFriendly(error)}
+                  </Notification>
+                ))}
               </animated.div>
             </Box>
           ))

--- a/app/components/Home/Home.js
+++ b/app/components/Home/Home.js
@@ -23,7 +23,7 @@ class Home extends React.Component {
     activeWalletSettings: PropTypes.object,
     deleteWallet: PropTypes.func.isRequired,
     lndConnect: PropTypes.object,
-    startLndHostError: PropTypes.string,
+    startLndError: PropTypes.object,
     lightningGrpcActive: PropTypes.bool.isRequired,
     walletUnlockerGrpcActive: PropTypes.bool.isRequired,
     wallets: PropTypes.array.isRequired,
@@ -61,7 +61,7 @@ class Home extends React.Component {
       activeWallet,
       deleteWallet,
       startLnd,
-      startLndHostError,
+      startLndError,
       unlockWallet,
       wallets,
       setActiveWallet,
@@ -117,7 +117,7 @@ class Home extends React.Component {
                       stopLnd={stopLnd}
                       lightningGrpcActive={lightningGrpcActive}
                       walletUnlockerGrpcActive={walletUnlockerGrpcActive}
-                      startLndHostError={startLndHostError}
+                      startLndError={startLndError}
                       setError={setError}
                       setStartLndError={setStartLndError}
                       deleteWallet={deleteWallet}

--- a/app/components/Home/WalletLauncher.js
+++ b/app/components/Home/WalletLauncher.js
@@ -14,7 +14,7 @@ class WalletLauncher extends React.Component {
     startLnd: PropTypes.func.isRequired,
     lightningGrpcActive: PropTypes.bool.isRequired,
     walletUnlockerGrpcActive: PropTypes.bool.isRequired,
-    startLndHostError: PropTypes.string,
+    startLndError: PropTypes.object,
     setStartLndError: PropTypes.func.isRequired,
     setError: PropTypes.func.isRequired,
     stopLnd: PropTypes.func.isRequired,
@@ -24,12 +24,12 @@ class WalletLauncher extends React.Component {
   }
 
   componentDidMount() {
-    const { stopLnd, startLndHostError, setError, setStartLndError } = this.props
+    const { stopLnd, startLndError, setError, setStartLndError } = this.props
     stopLnd()
 
-    // If the wallet unlocker became active, switch to the login screen
-    if (startLndHostError) {
-      setError(startLndHostError)
+    // If there are lnd start errors, show as a global error.
+    if (startLndError) {
+      setError(startLndError)
       setStartLndError(null)
     }
   }
@@ -42,15 +42,15 @@ class WalletLauncher extends React.Component {
       history,
       lightningGrpcActive,
       walletUnlockerGrpcActive,
-      startLndHostError,
+      startLndError,
       setError,
       setStartLndError,
       wallet
     } = this.props
 
-    // If the wallet unlocker became active, switch to the login screen
-    if (startLndHostError && !prevProps.startLndHostError) {
-      setError(startLndHostError)
+    // If we got lnd start errors, show as a global error.
+    if (startLndError && !prevProps.startLndError) {
+      setError(startLndError)
       setStartLndError(null)
     }
 

--- a/app/components/Onboarding/Steps/ConnectionConfirm.js
+++ b/app/components/Onboarding/Steps/ConnectionConfirm.js
@@ -40,14 +40,7 @@ class ConnectionConfirm extends React.Component {
 
   static defaultProps = {
     wizardApi: {},
-    wizardState: {},
-    connectionHost: '',
-    connectionCert: '',
-    connectionMacaroon: '',
-    connectionString: '',
-    startLndHostError: '',
-    startLndCertError: '',
-    startLndMacaroonError: ''
+    wizardState: {}
   }
 
   handleSubmit = async () => {

--- a/app/components/Onboarding/Steps/ConnectionDetails.js
+++ b/app/components/Onboarding/Steps/ConnectionDetails.js
@@ -28,13 +28,7 @@ class ConnectionDetails extends React.Component {
 
   static defaultProps = {
     wizardApi: {},
-    wizardState: {},
-    connectionHost: '',
-    connectionCert: '',
-    connectionMacaroon: '',
-    startLndHostError: '',
-    startLndCertError: '',
-    startLndMacaroonError: ''
+    wizardState: {}
   }
 
   componentDidMount() {

--- a/app/containers/Home.js
+++ b/app/containers/Home.js
@@ -17,7 +17,7 @@ const mapStateToProps = state => ({
   activeWalletSettings: walletSelectors.activeWalletSettings(state),
   lightningGrpcActive: state.lnd.lightningGrpcActive,
   walletUnlockerGrpcActive: state.lnd.walletUnlockerGrpcActive,
-  startLndHostError: state.lnd.startLndHostError,
+  startLndError: state.lnd.startLndError,
   unlockingWallet: state.lnd.unlockingWallet,
   unlockWalletError: state.lnd.unlockWalletError
 })

--- a/app/containers/Initializer.js
+++ b/app/containers/Initializer.js
@@ -22,7 +22,7 @@ class Initializer extends React.Component {
     isReady: PropTypes.bool.isRequired,
     lightningGrpcActive: PropTypes.bool.isRequired,
     walletUnlockerGrpcActive: PropTypes.bool.isRequired,
-    startLndHostError: PropTypes.string.isRequired,
+    startLndError: PropTypes.object,
     startActiveWallet: PropTypes.func.isRequired,
     fetchSuggestedNodes: PropTypes.func.isRequired,
     fetchTicker: PropTypes.func.isRequired,
@@ -55,7 +55,7 @@ class Initializer extends React.Component {
       hasWallets,
       history,
       lightningGrpcActive,
-      startLndHostError,
+      startLndError,
       walletUnlockerGrpcActive,
       startActiveWallet
     } = this.props
@@ -64,7 +64,9 @@ class Initializer extends React.Component {
     if (isReady && !prevProps.isReady) {
       if (activeWalletSettings) {
         if (isWalletOpen) {
-          return startActiveWallet()
+          // Catch the error and swallow it with a noop.
+          // Errors are handled below by listening for updates to the startLndError prop.
+          return startActiveWallet().catch(() => {})
         } else {
           return history.push(`/home/wallet/${activeWallet}`)
         }
@@ -75,8 +77,8 @@ class Initializer extends React.Component {
       return hasWallets ? history.push('/home') : history.push('/onboarding')
     }
 
-    // If there wad a problem starting lnd, swich to the wallet launcher.
-    if (startLndHostError && !prevProps.startLndHostError) {
+    // If there was a problem starting lnd, swich to the wallet launcher.
+    if (startLndError && !prevProps.startLndError) {
       return history.push(`/home/wallet/${activeWallet}`)
     }
 
@@ -107,7 +109,7 @@ const mapStateToProps = state => ({
   hasWallets: walletSelectors.hasWallets(state),
   lightningGrpcActive: state.lnd.lightningGrpcActive,
   walletUnlockerGrpcActive: state.lnd.walletUnlockerGrpcActive,
-  startLndHostError: state.lnd.startLndHostError,
+  startLndError: state.lnd.startLndError,
   isWalletOpen: state.wallet.isWalletOpen,
   isReady: appSelectors.isReady(state)
 })

--- a/app/containers/Onboarding.js
+++ b/app/containers/Onboarding.js
@@ -24,7 +24,8 @@ import {
   fetchSeed,
   createNewWallet,
   recoverOldWallet,
-  unlockWallet
+  unlockWallet,
+  lndSelectors
 } from 'reducers/lnd'
 
 const mapStateToProps = state => ({
@@ -39,9 +40,9 @@ const mapStateToProps = state => ({
   lndConnect: state.onboarding.lndConnect,
   lightningGrpcActive: state.lnd.lightningGrpcActive,
   walletUnlockerGrpcActive: state.lnd.walletUnlockerGrpcActive,
-  startLndHostError: state.lnd.startLndHostError,
-  startLndCertError: state.lnd.startLndCertError,
-  startLndMacaroonError: state.lnd.startLndMacaroonError,
+  startLndHostError: lndSelectors.startLndHostError(state),
+  startLndCertError: lndSelectors.startLndCertError(state),
+  startLndMacaroonError: lndSelectors.startLndMacaroonError(state),
   seed: state.onboarding.seed,
   unlockWalletError: state.lnd.unlockWalletError,
   onboarded: state.onboarding.onboarded,

--- a/app/containers/Root.js
+++ b/app/containers/Root.js
@@ -34,7 +34,7 @@ class Root extends React.Component {
     hasWallets: PropTypes.bool,
     clearError: PropTypes.func.isRequired,
     theme: PropTypes.object,
-    error: PropTypes.string,
+    error: PropTypes.oneOfType([PropTypes.string, PropTypes.array, PropTypes.object]),
     history: PropTypes.object.isRequired,
     isLoading: PropTypes.bool.isRequired,
 

--- a/app/lib/zap/controller.js
+++ b/app/lib/zap/controller.js
@@ -205,7 +205,8 @@ class ZapController {
       //  There was a problem accessing the macaroon file.
       else if (
         e.code === 'LND_GRPC_MACAROON_ERROR' ||
-        e.message.includes('cannot determine data format of binary-encoded macaroon')
+        e.message.includes('cannot determine data format of binary-encoded macaroon') ||
+        e.message.includes('verification failed: signature mismatch after caveat verification')
       ) {
         errors.macaroon = e.message
       }

--- a/stories/containers/home.stories.js
+++ b/stories/containers/home.stories.js
@@ -62,6 +62,12 @@ const store = new Store({
   ]
 })
 
+const setError = async error => {
+  console.log('setError', error)
+}
+const setStartLndError = async error => {
+  console.log('setStartLndError', error)
+}
 const startLnd = async wallet => {
   console.log('startLnd', wallet)
   await delay(500)
@@ -114,6 +120,8 @@ storiesOf('Containers.Home', module)
               stopLnd={stopLnd}
               unlockWallet={unlockWallet}
               deleteWallet={deleteWallet}
+              setError={setError}
+              setStartLndError={setStartLndError}
               setUnlockWalletError={setUnlockWalletError}
               setActiveWallet={setActiveWallet}
             />


### PR DESCRIPTION
## Description:

Consolidate errors from startLnd into a single object, and ensure that we handle all lnd start errors.

## Motivation and Context:

When the app starts it tries to automatically log into the last active wallet. If there is a problem with the cert or macaroon files, the user is left hanging on the loading screen.

Fix #1215

## How Has This Been Tested?

1. Set up a connection to a remote node
2. Open the wallet and then quit zap
3. Delete or move the cert or macaroon file
4. Start Zap and verify that you are taken to the launchpad with the cause of the connection error showing.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
