### PR TITLE
chore(config): remove duplicate code

### DIFF
--- a/app/lib/lnd/config.js
+++ b/app/lib/lnd/config.js
@@ -118,17 +118,6 @@ class LndConfig {
     autopilotMinconfs: 0
   }
 
-  static SETTINGS_DEFAULTS = {
-    name: null,
-    autopilot: true,
-    autopilotMaxchannels: 5,
-    autopilotMinchansize: 20000,
-    autopilotMaxchansize: 16777215,
-    autopilotAllocation: 0.6,
-    autopilotPrivate: true,
-    autopilotMinconfs: 0
-  }
-
   // Type descriptor properties.
   id: number
   type: string


### PR DESCRIPTION
## Description:

`SETTINGS_DEFAULTS ` const is defined twice in lib/lns/config.js`, probably the result of a bad conflict resolution. Remove the duplicate.

## Motivation and Context

Fix #1270

## Types of changes:

Chore

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
