### PR TITLE
fix(onboarding): handle btcpayserver connection issues

### DIFF
--- a/app/components/Onboarding/Steps/BtcPayServer.js
+++ b/app/components/Onboarding/Steps/BtcPayServer.js
@@ -19,10 +19,14 @@ class BtcPayServer extends React.Component {
     wizardState: {}
   }
 
-  componentDidUpdate(prevProps) {
-    const { startLndHostError } = this.props
-    if (startLndHostError && startLndHostError !== prevProps.startLndHostError) {
-      this.formApi.setError('connectionString', startLndHostError)
+  componentDidMount() {
+    const { props, formApi } = this
+    const { startLndHostError, startLndMacaroonError } = props
+    if (startLndHostError) {
+      formApi.setError('connectionString', startLndHostError)
+    }
+    if (startLndMacaroonError) {
+      formApi.setError('connectionString', startLndMacaroonError)
     }
   }
 

--- a/app/components/Onboarding/Steps/ConnectionConfirm.js
+++ b/app/components/Onboarding/Steps/ConnectionConfirm.js
@@ -83,10 +83,14 @@ class ConnectionConfirm extends React.Component {
       ...rest
     } = this.props
     const { getApi, preSubmit, onSubmit, onSubmitFailure } = wizardApi
+    let hostname
 
-    // Determine the hostname.
-    let hostname = connectionHost.split(':')[0]
-    if (connectionString) {
+    // If we have a hostname, use it as is.
+    if (connectionHost) {
+      hostname = connectionHost.split(':')[0]
+    }
+    // Otherwise, if we have a connection string, parse the host details from that.
+    else if (connectionString) {
       const { host } = parseConnectionString(connectionString)
       hostname = host
     }
@@ -117,13 +121,22 @@ class ConnectionConfirm extends React.Component {
 
         <Bar my={4} />
 
-        <Text>
-          <FormattedMessage {...messages.verify_host_title} />{' '}
-          <Span color="superGreen">{hostname}</Span>?{' '}
-        </Text>
-        <Text mt={2}>
-          <FormattedMessage {...messages.verify_host_description} />
-        </Text>
+        {!hostname && (
+          <Text>
+            <FormattedMessage {...messages.btcpay_error} />
+          </Text>
+        )}
+        {hostname && (
+          <>
+            <Text>
+              <FormattedMessage {...messages.verify_host_title} />{' '}
+              <Span color="superGreen">{hostname}</Span>?{' '}
+            </Text>
+            <Text mt={2}>
+              <FormattedMessage {...messages.verify_host_description} />
+            </Text>
+          </>
+        )}
       </Form>
     )
   }

--- a/app/components/UI/TextArea.js
+++ b/app/components/UI/TextArea.js
@@ -154,23 +154,16 @@ class TextArea extends React.PureComponent {
           required={required}
           error={fieldState.error}
         />
-        <Flex>
-          {description && (
-            <Text color="gray" fontSize="s" mt={1} mr="auto">
-              {description}
-            </Text>
-          )}
-          {showMessage && (fieldState.error || fieldState.asyncError) && (
-            <Message
-              variant={hasFocus ? 'warning' : 'error'}
-              justifyContent={justifyContent}
-              mt={1}
-              ml="auto"
-            >
-              {fieldState.error || fieldState.asyncError}
-            </Message>
-          )}
-        </Flex>
+        {description && (
+          <Text color="gray" fontSize="s" mt={1}>
+            {description}
+          </Text>
+        )}
+        {showMessage && (fieldState.error || fieldState.asyncError) && (
+          <Message variant={hasFocus ? 'warning' : 'error'} mt={1}>
+            {fieldState.error || fieldState.asyncError}
+          </Message>
+        )}
       </Flex>
     )
   }

--- a/test/unit/components/UI/__snapshots__/LightningInvoiceInput.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/LightningInvoiceInput.spec.js.snap
@@ -11,13 +11,6 @@ exports[`component.UI.LightningInvoiceInput should render correctly 1`] = `
   flex-direction: column;
 }
 
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
 .c1 {
   padding: 16px;
   width: 100%;
@@ -62,9 +55,6 @@ exports[`component.UI.LightningInvoiceInput should render correctly 1`] = `
       spellCheck="false"
       value=""
       width={1}
-    />
-    <div
-      className="c2"
     />
   </div>
 </form>


### PR DESCRIPTION
## Description:

Fix black screen of death issue when trying to connect to a btcpayserver instance.

## Motivation and Context:

After submitting the BtcPayServer connection form, the user is left on a black screen with no way to recover.

## How Has This Been Tested?

Try to set up a new wallet that connects to a BTCPayServer node. You can use these details for testing:

```
{
  "configurations": [
    {
      "type": "grpc",
      "cryptoCode": "BTC",
      "host": "example.com",
      "port": "19000",
      "macaroon": "macaroon"
    }
  ]
}
```

(they are not valid connection details so you will not be able to connect, but they follow the expected format and will trigger the error/solution)

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
