### PR TITLE
chore(deps): update bolt11 dependency to v1.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -290,7 +290,7 @@
     "axios": "0.18.0",
     "bip39-en": "1.1.1",
     "bitcoinjs-lib": "4.0.2",
-    "bolt11": "https://github.com/ln-zap/bolt11.git#2bcd70d6291c1fb199bb859cd21fd1f67e28cd66",
+    "bolt11": "1.2.2",
     "coininfo": "git+https://github.com/cryptocoinjs/coininfo.git#c7e003b2fc0db165b89e6f98f6d6360ad22616b2",
     "connected-react-router": "5.0.1",
     "copy-to-clipboard": "3.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3406,9 +3406,10 @@ body-parser@1.18.3:
     raw-body "2.3.3"
     type-is "~1.6.16"
 
-"bolt11@https://github.com/ln-zap/bolt11.git#2bcd70d6291c1fb199bb859cd21fd1f67e28cd66":
-  version "1.2.1"
-  resolved "https://github.com/ln-zap/bolt11.git#2bcd70d6291c1fb199bb859cd21fd1f67e28cd66"
+bolt11@1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/bolt11/-/bolt11-1.2.2.tgz#1d8ddaa46f5d4085efee3db4d84dd43756f028b8"
+  integrity sha512-hvmXNrNMrB7V2km3yotI/f23jodSnWVyoJqUsySFvLDcieDJf5Nox0+cleviSExM2YJt33PzxF44UFha/lwCJw==
   dependencies:
     bech32 "^1.1.2"
     bitcoinjs-lib "^3.3.1"


### PR DESCRIPTION
## Description:
Switch from custom fork of bolt11 to v1.2.2 official release.

## Motivation and Context:

My last patch against bolt11 to support uppercase payment requests was merged and 1.2.2 released with the fix.

## How Has This Been Tested?

Verify that uppercase and lowercase payment requests can be parsed.

## Types of changes:

Chore

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
