### PR TITLE
fix(ui): loading screen flicker on wallet start

### DIFF
--- a/app/containers/Root.js
+++ b/app/containers/Root.js
@@ -127,7 +127,7 @@ const mapStateToProps = state => ({
   hasWallets: walletSelectors.hasWallets(state),
   errors: errorSelectors.getErrorState(state),
   theme: themeSelectors.currentThemeSettings(state),
-  isLoading: appSelectors.isLoading(state) || state.lnd.startingLnd,
+  isLoading: appSelectors.isLoading(state),
   isMounted: appSelectors.isMounted(state)
 })
 


### PR DESCRIPTION
## Description:

Do not show the loading screen when starting up lnd

## Motivation and Context:

It usually takes less than a second to start lnd, and showing the loading screen for a split second is distracting and looks like a display glitch.

## How Has This Been Tested?

Click the `launch` button on the wallet settings page for a local wallet.

Prior to this patch, the Loading screen would show for a split second before the password entry screen shows.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
