### PR TITLE
refactor(icons): remove namespace from orbit icon

### DIFF
--- a/app/components/Icon/Orbit.js
+++ b/app/components/Icon/Orbit.js
@@ -1,12 +1,11 @@
 import React from 'react'
 
 const SvgOrbit = props => (
-  <svg viewBox="0 0 200 200" xmlns:bx="https://boxy-svg.com" {...props} width="1em" height="1em">
-    <g bx:origin="0 0" transform="rotate(135 100 100)">
-      <circle cx={20} cy={100} r={15} bx:origin="0 0" fill="#fd9800" />
+  <svg viewBox="0 0 200 200" {...props} width="1em" height="1em">
+    <g transform="rotate(135 100 100)">
+      <circle cx={20} cy={100} r={15} fill="#fd9800" />
       <path
         d="M43.716 156.854c44.22 44.218 116.627 22.346 134.01-35.695 15.845-59.58-38.821-114.247-98.4-98.4A79.752 79.752 0 0 0 43.43 43.432"
-        bx:origin="0 0"
         fill="none"
         paintOrder="stroke"
         stroke="#fff"
@@ -14,7 +13,7 @@ const SvgOrbit = props => (
         strokeWidth={2.8}
       />
     </g>
-    <g transform="rotate(9.999 -130.687 272.785) scale(.65141)" bx:origin="0 0">
+    <g transform="rotate(9.999 -130.687 272.785) scale(.65141)">
       <circle cx={21.478} cy={96.049} r={15.351} fill="#fd9800" />
       <path
         d="M45.371 153.325c44.547 44.547 117.494 22.512 135.005-35.96 15.964-60.023-39.109-115.096-99.13-99.132a80.34 80.34 0 0 0-36.162 20.828"
@@ -25,7 +24,7 @@ const SvgOrbit = props => (
         strokeWidth={7.369}
       />
     </g>
-    <g bx:origin="0 0" transform="matrix(-.12289 -.33764 .33672 -.12255 83.046 146.287)">
+    <g transform="matrix(-.12289 -.33764 .33672 -.12255 83.046 146.287)">
       <circle cx={28.276} cy={88.641} r={13.916} fill="#fd9800" />
       <path
         d="M105.092 165.386c59.827 0 94.188-63.953 66.822-115.117-29.446-51.163-103.409-51.163-133.133 0A76.826 76.826 0 0 0 28.38 88.644"

--- a/app/icons/orbit.svg
+++ b/app/icons/orbit.svg
@@ -1,16 +1,13 @@
 <svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" xmlns:bx="https://boxy-svg.com">
-  <defs>
-    <bx:guide x="19.983" y="127.197" angle="0"></bx:guide>
-  </defs>
-  <g bx:origin="0 0" transform="matrix(-0.707107, 0.707107, -0.707107, -0.707107, 241.421051, 99.999451)" origin="0.454539 0.492415">
-    <circle style="fill: rgb(253, 152, 0);" cx="20" cy="100" r="15" bx:origin="0 0" origin="3.1672 0.5"></circle>
-    <path style="fill: none; paint-order: stroke; stroke: rgb(255, 255, 255); stroke-linecap: round; stroke-width: 2.8px;" d="M 100.403 180 C 162.938 180 198.672 113.334 169.922 60.001 C 138.997 6.667 61.687 6.667 30.763 60.001 C 23.713 72.163 20 85.957 20 100.002" bx:origin="0 0" transform="matrix(0.707107, 0.707107, -0.707107, 0.707107, 99.999965, -41.421415)" origin="0.5 0.499998"></path>
+  <g transform="matrix(-0.707107, 0.707107, -0.707107, -0.707107, 241.421051, 99.999451)" origin="0.454539 0.492415">
+    <circle style="fill: rgb(253, 152, 0);" cx="20" cy="100" r="15" origin="3.1672 0.5"></circle>
+    <path style="fill: none; paint-order: stroke; stroke: rgb(255, 255, 255); stroke-linecap: round; stroke-width: 2.8px;" d="M 100.403 180 C 162.938 180 198.672 113.334 169.922 60.001 C 138.997 6.667 61.687 6.667 30.763 60.001 C 23.713 72.163 20 85.957 20 100.002" transform="matrix(0.707107, 0.707107, -0.707107, 0.707107, 99.999965, -41.421415)" origin="0.5 0.499998"></path>
   </g>
-  <g transform="matrix(0.641515, 0.113116, -0.113116, 0.641515, 45.383427, 26.837219)" bx:origin="0 0" origin="0.454538 0.492415">
+  <g transform="matrix(0.641515, 0.113116, -0.113116, 0.641515, 45.383427, 26.837219)" origin="0.454538 0.492415">
     <circle style="fill: rgb(253, 152, 0);" cx="21.478" cy="96.049" r="15.351" origin="3.125068 0.49999"></circle>
     <path style="fill: none; paint-order: stroke; stroke: rgb(255, 255, 255); stroke-linecap: round; stroke-width: 7.36861px;" d="M 102.479 176.643 C 165.478 176.643 201.478 109.481 172.514 55.752 C 141.36 2.022 63.475 2.022 32.322 55.752 C 25.219 68.005 21.479 81.901 21.479 96.05" transform="matrix(0.707107, 0.707107, -0.707107, 0.707107, 97.813187, -44.044418)" origin="0.499999 0.5"></path>
   </g>
-  <g bx:origin="0 0" transform="matrix(-0.12289, -0.337638, 0.336718, -0.122555, 83.045967, 146.287384)" origin="0.454588 0.49247">
+  <g transform="matrix(-0.12289, -0.337638, 0.336718, -0.122555, 83.045967, 146.287384)" origin="0.454588 0.49247">
     <circle style="fill: rgb(253, 152, 0);" cx="28.276" cy="88.641" r="13.916" origin="3.253673 0.500016"></circle>
     <path style="fill: none; paint-order: stroke; stroke: rgb(255, 255, 255); stroke-linecap: round; stroke-width: 7.80342px;" d="M 105.092 165.386 C 164.919 165.386 199.28 101.433 171.914 50.269 C 142.468 -0.894 68.505 -0.894 38.781 50.269 C 32.004 61.937 28.417 75.17 28.38 88.644" transform="matrix(0.707084, 0.709061, -0.705203, 0.707084, 93.241804, -48.42771)" origin="0.5 0.5"></path>
   </g>


### PR DESCRIPTION
## Description:

Remove unneeded namespaces from svg icon

## Motivation and Context:

This svg icon has some namespaced attributes that are causing errors in the console when generating the coverage report after running the unit tests.

## How Has This Been Tested?

Run `yarn test-unit` and verify that the error message shown below no longer appears.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/200251/50818703-1d238f00-1328-11e9-8d0a-b045e307c5d1.png)

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
