### PR TITLE
fix(wallet): phots to ltc conversion

### DIFF
--- a/app/lib/utils/btc.js
+++ b/app/lib/utils/btc.js
@@ -172,6 +172,7 @@ export function convert(from, to, amount, price) {
     case 'phots':
       switch (to) {
         case 'btc':
+        case 'ltc':
           return bitsToBtc(amount)
         case 'sats':
         case 'lits':


### PR DESCRIPTION
## Description:

Allow for phots to ltc conversion

## Motivation and Context:

Fix #1345

## How Has This Been Tested?

1. Connect to litecoin node
1. Navigate to Request form
1. Set currency unit to photons
1. Enter a value in the amount field
1. Change currency unit to LTC

Ensure that correct conversion happens (previously would result in an error)

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
