### PR TITLE
fix(ui): highlight border of selected inputs

### DIFF
--- a/app/components/UI/Input.js
+++ b/app/components/UI/Input.js
@@ -2,38 +2,83 @@
 
 import React from 'react'
 import { asField } from 'informed'
-import { withTheme } from 'styled-components'
-import system from '@rebass/components'
+import styled, { withTheme } from 'styled-components'
 import { styles } from 'styled-system'
-import * as yup from 'yup'
+import system from '@rebass/components'
 import { Flex } from 'rebass'
 import { Message, Label, Span, Text } from 'components/UI'
+import withRequiredValidation from 'components/withRequiredValidation'
+
+function isFieldValid({ value, error, asyncError, touched }) {
+  return value && !error && !asyncError && touched
+}
+
+function mapDefaultBorderColor(props) {
+  const {
+    disabled,
+    readOnly,
+    fieldState,
+    fieldState: { error, asyncError },
+    theme: {
+      colors: { gray, superGreen, superRed }
+    }
+  } = props
+
+  let borderColor = gray
+  if (readOnly || disabled) {
+    borderColor = gray
+  } else if (error || asyncError) {
+    borderColor = superRed
+  } else if (isFieldValid(fieldState)) {
+    borderColor = superGreen
+  }
+  return borderColor
+}
+
+function mapFocusBorderColor(props) {
+  const {
+    fieldState,
+    theme: {
+      colors: { lightningOrange, superGreen }
+    }
+  } = props
+  return isFieldValid(fieldState) ? superGreen : lightningOrange
+}
 
 // Create an html input element that accepts all style props from styled-system.
