### PR TITLE
refactor(lib): apply notification.onClick properly

### DIFF
--- a/app/lib/utils/notifications.js
+++ b/app/lib/utils/notifications.js
@@ -1,8 +1,7 @@
 export const showNotification = (title, body, onClick) => {
-  new Notification(title, {
-    body,
-    onClick
-  })
+  const notification = new Notification(title, { body })
+
+  notification.onClick = onClick
 }
 
 export default { showNotification }


### PR DESCRIPTION
## Description:

Correctly apply `Notification.onClick` property. We don't actually use the onClick anywhere currently, but the current code would not work if we did.

## Motivation and Context:

Fix #1336 

## How Has This Been Tested?

Manually - verify all notifications work correctly

## Types of changes:

Refactor / Fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
