### PR TITLE
fix(payment): timeout payment requests after 60 seconds

### DIFF
--- a/app/components/Activity/Payment/Payment.js
+++ b/app/components/Activity/Payment/Payment.js
@@ -50,7 +50,9 @@ const Payment = ({
             )}
             {payment.status === 'failed' && (
               <Message variant="error">
-                <FormattedMessage {...messages.status_error} /> {payment.error}
+                <FormattedMessage {...messages.status_error} />
+                {` `}
+                {payment.error}
               </Message>
             )}
           </>

--- a/app/components/UI/Message.js
+++ b/app/components/UI/Message.js
@@ -44,7 +44,7 @@ class Message extends React.Component {
       <StyledMessage fontSize="s" fontWeight="normal" variant={variant} {...rest}>
         <Flex alignItems="center" justifyContent={justifyContent}>
           {this.renderIcon()}
-          <Box>{children}</Box>
+          <Text>{children}</Text>
         </Flex>
       </StyledMessage>
     )

--- a/app/lib/lnd/methods/index.js
+++ b/app/lib/lnd/methods/index.js
@@ -180,12 +180,11 @@ export default function(lnd, log, event, msg, data) {
         .then(payment => {
           log.info('payment:', payment)
           const { payment_route } = payment
-          log.info('payinvoice success:', payment_route)
           event.sender.send('paymentSuccessful', Object.assign(data, { payment_route }))
           return payment
         })
         .catch(error => {
-          log.error('error: ', error)
+          log.error('payment error: ', error)
           event.sender.send('paymentFailed', Object.assign(data, { error: error.toString() }))
         })
       break

--- a/app/lib/utils/promiseTimeout.js
+++ b/app/lib/utils/promiseTimeout.js
@@ -1,0 +1,14 @@
+const promiseTimeout = function(ms, promise) {
+  // Create a promise that rejects in <ms> milliseconds
+  let timeout = new Promise((resolve, reject) => {
+    let id = setTimeout(() => {
+      clearTimeout(id)
+      reject(`Timed out.`)
+    }, ms)
+  })
+
+  // Returns a race between our timeout and the passed in promise
+  return Promise.race([promise, timeout])
+}
+
+export default promiseTimeout

--- a/test/unit/components/UI/__snapshots__/Message.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Message.spec.js.snap
@@ -17,9 +17,9 @@ exports[`component.UI.Message should render correctly with default props 1`] = `
       mr={1}
       width="14px"
     />
-    <styled.div>
+    <Styled(styled.div)>
       A message
-    </styled.div>
+    </Styled(styled.div)>
   </Styled(styled.div)>
 </Styled(Styled(styled.div))>
 `;


### PR DESCRIPTION
## Description:

Mark payments as failed if there is no response within 60 seconds.

## Motivation and Context:

Fix #1292

## How Has This Been Tested?

Try to pay a payment that times out.

I was able to do this by trying to send a payment immediately after logging into a local wallet - presumably before lnd had a chance to reestablish an up to date network picture.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/200251/50863392-ca38ee80-139e-11e9-8a6f-5c1d49da06ea.png)


## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