-const SystemInput = system(
-  {
-    as: 'input',
-    border: 1,
-    borderColor: 'gray',
-    borderRadius: 5,
-    bg: 'transparent',
-    color: 'primaryText',
-    fontFamily: 'sans',
-    fontSize: 'm',
-    fontWeight: 'light',
-    p: 3,
-    width: 1
-  },
-  'space',
-  'color',
-  'borders',
-  'borderColor',
-  'borderRadius',
-  'fontFamily',
-  'fontSize',
-  'fontWeight',
-  'width'
-)
+const SystemInput = styled(
+  system(
+    {
+      as: 'input',
+      border: 1,
+      borderColor: 'gray',
+      borderRadius: 5,
+      bg: 'transparent',
+      color: 'primaryText',
+      fontFamily: 'sans',
+      fontSize: 'm',
+      fontWeight: 'light',
+      p: 3,
+      width: 1
+    },
+    'space',
+    'color',
+    'borders',
+    'borderColor',
+    'borderRadius',
+    'fontFamily',
+    'fontSize',
+    'fontWeight',
+    'width'
+  )
+)`
+  opacity: ${props => (props.disabled || props.readOnly ? '0.6' : 'inherit')};
+  outline: none;
+  border-color: ${mapDefaultBorderColor};
+  &:not([readOnly]):not([disabled]):focus {
+    border-color: ${mapFocusBorderColor};
+  }
+`
 
 /**
  * @render react
@@ -70,7 +115,6 @@ class Input extends React.Component {
 
   render() {
     const {
-      css,
       description,
       onChange,
       onBlur,
@@ -89,6 +133,9 @@ class Input extends React.Component {
       variant,
       ...rest
     } = this.props
+    const { hasFocus } = this.state
+    const { setValue, setTouched } = fieldApi
+    const { value } = fieldState
 
     // Extract any styled-system space props so that we can apply them directly to the wrapper.
     const spaceProps = {}
@@ -98,22 +145,6 @@ class Input extends React.Component {
         delete rest[key]
       }
     })
-
-    const { readOnly } = this.props
-    const { hasFocus } = this.state
-    const { setValue, setTouched } = fieldApi
-    const { value } = fieldState
-    const isValid = value && !fieldState.error && !fieldState.asyncError && fieldState.touched
-
-    // Calculate the border color based on the current field state.
-    let borderColor
-    if (readOnly) {
-      borderColor = theme.colors.gray
-    } else if (fieldState.error || fieldState.asyncError) {
-      borderColor = theme.colors.superRed
-    } else if (isValid) {
-      borderColor = theme.colors.superGreen
-    }
 
     return (
       <Flex flexDirection="column" justifyContent={justifyContent} {...spaceProps}>
@@ -128,26 +159,17 @@ class Input extends React.Component {
             )}
           </Label>
         )}
+
         <SystemInput
-          borderColor={borderColor || theme.colors.gray}
-          opacity={readOnly ? 0.6 : null}
-          css={Object.assign(
-            {
-              outline: 'none',
-              '&:not([readOnly]):not([disabled]):focus': {
-                border: `1px solid ${
-                  isValid ? theme.colors.superGreen : theme.colors.lightningOrange
-                } }`
-              }
-            },
-            css
-          )}
           p={variant === 'thin' ? 2 : 3}
           {...rest}
           field={field}
           type={type}
+          theme={theme}
+          fieldState={fieldState}
           ref={this.inputRef}
           value={!value && value !== 0 ? '' : value}
+          required={required}
           onChange={e => {
             setValue(e.target.value)
             if (onChange) {
@@ -175,7 +197,6 @@ class Input extends React.Component {
               onFocus(e)
             }
           }}
-          required={required}
         />
         {type !== 'hidden' && description && (
           <Text color="gray" fontSize="s" mt={1}>
@@ -192,33 +213,4 @@ class Input extends React.Component {
   }
 }
 
-const InputAsField = asField(Input)
-
-class WrappedInputAsField extends React.Component {
-  validate = value => {
-    const { disabled, required } = this.props
-    if (disabled) {
-      return
-    }
-    try {
-      if (required) {
-        const validator = yup.string().required()
-        validator.validateSync(value)
-      }
-    } catch (error) {
-      return error.message
-    }
-
-    // Run any additional validation provided by the caller.
-    const { validate } = this.props
-    if (validate) {
-      return validate(value)
-    }
-  }
-
-  render() {
-    return <InputAsField validate={this.validate} {...this.props} />
-  }
-}
-
-export default withTheme(WrappedInputAsField)
+export default withRequiredValidation(withTheme(asField(Input)))

--- a/app/components/UI/Input.js
+++ b/app/components/UI/Input.js
@@ -70,7 +70,6 @@ class Input extends React.Component {
 
   render() {
     const {
-      border,
       css,
       description,
       onChange,
@@ -116,18 +115,6 @@ class Input extends React.Component {
       borderColor = theme.colors.superGreen
     }
 
-    const cssProps = Object.assign(
-      {
-        outline: 'none'
-      },
-      css
-    )
-
-    if (border) {
-      cssProps['&:not([readOnly]):not([disabled]):focus'] = {
-        border: `1px solid ${isValid ? theme.colors.superGreen : theme.colors.lightningOrange} }`
-      }
-    }
     return (
       <Flex flexDirection="column" justifyContent={justifyContent} {...spaceProps}>
         {label && (
@@ -142,11 +129,20 @@ class Input extends React.Component {
           </Label>
         )}
         <SystemInput
-          p={variant === 'thin' ? 2 : 3}
-          width={1}
-          border={border}
           borderColor={borderColor || theme.colors.gray}
-          css={cssProps}
+          opacity={readOnly ? 0.6 : null}
+          css={Object.assign(
+            {
+              outline: 'none',
+              '&:not([readOnly]):not([disabled]):focus': {
+                border: `1px solid ${
+                  isValid ? theme.colors.superGreen : theme.colors.lightningOrange
+                } }`
+              }
+            },
+            css
+          )}
+          p={variant === 'thin' ? 2 : 3}
           {...rest}
           field={field}
           type={type}

--- a/app/components/UI/TextArea.js
+++ b/app/components/UI/TextArea.js
@@ -12,7 +12,7 @@ const SystemTextArea = system(
     as: 'textarea',
     border: 1,
     borderColor: 'gray',
-    borderRadius: '5px',
+    borderRadius: 5,
     bg: 'transparent',
     color: 'primaryText',
     fontFamily: 'sans',
@@ -22,7 +22,15 @@ const SystemTextArea = system(
     width: 1,
     rows: 5
   },
-  ...Object.keys(styles)
+  'space',
+  'color',
+  'borders',
+  'borderColor',
+  'borderRadius',
+  'fontFamily',
+  'fontSize',
+  'fontWeight',
+  'width'
 )
 
 /**
@@ -66,6 +74,7 @@ class TextArea extends React.PureComponent {
       fieldState,
       justifyContent,
       showMessage,
+      variant,
       ...rest
     } = this.props
     const { readOnly } = this.props
@@ -108,7 +117,6 @@ class TextArea extends React.PureComponent {
         )}
         <SystemTextArea
           borderColor={borderColor || theme.colors.gray}
-          opacity={readOnly ? 0.6 : null}
           css={Object.assign(
             {
               outline: 'none',
@@ -120,6 +128,8 @@ class TextArea extends React.PureComponent {
             },
             css
           )}
+          opacity={readOnly ? 0.6 : null}
+          p={variant === 'thin' ? 2 : 3}
           {...rest}
           field={field}
           ref={this.inputRef}

--- a/app/components/withRequiredValidation/index.js
+++ b/app/components/withRequiredValidation/index.js
@@ -1,0 +1,3 @@
+import withRequiredValidation from './withRequiredValidation'
+
+export default withRequiredValidation

--- a/app/components/withRequiredValidation/withRequiredValidation.js
+++ b/app/components/withRequiredValidation/withRequiredValidation.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import * as yup from 'yup'
+
+/**
+ * A HOC that will add validation of a `required` property to a field.
+ * @param {React.Component} Component Component to wrap
+ */
+const withRequiredValidation = Component =>
+  class extends React.Component {
+    static displayName = 'withRequiredValidation'
+
+    validate = value => {
+      const { disabled, required } = this.props
+      if (disabled) {
+        return
+      }
+      try {
+        if (required) {
+          const validator = yup.string().required()
+          validator.validateSync(value)
+        }
+      } catch (error) {
+        return error.message
+      }
+
+      // Run any additional validation provided by the caller.
+      const { validate } = this.props
+      if (validate) {
+        return validate(value)
+      }
+    }
+
+    render() {
+      return <Component validate={this.validate} {...this.props} />
+    }
+  }
+
+export default withRequiredValidation

