### PR TITLE
perf(ui): reduce superfluous component renders

### DIFF
--- a/app/components/Activity/Activity.js
+++ b/app/components/Activity/Activity.js
@@ -6,7 +6,6 @@ import { Bar, Button, Form, Heading, Input, Panel, Spinner, Text } from 'compone
 import Search from 'components/Icon/Search'
 import X from 'components/Icon/X'
 
-import Wallet from 'components/Wallet'
 import messages from './messages'
 import ActivityListItem from './ActivityListItem'
 
@@ -116,14 +115,7 @@ class Activity extends Component {
   }
 
   renderActivityList = () => {
-    const {
-      currentActivity,
-      currencyName,
-      ticker,
-      currentTicker,
-      showActivityModal,
-      network
-    } = this.props
+    const { currentActivity, currencyName, ticker, currentTicker, showActivityModal } = this.props
 
     if (!currencyName) {
       return null
@@ -141,7 +133,6 @@ class Activity extends Component {
               currencyName,
               currentTicker,
               showActivityModal,
-              network,
               ticker
             }}
           />
@@ -168,22 +159,18 @@ class Activity extends Component {
   render() {
     const {
       activity: { searchActive },
-      balance,
       currentActivity,
       currentTicker,
-      walletProps,
       showExpiredToggle
     } = this.props
 
-    if (!currentTicker || balance.channelBalance === null || balance.walletBalance === null) {
+    if (!currentTicker) {
       return null
     }
 
     return (
       <Panel>
         <Panel.Header>
-          <Wallet {...walletProps} />
-
           <Flex
             as="nav"
             justifyContent="space-between"
@@ -211,25 +198,19 @@ class Activity extends Component {
 }
 
 Activity.propTypes = {
-  fetchActivityHistory: PropTypes.func.isRequired,
-
-  ticker: PropTypes.object.isRequired,
-  currentTicker: PropTypes.object,
-  network: PropTypes.object.isRequired,
-
-  showActivityModal: PropTypes.func.isRequired,
-  changeFilter: PropTypes.func.isRequired,
-  updateSearchActive: PropTypes.func.isRequired,
-  updateSearchText: PropTypes.func.isRequired,
-  toggleExpiredRequests: PropTypes.func.isRequired,
-
   activity: PropTypes.object.isRequired,
   currentActivity: PropTypes.array.isRequired,
+  currencyName: PropTypes.string,
+  currentTicker: PropTypes.object,
+  ticker: PropTypes.object.isRequired,
   showExpiredToggle: PropTypes.bool.isRequired,
-  balance: PropTypes.object.isRequired,
-  walletProps: PropTypes.object.isRequired,
 
-  currencyName: PropTypes.string
+  changeFilter: PropTypes.func.isRequired,
+  fetchActivityHistory: PropTypes.func.isRequired,
+  showActivityModal: PropTypes.func.isRequired,
+  toggleExpiredRequests: PropTypes.func.isRequired,
+  updateSearchActive: PropTypes.func.isRequired,
+  updateSearchText: PropTypes.func.isRequired
 }
 
 export default injectIntl(Activity)

--- a/app/components/Activity/ActivityListItem.js
+++ b/app/components/Activity/ActivityListItem.js
@@ -2,13 +2,14 @@ import React, { PureComponent } from 'react'
 import { Box, Flex } from 'rebass'
 import PropTypes from 'prop-types'
 
+import InvoiceContainer from 'containers/Activity/InvoiceContainer'
+import PaymentContainer from 'containers/Activity/PaymentContainer'
+import TransactionContainer from 'containers/Activity/TransactionContainer'
+
 import ChainLink from 'components/Icon/ChainLink'
 import Clock from 'components/Icon/Clock'
 import Zap from 'components/Icon/Zap'
 import { Text } from 'components/UI'
-import Transaction from './Transaction'
-import Invoice from './Invoice'
-import Payment from './Payment'
 
 const ActivityIcon = ({ activity }) => {
   switch (activity.type) {
@@ -29,56 +30,20 @@ export default class ActivityListItem extends PureComponent {
     showActivityModal: PropTypes.func.isRequired,
     currencyName: PropTypes.string,
     ticker: PropTypes.object.isRequired,
-    network: PropTypes.object.isRequired,
     activity: PropTypes.object.isRequired
   }
 
   render() {
-    const {
-      activity,
-      currencyName,
-      currentTicker,
-      network,
-      ticker,
-      showActivityModal,
-      ...rest
-    } = this.props
+    const { activity, currencyName, currentTicker, ticker, showActivityModal, ...rest } = this.props
     return (
       <Flex justifyContent="space-between" alignItems="center" {...rest}>
         <Text width={24} ml={-35} color="gray" textAlign="center">
           <ActivityIcon activity={activity} />
         </Text>
         <Box width={1} css={!activity.sending ? { cursor: 'pointer' } : null}>
-          {activity.type === 'transaction' && (
-            <Transaction
-              transaction={activity}
-              ticker={ticker}
-              currentTicker={currentTicker}
-              showActivityModal={showActivityModal}
-              currencyName={currencyName}
-            />
-          )}
-
-          {activity.type === 'invoice' && (
-            <Invoice
-              invoice={activity}
-              ticker={ticker}
-              currentTicker={currentTicker}
-              showActivityModal={showActivityModal}
-              currencyName={currencyName}
-            />
-          )}
-
-          {activity.type === 'payment' && (
-            <Payment
-              payment={activity}
-              ticker={ticker}
-              currentTicker={currentTicker}
-              showActivityModal={showActivityModal}
-              nodes={network.nodes}
-              currencyName={currencyName}
-            />
-          )}
+          {activity.type === 'transaction' && <TransactionContainer transaction={activity} />}
+          {activity.type === 'invoice' && <InvoiceContainer invoice={activity} />}
+          {activity.type === 'payment' && <PaymentContainer payment={activity} />}
         </Box>
       </Flex>
     )

--- a/app/components/App/App.js
+++ b/app/components/App/App.js
@@ -1,14 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-
 import Form from 'components/Form'
 import ChannelForm from 'components/Contacts/ChannelForm'
 import Network from 'components/Contacts/Network'
 import AddChannel from 'components/Contacts/AddChannel'
 import ReceiveModal from 'components/Wallet/ReceiveModal'
 import { ActivityModalContainer } from 'containers/Activity/ActivityModalContainer'
-
 import Activity from 'containers/Activity'
+import Wallet from 'containers/Wallet'
 import { MainContent, Sidebar } from 'components/UI'
 
 // Initial refetch after 2 seconds.
@@ -106,6 +105,7 @@ class App extends React.Component {
         )}
 
         <MainContent>
+          <Wallet />
           <Activity />
         </MainContent>
 

--- a/app/components/App/App.js
+++ b/app/components/App/App.js
@@ -38,10 +38,13 @@ class App extends React.Component {
   }
 
   componentDidMount() {
-    const { setIsWalletOpen } = this.props
+    const { fetchDescribeNetwork, setIsWalletOpen } = this.props
 
     // Set wallet open state.
     setIsWalletOpen(true)
+
+    // fetch LN network from nodes POV.
+    fetchDescribeNetwork()
 
     // fetch node info.
     this.fetchData()
@@ -56,15 +59,12 @@ class App extends React.Component {
    * node data quite frequently but as time goes on the frequency is reduced down to a maximum of MAX_REFETCH_INTERVAL
    */
   fetchData = () => {
-    const { fetchPeers, fetchDescribeNetwork } = this.props
+    const { fetchPeers } = this.props
     const { nextFetchIn } = this
     const next = Math.round(Math.min(nextFetchIn * BACKOFF_SCHEDULE, MAX_REFETCH_INTERVAL))
 
     // Fetch information about connected peers.
     fetchPeers()
-
-    // fetch LN network from nodes POV.
-    fetchDescribeNetwork()
 
     // ensure previous timer is cleared if it exists
     this.clearFetchTimer()

--- a/app/components/Contacts/Network/Network.js
+++ b/app/components/Contacts/Network/Network.js
@@ -4,6 +4,7 @@ import { FormattedNumber, FormattedMessage, injectIntl } from 'react-intl'
 import { Box, Flex } from 'rebass'
 import blockExplorer from 'lib/utils/blockExplorer'
 import { satoshisToFiat } from 'lib/utils/btc'
+import SuggestedNodes from 'containers/Contacts/SuggestedNodes'
 import ExternalLink from 'components/Icon/ExternalLink'
 import PlusCircle from 'components/Icon/PlusCircle'
 import Search from 'components/Icon/Search'
@@ -20,7 +21,6 @@ import {
   Text,
   Value
 } from 'components/UI'
-import SuggestedNodes from '../SuggestedNodes'
 import messages from './messages'
 
 class Network extends Component {
@@ -63,7 +63,6 @@ class Network extends Component {
       updateChannelSearchQuery,
       setSelectedChannel,
       closeChannel,
-      suggestedNodesProps,
       network,
       currencyName,
       intl
@@ -213,7 +212,7 @@ class Network extends Component {
         </Panel.Header>
 
         <Panel.Body css={{ 'overflow-y': 'auto' }}>
-          {!hasChannels && <SuggestedNodes {...suggestedNodesProps} py={3} mx={3} />}
+          {!hasChannels && <SuggestedNodes py={3} mx={3} />}
 
           {hasChannels && (
             <Box>
@@ -427,7 +426,6 @@ Network.propTypes = {
   balance: PropTypes.object.isRequired,
   currentTicker: PropTypes.object,
   ticker: PropTypes.object.isRequired,
-  suggestedNodesProps: PropTypes.object.isRequired,
   network: PropTypes.object.isRequired,
   fetchChannels: PropTypes.func.isRequired,
   openContactsForm: PropTypes.func.isRequired,

--- a/app/components/Contacts/Network/Network.js
+++ b/app/components/Contacts/Network/Network.js
@@ -53,7 +53,7 @@ class Network extends Component {
         pendingChannels: { pending_open_channels }
       },
       currentChannels,
-      balance,
+      channelBalance,
       ticker,
       currentTicker,
       nodes,
@@ -142,7 +142,7 @@ class Network extends Component {
       return 'online'
     }
 
-    const fiatAmount = satoshisToFiat(balance.channelBalance, currentTicker[ticker.fiatTicker])
+    const fiatAmount = satoshisToFiat(channelBalance || 0, currentTicker[ticker.fiatTicker])
     const { refreshing } = this.state
     const hasChannels = Boolean(
       loadingChannelPubkeys.length || pending_open_channels.length || channels.length
@@ -171,7 +171,7 @@ class Network extends Component {
           <Box mx={3}>
             <Text>
               <Value
-                value={balance.channelBalance || 0}
+                value={channelBalance || 0}
                 currency={ticker.currency}
                 currentTicker={currentTicker}
                 fiatTicker={ticker.fiatTicker}
@@ -423,7 +423,7 @@ Network.propTypes = {
   currentChannels: PropTypes.array.isRequired,
   nodes: PropTypes.array.isRequired,
   channels: PropTypes.object.isRequired,
-  balance: PropTypes.object.isRequired,
+  channelBalance: PropTypes.number,
   currentTicker: PropTypes.object,
   ticker: PropTypes.object.isRequired,
   network: PropTypes.object.isRequired,

--- a/app/components/Wallet/Wallet.js
+++ b/app/components/Wallet/Wallet.js
@@ -10,7 +10,7 @@ import { FormattedNumber, FormattedMessage } from 'react-intl'
 import messages from './messages'
 
 const Wallet = ({
-  balance,
+  totalBalance,
   currencyFilters,
   currentTicker,
   info,
@@ -19,19 +19,11 @@ const Wallet = ({
   setCurrency,
   setFormType
 }) => {
-  if (
-    !currentTicker ||
-    !ticker.currency ||
-    balance.channelBalance === null ||
-    balance.walletBalance === null
-  ) {
+  if (!currentTicker || !ticker.currency) {
     return null
   }
 
-  const fiatAmount = btc.satoshisToFiat(
-    parseInt(balance.walletBalance, 10) + parseInt(balance.channelBalance, 10),
-    currentTicker[ticker.fiatTicker]
-  )
+  const fiatAmount = btc.satoshisToFiat(totalBalance, currentTicker[ticker.fiatTicker])
 
   return (
     <Box pt={3} px={5} pb={3} bg="secondaryColor">
@@ -62,7 +54,7 @@ const Wallet = ({
               <Flex alignItems="baseline">
                 <Text fontSize="xxl">
                   <Value
-                    value={parseFloat(balance.walletBalance) + parseFloat(balance.channelBalance)}
+                    value={totalBalance}
                     currency={ticker.currency}
                     currentTicker={currentTicker}
                     fiatTicker={ticker.fiatTicker}
@@ -75,16 +67,10 @@ const Wallet = ({
                   ml={1}
                 />
               </Flex>
-              {Boolean(fiatAmount) && (
-                <Text color="gray">
-                  {'≈ '}
-                  <FormattedNumber
-                    currency={ticker.fiatTicker}
-                    style="currency"
-                    value={fiatAmount}
-                  />
-                </Text>
-              )}
+              <Text color="gray">
+                {'≈ '}
+                <FormattedNumber currency={ticker.fiatTicker} style="currency" value={fiatAmount} />
+              </Text>
             </Box>
           </Flex>
         </Box>
@@ -103,7 +89,7 @@ const Wallet = ({
 
 Wallet.propTypes = {
   // Store props
-  balance: PropTypes.object.isRequired,
+  totalBalance: PropTypes.number,
   currencyFilters: PropTypes.array.isRequired,
   currentTicker: PropTypes.object,
   info: PropTypes.object.isRequired,

--- a/app/components/Wallet/Wallet.js
+++ b/app/components/Wallet/Wallet.js
@@ -11,16 +11,20 @@ import messages from './messages'
 
 const Wallet = ({
   balance,
-  info,
-  openReceiveModal,
-  ticker,
-  currentTicker,
-  openPayForm,
-  openRequestForm,
   currencyFilters,
-  setCurrency
+  currentTicker,
+  info,
+  ticker,
+  openWalletModal,
+  setCurrency,
+  setFormType
 }) => {
-  if (!ticker.currency) {
+  if (
+    !currentTicker ||
+    !ticker.currency ||
+    balance.channelBalance === null ||
+    balance.walletBalance === null
+  ) {
     return null
   }
 
@@ -48,7 +52,7 @@ const Wallet = ({
       <Flex as="header" justifyContent="space-between" mt={4}>
         <Box as="section">
           <Flex alignItems="center">
-            <Box onClick={openReceiveModal} mr={3}>
+            <Box onClick={openWalletModal} mr={3}>
               <Button variant="secondary">
                 <Qrcode width="21px" height="21px" />
               </Button>
@@ -85,10 +89,10 @@ const Wallet = ({
           </Flex>
         </Box>
         <Box as="section">
-          <Button onClick={openPayForm} mr={2} width={145}>
+          <Button onClick={() => setFormType('PAY_FORM')} mr={2} width={145}>
             <FormattedMessage {...messages.pay} />
           </Button>
-          <Button onClick={openRequestForm} width={145}>
+          <Button onClick={() => setFormType('REQUEST_FORM')} width={145}>
             <FormattedMessage {...messages.request} />
           </Button>
         </Box>
@@ -98,16 +102,17 @@ const Wallet = ({
 }
 
 Wallet.propTypes = {
+  // Store props
   balance: PropTypes.object.isRequired,
+  currencyFilters: PropTypes.array.isRequired,
+  currentTicker: PropTypes.object,
   info: PropTypes.object.isRequired,
   ticker: PropTypes.object.isRequired,
-  currentTicker: PropTypes.object.isRequired,
-  openPayForm: PropTypes.func.isRequired,
-  openRequestForm: PropTypes.func.isRequired,
-  openReceiveModal: PropTypes.func.isRequired,
-  network: PropTypes.object.isRequired,
-  currencyFilters: PropTypes.array.isRequired,
-  setCurrency: PropTypes.func.isRequired
+
+  // Dispatch props
+  openWalletModal: PropTypes.func.isRequired,
+  setCurrency: PropTypes.func.isRequired,
+  setFormType: PropTypes.func.isRequired
 }
 
 export default Wallet

--- a/app/containers/Activity.js
+++ b/app/containers/Activity.js
@@ -1,86 +1,36 @@
 import { connect } from 'react-redux'
-
-import { setCurrency, tickerSelectors } from 'reducers/ticker'
-import { setInvoice, invoiceSelectors } from 'reducers/invoice'
-import { paymentSelectors } from 'reducers/payment'
-import { fetchActivityHistory } from 'reducers/activity'
-
+import { tickerSelectors } from 'reducers/ticker'
 import {
   showActivityModal,
-  hideActivityModal,
   changeFilter,
   toggleExpiredRequests,
   activitySelectors,
   updateSearchActive,
-  updateSearchText
+  updateSearchText,
+  fetchActivityHistory
 } from 'reducers/activity'
-import { walletAddress, openWalletModal } from 'reducers/address'
-import { setFormType } from 'reducers/form'
 
 import Activity from 'components/Activity'
 
 const mapDispatchToProps = {
-  setCurrency,
-  setInvoice,
+  changeFilter,
   fetchActivityHistory,
   showActivityModal,
-  hideActivityModal,
-  changeFilter,
   toggleExpiredRequests,
-  walletAddress,
-  openWalletModal,
   updateSearchActive,
-  updateSearchText,
-  setFormType
+  updateSearchText
 }
 
 const mapStateToProps = state => ({
   activity: state.activity,
-  balance: state.balance,
-  address: state.address,
-  info: state.info,
-  payment: state.payment,
-  transaction: state.transaction,
-  invoice: state.invoice,
-  invoices: invoiceSelectors.invoices(state),
-  ticker: state.ticker,
-  network: state.network,
-  paymentModalOpen: paymentSelectors.paymentModalOpen(state),
-  invoiceModalOpen: invoiceSelectors.invoiceModalOpen(state),
-  currentTicker: tickerSelectors.currentTicker(state),
-  currencyFilters: tickerSelectors.currencyFilters(state),
-  currencyName: tickerSelectors.currencyName(state),
   currentActivity: activitySelectors.currentActivity(state)(state),
-  nonActiveFilters: activitySelectors.nonActiveFilters(state),
-  showExpiredToggle: activitySelectors.showExpiredToggle(state)
-})
-
-const mergeProps = (stateProps, dispatchProps, ownProps) => ({
-  ...stateProps,
-  ...dispatchProps,
-  ...ownProps,
-
-  walletProps: {
-    balance: stateProps.balance,
-    activeWalletSettings: stateProps.activeWalletSettings,
-    address: stateProps.address.address,
-    info: stateProps.info,
-    ticker: stateProps.ticker,
-    currentTicker: stateProps.currentTicker,
-    currencyFilters: stateProps.currencyFilters,
-    currencyName: stateProps.currencyName,
-    network: stateProps.info.network,
-    theme: stateProps.currentTheme,
-    setCurrency: dispatchProps.setCurrency,
-    walletAddress: dispatchProps.walletAddress,
-    openReceiveModal: dispatchProps.openWalletModal,
-    openPayForm: () => dispatchProps.setFormType('PAY_FORM'),
-    openRequestForm: () => dispatchProps.setFormType('REQUEST_FORM')
-  }
+  currencyName: tickerSelectors.currencyName(state),
+  currentTicker: tickerSelectors.currentTicker(state),
+  showExpiredToggle: activitySelectors.showExpiredToggle(state),
+  ticker: state.ticker
 })
 
 export default connect(
   mapStateToProps,
-  mapDispatchToProps,
-  mergeProps
+  mapDispatchToProps
 )(Activity)

--- a/app/containers/Activity/InvoiceContainer.js
+++ b/app/containers/Activity/InvoiceContainer.js
@@ -1,0 +1,21 @@
+import { connect } from 'react-redux'
+import { tickerSelectors } from 'reducers/ticker'
+import { showActivityModal } from 'reducers/activity'
+
+import Invoice from 'components/Activity/Invoice'
+
+const mapDispatchToProps = {
+  showActivityModal
+}
+
+const mapStateToProps = state => ({
+  currencyName: tickerSelectors.currencyName(state),
+  currentTicker: tickerSelectors.currentTicker(state),
+  nodes: state.network.nodes,
+  ticker: state.ticker
+})
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Invoice)

--- a/app/containers/Activity/PaymentContainer.js
+++ b/app/containers/Activity/PaymentContainer.js
@@ -1,0 +1,21 @@
+import { connect } from 'react-redux'
+import { tickerSelectors } from 'reducers/ticker'
+import { showActivityModal } from 'reducers/activity'
+
+import Payment from 'components/Activity/Payment'
+
+const mapDispatchToProps = {
+  showActivityModal
+}
+
+const mapStateToProps = state => ({
+  currencyName: tickerSelectors.currencyName(state),
+  currentTicker: tickerSelectors.currentTicker(state),
+  nodes: state.network.nodes,
+  ticker: state.ticker
+})
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Payment)

--- a/app/containers/Activity/TransactionContainer.js
+++ b/app/containers/Activity/TransactionContainer.js
@@ -1,0 +1,21 @@
+import { connect } from 'react-redux'
+import { tickerSelectors } from 'reducers/ticker'
+import { showActivityModal } from 'reducers/activity'
+
+import Transaction from 'components/Activity/Transaction'
+
+const mapDispatchToProps = {
+  showActivityModal
+}
+
+const mapStateToProps = state => ({
+  currencyName: tickerSelectors.currencyName(state),
+  currentTicker: tickerSelectors.currentTicker(state),
+  nodes: state.network.nodes,
+  ticker: state.ticker
+})
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Transaction)

--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -116,7 +116,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const networkTabProps = {
     currentChannels: stateProps.currentChannels,
     channels: stateProps.channels,
-    balance: stateProps.balance,
+    channelBalance: stateProps.balance.channelBalance,
     currentTicker: stateProps.currentTicker,
     contactsform: stateProps.contactsform,
     nodes: stateProps.network.nodes,

--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -72,7 +72,6 @@ const mapStateToProps = state => ({
   info: state.info,
   payment: state.payment,
   transaction: state.transaction,
-  peers: state.peers,
   channels: state.channels,
   contactsform: state.contactsform,
   balance: state.balance,

--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -130,17 +130,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     changeFilter: dispatchProps.changeFilter,
     updateChannelSearchQuery: dispatchProps.updateChannelSearchQuery,
     setSelectedChannel: dispatchProps.setSelectedChannel,
-    closeChannel: dispatchProps.closeChannel,
-
-    suggestedNodesProps: {
-      suggestedNodesLoading: stateProps.channels.suggestedNodesLoading,
-      suggestedNodes: stateProps.info.data.testnet
-        ? stateProps.channels.suggestedNodes.testnet
-        : stateProps.channels.suggestedNodes.mainnet,
-
-      setNode: dispatchProps.setNode,
-      openSubmitChannelForm: () => dispatchProps.openSubmitChannelForm()
-    }
+    closeChannel: dispatchProps.closeChannel
   }
 
   const contactsFormProps = {

--- a/app/containers/Contacts/SuggestedNodes.js
+++ b/app/containers/Contacts/SuggestedNodes.js
@@ -1,0 +1,18 @@
+import { connect } from 'react-redux'
+import { openSubmitChannelForm, setNode, contactFormSelectors } from 'reducers/contactsform'
+import SuggestedNodes from 'components/Contacts/SuggestedNodes'
+
+const mapStateToProps = state => ({
+  suggestedNodesLoading: state.channels.suggestedNodesLoading,
+  suggestedNodes: contactFormSelectors.suggestedNodes(state)
+})
+
+const mapDispatchToProps = {
+  openSubmitChannelForm,
+  setNode
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(SuggestedNodes)

--- a/app/containers/Wallet.js
+++ b/app/containers/Wallet.js
@@ -2,6 +2,7 @@ import { connect } from 'react-redux'
 import { setCurrency, tickerSelectors } from 'reducers/ticker'
 import { openWalletModal } from 'reducers/address'
 import { setFormType } from 'reducers/form'
+import { balanceSelectors } from 'reducers/balance'
 import Wallet from 'components/Wallet'
 
 const mapDispatchToProps = {
@@ -11,9 +12,9 @@ const mapDispatchToProps = {
 }
 
 const mapStateToProps = state => ({
-  balance: state.balance,
   info: state.info,
   ticker: state.ticker,
+  totalBalance: balanceSelectors.totalBalance(state),
   currentTicker: tickerSelectors.currentTicker(state),
   currencyFilters: tickerSelectors.currencyFilters(state)
 })

--- a/app/containers/Wallet.js
+++ b/app/containers/Wallet.js
@@ -1,0 +1,24 @@
+import { connect } from 'react-redux'
+import { setCurrency, tickerSelectors } from 'reducers/ticker'
+import { openWalletModal } from 'reducers/address'
+import { setFormType } from 'reducers/form'
+import Wallet from 'components/Wallet'
+
+const mapDispatchToProps = {
+  openWalletModal,
+  setCurrency,
+  setFormType
+}
+
+const mapStateToProps = state => ({
+  balance: state.balance,
+  info: state.info,
+  ticker: state.ticker,
+  currentTicker: tickerSelectors.currentTicker(state),
+  currencyFilters: tickerSelectors.currencyFilters(state)
+})
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Wallet)

--- a/app/reducers/balance.js
+++ b/app/reducers/balance.js
@@ -1,3 +1,4 @@
+import { createSelector } from 'reselect'
 import { send } from 'redux-electron-ipc'
 
 // ------------------------------------
@@ -38,6 +39,20 @@ const ACTION_HANDLERS = {
     channelBalance
   })
 }
+
+const channelBalanceSelector = state => state.balance.channelBalance
+const walletBalanceSelector = state => state.balance.walletBalance
+
+// Selectors
+const balanceSelectors = {}
+
+balanceSelectors.totalBalance = createSelector(
+  channelBalanceSelector,
+  walletBalanceSelector,
+  (channelBalance, walletBalance) => (channelBalance || 0) + (walletBalance || 0)
+)
+
+export { balanceSelectors }
 
 // ------------------------------------
 // Reducer

--- a/app/reducers/channels.js
+++ b/app/reducers/channels.js
@@ -5,6 +5,7 @@ import { requestSuggestedNodes } from 'lib/utils/api'
 import { setError } from './error'
 import { fetchBalance } from './balance'
 import { walletSelectors } from './wallet'
+import { updateNodeData } from './network'
 
 // ------------------------------------
 // Constants
@@ -290,8 +291,13 @@ const throttledFetchChannels = throttle(dispatch => dispatch(fetchChannels()), 1
 export const channelGraphData = (event, data) => (dispatch, getState) => {
   const { info, channels } = getState()
   const {
-    channelGraphData: { channel_updates }
+    channelGraphData: { channel_updates, node_updates }
   } = data
+
+  // Process node updates.
+  if (node_updates.length) {
+    dispatch(updateNodeData(node_updates))
+  }
 
   // if there are any new channel updates
   let hasUpdates = false

--- a/app/reducers/contactsform.js
+++ b/app/reducers/contactsform.js
@@ -141,6 +141,9 @@ const nodeSelector = state => state.contactsform.node
 const channelsSelector = state => state.channels.channels
 const peersSelector = state => state.peers.peers
 const contactable = node => node.addresses.length > 0
+const testnetSelector = state => state.info.data.testnet
+const testnetNodesSelector = state => state.channels.suggestedNodes.testnet
+const mainnetNodesSelector = state => state.channels.suggestedNodes.mainnet
 
 // comparator to sort the contacts list with contactable contacts first
 const contactableFirst = (a, b) => {
@@ -151,6 +154,15 @@ const contactableFirst = (a, b) => {
   }
   return 0
 }
+
+contactFormSelectors.suggestedNodes = createSelector(
+  testnetSelector,
+  testnetNodesSelector,
+  mainnetNodesSelector,
+  (testnet, testnetNodes, mainnetNodes) => {
+    return testnet ? testnetNodes : mainnetNodes
+  }
+)
 
 contactFormSelectors.filteredNetworkNodes = createSelector(
   networkNodesSelector,

--- a/app/reducers/network.js
+++ b/app/reducers/network.js
@@ -33,9 +33,18 @@ export const GET_INFO_AND_QUERY_ROUTES = 'GET_INFO_AND_QUERY_ROUTES'
 export const RECEIVE_INFO_AND_QUERY_ROUTES = 'RECEIVE_INFO_AND_QUERY_ROUTES'
 export const CLEAR_QUERY_ROUTES = 'CLEAR_QUERY_ROUTES'
 
+export const UPDATE_NODE_DATA = 'UPDATE_NODE_DATA'
+
 // ------------------------------------
 // Actions
 // ------------------------------------
+export function updateNodeData(nodeData) {
+  return {
+    type: UPDATE_NODE_DATA,
+    nodeData
+  }
+}
+
 export function getDescribeNetwork() {
   return {
     type: GET_DESCRIBE_NETWORK
@@ -161,9 +170,38 @@ export const receiveInvoiceAndQueryRoutes = (event, { routes }) => dispatch =>
   dispatch({ type: RECEIVE_INFO_AND_QUERY_ROUTES, routes })
 
 // ------------------------------------
+// Helpers
+// ------------------------------------
+const mergeNodeUpdates = (state, nodeData) => {
+  const { nodes: originalNodes } = state
+  // Check if this is an existing node
+  const index = originalNodes.findIndex(item => item.pub_key === nodeData.identity_key)
+  // If we didn't find the node, add it to the end of the nodes list.
+  // Otherwise update existing.
+  const nodes =
+    index < 0
+      ? [...originalNodes, nodeData]
+      : [
+          ...originalNodes.slice(0, index),
+          {
+            ...originalNodes[index],
+            ...nodeData,
+            last_update: Math.round(new Date() / 1000)
+          },
+          ...originalNodes.slice(index)
+        ]
+
+  return {
+    ...state,
+    nodes
+  }
+}
+
+// ------------------------------------
 // Action Handlers
 // ------------------------------------
 const ACTION_HANDLERS = {
+  [UPDATE_NODE_DATA]: (state, { nodeData }) => nodeData.reduce(mergeNodeUpdates, state),
   [GET_DESCRIBE_NETWORK]: state => ({ ...state, networkLoading: true }),
   [RECEIVE_DESCRIBE_NETWORK]: (state, { nodes, edges }) => ({
     ...state,


### PR DESCRIPTION
## Description:

There are a number of places where the app is re-rendering things needlessly. Sometimes multiple times per second.

There are many more improvements that could be made, but to keep the scope of this PR relatively focused I have focused on a handful of the main offenders:

- Separate out the Wallet and Activity containers in order to reduce unnecessary re-renders of these components.
- Rather than calling describeNetwork periodically and replacing our entire node list with an updated list, subscribe to channel updates and only update node data for specific nodes that have been updated or added.
- reduce network pane re-renders by splitting out containers and connecting close to the source.
- prevent rerenders on balance fetch by using reselect to calculate the total balance

## Motivation and Context:

Improve app performance

## How Has This Been Tested?

Enable component update highlighting in react dev tools and connect to a wallet with several channels and transactions.

Compare renders before and after the patch.

## Types of changes:

Performance improvements

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
