### PR TITLE
refactor(props): do not pass lndConnect to DOM

### DIFF
--- a/app/components/Onboarding/Steps/ConnectionDetails.js
+++ b/app/components/Onboarding/Steps/ConnectionDetails.js
@@ -146,6 +146,7 @@ class ConnectionDetails extends React.Component {
       connectionHost,
       connectionCert,
       connectionMacaroon,
+      lndConnect,
       setConnectionHost,
       setConnectionCert,
       setConnectionMacaroon,


### PR DESCRIPTION
## Description:

Remove `lndConnect` prop in spread operator to ensure it doesn't get passed to the DOM as part of `...rest` 

## Motivation and Context:

Error in console on `ConnectionDetails` component in onboarding process.

> Warning: React does not recognize the `lndConnect` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `lndconnect` instead. If you accidentally passed it from a parent component, remove it from the DOM element.

## How Has This Been Tested?

1. Create new remote wallet
2. Check the console when on the Connection Details step

## Screenshot

![image](https://user-images.githubusercontent.com/200251/50738087-9a3bf080-11d0-11e9-976e-99b9668590f5.png)


## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