--- a/stories/forms/form.stories.js
+++ b/stories/forms/form.stories.js
@@ -50,16 +50,73 @@ storiesOf('Forms', module)
           description="This field also has a description."
         />
       </Form>
+      <Form mb={4}>
+        <Input
+          field="fieldName"
+          id="field-name"
+          label="Required field"
+          required
+          validateOnBlur
+          validateOnChange
+        />
+      </Form>
+      <Form mb={4}>
+        <Input field="fieldName" id="field-name" label="Disabled field" disabled />
+      </Form>
+      <Form mb={4}>
+        <Input
+          field="fieldName"
+          id="field-name"
+          label="Read only field"
+          readOnly
+          initialValue="This is a read only field"
+        />
+      </Form>
+    </>
+  ))
+  .add('TextArea', () => (
+    <>
+      <Form mb={4}>
+        <TextArea field="fieldName" id="field-name" />
+      </Form>
+      <Form mb={4}>
+        <TextArea field="fieldName" id="field-name" label="TextArea with Label" />
+      </Form>
+      <Form mb={4}>
+        <TextArea
+          field="fieldName"
+          id="field-name"
+          label="TextArea with Label and description"
+          description="This field also has a description."
+        />
+      </Form>
+      <Form mb={4}>
+        <TextArea
+          field="fieldName"
+          id="field-name"
+          label="Required field"
+          required
+          validateOnBlur
+          validateOnChange
+        />
+      </Form>
+      <Form mb={4}>
+        <TextArea field="fieldName" id="field-name" label="Disabled field" disabled />
+      </Form>
+      <Form mb={4}>
+        <TextArea
+          field="fieldName"
+          id="field-name"
+          label="Read only field"
+          readOnly
+          initialValue="This is a read only field"
+        />
+      </Form>
     </>
   ))
   .add('Label', () => (
     <Form>
       <Label htmlFor="id">Label</Label>
-    </Form>
-  ))
-  .add('TextArea', () => (
-    <Form>
-      <TextArea field="fieldName" placeholder="Type here" />
     </Form>
   ))
   .add('CryptoAmountInput', () => (
@@ -152,6 +209,7 @@ storiesOf('Forms', module)
                   placeholder="Type here"
                   validate={validate}
                   validateOnBlur
+                  validateOnChange
                 />
               </Box>
 
@@ -162,6 +220,7 @@ storiesOf('Forms', module)
                   label="Example TextArea"
                   validate={validate}
                   validateOnBlur
+                  validateOnChange
                 />
               </Box>
 

--- a/test/unit/components/UI/__snapshots__/Input.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Input.spec.js.snap
@@ -22,11 +22,13 @@ exports[`component.UI.Input should render correctly 1`] = `
   font-size: 13px;
   font-weight: 300;
   width: 100%;
+  opacity: inherit;
   outline: none;
+  border-color: #959595;
 }
 
 .c1:not([readOnly]):not([disabled]):focus {
-  border: 1px solid #fd9800;
+  border-color: #fd9800;
 }
 
 <form
@@ -46,7 +48,6 @@ exports[`component.UI.Input should render correctly 1`] = `
       onBlur={[Function]}
       onChange={[Function]}
       onFocus={[Function]}
-      opacity={null}
       value=""
       width={1}
     />

--- a/test/unit/components/UI/__snapshots__/Input.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Input.spec.js.snap
@@ -25,6 +25,10 @@ exports[`component.UI.Input should render correctly 1`] = `
   outline: none;
 }
 
+.c1:not([readOnly]):not([disabled]):focus {
+  border: 1px solid #fd9800;
+}
+
 <form
   onReset={[Function]}
   onSubmit={[Function]}
@@ -42,6 +46,7 @@ exports[`component.UI.Input should render correctly 1`] = `
       onBlur={[Function]}
       onChange={[Function]}
       onFocus={[Function]}
+      opacity={null}
       value=""
       width={1}
     />

--- a/test/unit/components/UI/__snapshots__/LightningInvoiceInput.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/LightningInvoiceInput.spec.js.snap
@@ -13,18 +13,15 @@ exports[`component.UI.LightningInvoiceInput should render correctly 1`] = `
 
 .c1 {
   padding: 16px;
-  width: 100%;
-  font-size: 13px;
   color: #ffffff;
   background-color: transparent;
-  color: #ffffff;
-  background-color: transparent;
-  font-family: Roboto,system-ui,sans-serif;
-  font-weight: 300;
-  border: 1px solid;
   border: 1px solid;
   border-color: #959595;
   border-radius: 5px;
+  font-family: Roboto,system-ui,sans-serif;
+  font-size: 13px;
+  font-weight: 300;
+  width: 100%;
   outline: none;
 }
 

--- a/test/unit/components/UI/__snapshots__/LightningInvoiceInput.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/LightningInvoiceInput.spec.js.snap
@@ -22,11 +22,13 @@ exports[`component.UI.LightningInvoiceInput should render correctly 1`] = `
   font-size: 13px;
   font-weight: 300;
   width: 100%;
+  opacity: inherit;
   outline: none;
+  border-color: #959595;
 }
 
 .c1:not([readOnly]):not([disabled]):focus {
-  border: 1px solid #fd9800;
+  border-color: #fd9800;
 }
 
 <form
@@ -45,7 +47,6 @@ exports[`component.UI.LightningInvoiceInput should render correctly 1`] = `
       onBlur={[Function]}
       onChange={[Function]}
       onFocus={[Function]}
-      opacity={null}
       placeholder="Paste a Lightning Payment Request or bitcoin Address here"
       required={false}
       rows={5}

--- a/test/unit/components/UI/__snapshots__/Select.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Select.spec.js.snap
@@ -25,6 +25,10 @@ exports[`component.UI.Toggle should render correctly 1`] = `
   outline: none;
 }
 
