### PR TITLE
fix(i18n): ensure modal help link is translatable

### DIFF
--- a/app/components/Onboarding/Steps/messages.js
+++ b/app/components/Onboarding/Steps/messages.js
@@ -35,7 +35,6 @@ export default defineMessages({
     'By selecting the default mode we will do everything for you. Just click and go!',
   disable: 'Disable Autopilot',
   enable: 'Enable Autopilot',
-  help: 'Need Help?',
   hostname_description: 'Hostname and port of the Lnd gRPC interface. Example: localhost:10009',
   hostname_title: 'Host',
   import_description: "Recovering a wallet, nice. You don't need anyone else, you got yourself :)",

--- a/app/components/UI/Modal.js
+++ b/app/components/UI/Modal.js
@@ -1,9 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { FormattedMessage } from 'react-intl'
 import { Box, Flex } from 'rebass'
 import X from 'components/Icon/X'
 import ZapLogo from 'components/Icon/ZapLogo'
 import { Panel, Text } from 'components/UI'
+import messages from './messages'
 
 /**
  * @render react
@@ -63,7 +65,7 @@ class Modal extends React.Component {
                 css={{ cursor: 'pointer', opacity: 0.6, '&:hover': { opacity: 1 } }}
                 onClick={() => window.Zap.openHelpPage()}
               >
-                Need Help?
+                <FormattedMessage {...messages.help} />
               </Text>
             </Flex>
           )}

--- a/app/components/UI/messages.js
+++ b/app/components/UI/messages.js
@@ -4,6 +4,7 @@ import { defineMessages } from 'react-intl'
 export default defineMessages({
   expires: 'Expires',
   expired: 'Expired',
+  help: 'Need Help?',
   required_field: 'This is a required field',
   invalid_request: 'Not a valid {chain} request.',
   valid_request: 'Valid {chain} request',

--- a/app/translations/af-ZA.json
+++ b/app/translations/af-ZA.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "",
+  "components.UI.help": "",
   "components.Onboarding.Steps.hostname_description": "",
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/ar-SA.json
+++ b/app/translations/ar-SA.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "تحتاج مساعدة؟",
+  "components.UI.help": "تحتاج مساعدة؟",
   "components.Onboarding.Steps.hostname_description": "",
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/bg-BG.json
+++ b/app/translations/bg-BG.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "Нужда от помощ?",
+  "components.UI.help": "Нужда от помощ?",
   "components.Onboarding.Steps.hostname_description": "Име на хост и порт на Lnd gRPC интерфейса. Пример: localhost:10009",
   "components.Onboarding.Steps.hostname_title": "Хост",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/ca-ES.json
+++ b/app/translations/ca-ES.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "",
+  "components.UI.help": "",
   "components.Onboarding.Steps.hostname_description": "",
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/cs-CZ.json
+++ b/app/translations/cs-CZ.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "Potřebujete poradit?",
+  "components.UI.help": "Potřebujete poradit?",
   "components.Onboarding.Steps.hostname_description": "Název hostitele a portu rozhraní Lnd gRPC. Příklad: localhost:10009",
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/da-DK.json
+++ b/app/translations/da-DK.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "Brug for hjælp?",
+  "components.UI.help": "Brug for hjælp?",
   "components.Onboarding.Steps.hostname_description": "",
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/de-DE.json
+++ b/app/translations/de-DE.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "Brauchst du Hilfe?",
+  "components.UI.help": "Brauchst du Hilfe?",
   "components.Onboarding.Steps.hostname_description": "Hostname und Port des Lnd gRPC Interface. Beispiel: localhost:10009",
   "components.Onboarding.Steps.hostname_title": "Betreiber",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/el-GR.json
+++ b/app/translations/el-GR.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "Χρειάζεστε βοήθεια;",
+  "components.UI.help": "Χρειάζεστε βοήθεια;",
   "components.Onboarding.Steps.hostname_description": "Όνομα κεντρικού υπολογιστή και θύρα της διεπαφής Lnd gRPC. Παράδειγμα: localhost:10009",
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "Disable Autopilot",
   "components.Onboarding.Steps.enable": "Enable Autopilot",
   "components.Onboarding.Steps.generating_seed": "Generating Seed...",
-  "components.Onboarding.Steps.help": "Need Help?",
+  "components.UI.help": "Need Help?",
   "components.Onboarding.Steps.hostname_description": "Hostname and port of the Lnd gRPC interface. Example: localhost:10009",
   "components.Onboarding.Steps.hostname_title": "Host",
   "components.Onboarding.Steps.import_description": "Recovering a wallet, nice. You don't need anyone else, you got yourself :)",

--- a/app/translations/es-ES.json
+++ b/app/translations/es-ES.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "¿Necesitas ayuda?",
+  "components.UI.help": "¿Necesitas ayuda?",
   "components.Onboarding.Steps.hostname_description": "Nombre de host y el puerto de la interfaz de gRPC Lnd. Ejemplo: localhost:10009",
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/fi-FI.json
+++ b/app/translations/fi-FI.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "",
+  "components.UI.help": "",
   "components.Onboarding.Steps.hostname_description": "",
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/fr-FR.json
+++ b/app/translations/fr-FR.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "Aide ?",
+  "components.UI.help": "Aide ?",
   "components.Onboarding.Steps.hostname_description": "Le nom d’hôte et le port de l’interface de gRPC Lnd. Exemple : localhost:10009",
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/ga-IE.json
+++ b/app/translations/ga-IE.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "Teastaionn Cabhair?",
+  "components.UI.help": "Teastaionn Cabhair?",
   "components.Onboarding.Steps.hostname_description": "Ainm óstach agus calafort an Lnd gRPC comhéadan. Mar shampla: localhost:10009",
   "components.Onboarding.Steps.hostname_title": "Óstach",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/he-IL.json
+++ b/app/translations/he-IL.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "צריך עזרה?",
+  "components.UI.help": "צריך עזרה?",
   "components.Onboarding.Steps.hostname_description": "",
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/hi-IN.json
+++ b/app/translations/hi-IN.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "",
+  "components.UI.help": "",
   "components.Onboarding.Steps.hostname_description": "",
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/hr-HR.json
+++ b/app/translations/hr-HR.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "Trebate li pomoć?",
+  "components.UI.help": "Trebate li pomoć?",
   "components.Onboarding.Steps.hostname_description": "Hostname i port Lnd gRPC sučelja. Primjer: localhost:10009",
   "components.Onboarding.Steps.hostname_title": "Domaćin",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/hu-HU.json
+++ b/app/translations/hu-HU.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "",
+  "components.UI.help": "",
   "components.Onboarding.Steps.hostname_description": "",
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/it-IT.json
+++ b/app/translations/it-IT.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "",
+  "components.UI.help": "",
   "components.Onboarding.Steps.hostname_description": "",
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/ja-JP.json
+++ b/app/translations/ja-JP.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "ヘルプが必要ですか。",
+  "components.UI.help": "ヘルプが必要ですか。",
   "components.Onboarding.Steps.hostname_description": "ホスト名とLnd gRPC インターフェイスのポート。例: localhost:10009",
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/ko-KR.json
+++ b/app/translations/ko-KR.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "",
+  "components.UI.help": "",
   "components.Onboarding.Steps.hostname_description": "",
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/nl-NL.json
+++ b/app/translations/nl-NL.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "Hulp nodig?",
+  "components.UI.help": "Hulp nodig?",
   "components.Onboarding.Steps.hostname_description": "Hostnaam en poort van de Lnd gRPC interface. Voorbeeld: localhost:10009",
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/no-NO.json
+++ b/app/translations/no-NO.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "",
+  "components.UI.help": "",
   "components.Onboarding.Steps.hostname_description": "",
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/pl-PL.json
+++ b/app/translations/pl-PL.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "Potrzebujesz pomocy?",
+  "components.UI.help": "Potrzebujesz pomocy?",
   "components.Onboarding.Steps.hostname_description": "",
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/pt-BR.json
+++ b/app/translations/pt-BR.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "Precisa de ajuda?",
+  "components.UI.help": "Precisa de ajuda?",
   "components.Onboarding.Steps.hostname_description": "Hostname e porta da interface Lnd gRPC. Exemplo: localhost:10009",
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/pt-PT.json
+++ b/app/translations/pt-PT.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "Precisa de Ajuda?",
+  "components.UI.help": "Precisa de Ajuda?",
   "components.Onboarding.Steps.hostname_description": "",
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/ro-RO.json
+++ b/app/translations/ro-RO.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "Ai nevoie de ajutor?",
+  "components.UI.help": "Ai nevoie de ajutor?",
   "components.Onboarding.Steps.hostname_description": "Numele de gazdă şi port de interfaţă Lnd gRPC. Exemplu: localhost:10009",
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/ru-RU.json
+++ b/app/translations/ru-RU.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "Нужна помощь?",
+  "components.UI.help": "Нужна помощь?",
   "components.Onboarding.Steps.hostname_description": "Имя хоста и порт для интерфейса Lnd gRPC. Пример: localhost:10009",
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/sr-SP.json
+++ b/app/translations/sr-SP.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "",
+  "components.UI.help": "",
   "components.Onboarding.Steps.hostname_description": "",
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/sv-SE.json
+++ b/app/translations/sv-SE.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "Behöver du hjälp?",
+  "components.UI.help": "Behöver du hjälp?",
   "components.Onboarding.Steps.hostname_description": "Hostname och port för Lnd gRPC interface. Exempel: localhost:10009",
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/tr-TR.json
+++ b/app/translations/tr-TR.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "Yardım ister misin?",
+  "components.UI.help": "Yardım ister misin?",
   "components.Onboarding.Steps.hostname_description": "Lnd gRPC arayüzünün ana makine adı ve portu. Örnek: localhost: 10009",
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/uk-UA.json
+++ b/app/translations/uk-UA.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "Потрібна допомога?",
+  "components.UI.help": "Потрібна допомога?",
   "components.Onboarding.Steps.hostname_description": "Ім'я хоста і порту Lnd gRPC інтерфейсу. Приклад: localhost:10009",
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/vi-VN.json
+++ b/app/translations/vi-VN.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "",
+  "components.UI.help": "",
   "components.Onboarding.Steps.hostname_description": "",
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/zh-CN.json
+++ b/app/translations/zh-CN.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "需要帮助吗？",
+  "components.UI.help": "需要帮助吗？",
   "components.Onboarding.Steps.hostname_description": "Lnd gRPC 接口的主机名和端口。示例: localhost:10009",
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",

--- a/app/translations/zh-TW.json
+++ b/app/translations/zh-TW.json
@@ -143,7 +143,7 @@
   "components.Onboarding.Steps.disable": "",
   "components.Onboarding.Steps.enable": "",
   "components.Onboarding.Steps.generating_seed": "",
-  "components.Onboarding.Steps.help": "需要帮助吗？",
+  "components.UI.help": "需要帮助吗？",
   "components.Onboarding.Steps.hostname_description": "Lnd gRPC 接口的主机名和端口。示例: localhost:10009",
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",


### PR DESCRIPTION
## Description:

Extract help link text into translation files to ensure it can be translated.

## Motivation and Context:

Fix #1271

## How Has This Been Tested?

Manually - ensure that help string displays correctly in the Syncing modal window.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
