### PR TITLE
fix(onboarding): better categorize macaroon error

### DIFF
--- a/app/lib/zap/controller.js
+++ b/app/lib/zap/controller.js
@@ -205,8 +205,11 @@ class ZapController {
       //  There was a problem accessing the macaroon file.
       else if (
         e.code === 'LND_GRPC_MACAROON_ERROR' ||
-        e.message.includes('cannot determine data format of binary-encoded macaroon') ||
-        e.message.includes('verification failed: signature mismatch after caveat verification')
+        [
+          'cannot determine data format of binary-encoded macaroon',
+          'verification failed: signature mismatch after caveat verification',
+          'unmarshal v2: section extends past end of buffer'
+        ].includes(e.message)
       ) {
         errors.macaroon = e.message
       }


### PR DESCRIPTION
## Description:

Ensure macaroon error is categorised as such.

## Motivation and Context:

If you try to connect to a remote server with a macaroon that has incorrect line endings the error message shows as a host error rather than a macaroon error

(these can get converted when, for example, committing a macaroon file to github:

> warning: CRLF will be replaced by LF in test/e2e/fixtures/readonly.macaroon.
> The file will have its original line endings in your working directory

## How Has This Been Tested?

Manually - try connecting to a remote server using a macaroon file whose line endings have been altered

## Screenshots (if appropriate):

**before:**

<img width="1132" alt="screenshot 2019-01-10 11 00 21" src="https://user-images.githubusercontent.com/200251/50961457-129ffb80-14c8-11e9-8416-20bdfb562539.png">

**after:**

<img width="1132" alt="screenshot 2019-01-10 10 58 58" src="https://user-images.githubusercontent.com/200251/50961474-192e7300-14c8-11e9-9686-a2e759a57c2b.png">

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