+.c2:not([readOnly]):not([disabled]):focus {
+  border: 1px solid #fd9800;
+}
+
 .c3 {
   padding: 0;
   margin-top: 0;
@@ -138,6 +142,7 @@ exports[`component.UI.Toggle should render correctly 1`] = `
           onFocus={[Function]}
           onKeyDown={[Function]}
           onMouseDown={[Function]}
+          opacity={null}
           placeholder="Please select"
           value=""
           width={1}

--- a/test/unit/components/UI/__snapshots__/Select.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Select.spec.js.snap
@@ -22,11 +22,13 @@ exports[`component.UI.Toggle should render correctly 1`] = `
   font-size: 13px;
   font-weight: 300;
   width: 100%;
+  opacity: inherit;
   outline: none;
+  border-color: #959595;
 }
 
 .c2:not([readOnly]):not([disabled]):focus {
-  border: 1px solid #fd9800;
+  border-color: #fd9800;
 }
 
 .c3 {
@@ -142,7 +144,6 @@ exports[`component.UI.Toggle should render correctly 1`] = `
           onFocus={[Function]}
           onKeyDown={[Function]}
           onMouseDown={[Function]}
-          opacity={null}
           placeholder="Please select"
           value=""
           width={1}

--- a/test/unit/components/UI/__snapshots__/TextArea.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/TextArea.spec.js.snap
@@ -22,11 +22,13 @@ exports[`component.UI.Input should render correctly 1`] = `
   font-size: 13px;
   font-weight: 300;
   width: 100%;
+  opacity: inherit;
   outline: none;
+  border-color: #959595;
 }
 
 .c1:not([readOnly]):not([disabled]):focus {
-  border: 1px solid #fd9800;
+  border-color: #fd9800;
 }
 
 <form
