### PR TITLE
fix(wallet): satoshi to millisatoshi conversion

### DIFF
--- a/app/lib/utils/btc.js
+++ b/app/lib/utils/btc.js
@@ -84,7 +84,7 @@ export function satoshisToBits(satoshis) {
 export function satoshisToMillisatoshis(satoshis) {
   if (isEmptyAmount(satoshis)) return null
 
-  return satoshisToBits(satoshis) * 1000 || 0
+  return satoshis * 1000 || 0
 }
 
 export function satoshisToFiat(satoshis, price) {


### PR DESCRIPTION
## Description:

Millisatoshi should be satoshi * 1000 (we were converting satoshi to bits first, and then multiplying by 1000 which was resulting in an incorrect conversion.

## Motivation and Context:

Fix #1332

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