@@ -46,7 +48,6 @@ exports[`component.UI.Input should render correctly 1`] = `
       onBlur={[Function]}
       onChange={[Function]}
       onFocus={[Function]}
-      opacity={null}
       value=""
       width={1}
     />

--- a/test/unit/components/UI/__snapshots__/TextArea.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/TextArea.spec.js.snap
@@ -25,6 +25,10 @@ exports[`component.UI.Input should render correctly 1`] = `
   outline: none;
 }
 
+.c1:not([readOnly]):not([disabled]):focus {
+  border: 1px solid #fd9800;
+}
+
 <form
   onReset={[Function]}
   onSubmit={[Function]}
@@ -42,6 +46,7 @@ exports[`component.UI.Input should render correctly 1`] = `
       onBlur={[Function]}
       onChange={[Function]}
       onFocus={[Function]}
+      opacity={null}
       value=""
       width={1}
     />


### PR DESCRIPTION
## Description:

 - Ensure that input field borders are correctly highlighted when you click into them.
 - Refactor `Input` and `TextArea` fields to be more consistent
 - Extract some common input behavior out into an HOC

## Motivation and Context:

This fixes an issue with the inputs where by they don't properly get highlighted when you click in to them.

## How Has This Been Tested?

 - Added several more examples to the storybook.
 - Test behavior of various input fields throughout the app

## Screenshots (if appropriate):

**Default state Before:**
<img width="1132" alt="initial-before" src="https://user-images.githubusercontent.com/200251/51317455-e819e980-1a57-11e9-967e-8654f2c5084a.png">

**Default state After:**
<img width="1132" alt="initial-after" src="https://user-images.githubusercontent.com/200251/51317452-e6502600-1a57-11e9-8708-30cc18b0603c.png">

**With errors Before:**
<img width="1132" alt="with-error-before" src="https://user-images.githubusercontent.com/200251/51317495-04b62180-1a58-11e9-8ddf-3b49777c884f.png">

**With errors  After:**
<img width="1132" alt="with-error-after" src="https://user-images.githubusercontent.com/200251/51317487-fec04080-1a57-11e9-9995-4928c2611321.png">

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
