### PR TITLE
perf(ui): only update node data when changed

### DIFF
--- a/app/components/App/App.js
+++ b/app/components/App/App.js
@@ -39,10 +39,13 @@ class App extends React.Component {
   }
 
   componentDidMount() {
-    const { setIsWalletOpen } = this.props
+    const { fetchDescribeNetwork, setIsWalletOpen } = this.props
 
     // Set wallet open state.
     setIsWalletOpen(true)
+
+    // fetch LN network from nodes POV.
+    fetchDescribeNetwork()
 
     // fetch node info.
     this.fetchData()
@@ -57,15 +60,12 @@ class App extends React.Component {
    * node data quite frequently but as time goes on the frequency is reduced down to a maximum of MAX_REFETCH_INTERVAL
    */
   fetchData = () => {
-    const { fetchPeers, fetchDescribeNetwork } = this.props
+    const { fetchPeers } = this.props
     const { nextFetchIn } = this
     const next = Math.round(Math.min(nextFetchIn * BACKOFF_SCHEDULE, MAX_REFETCH_INTERVAL))
 
     // Fetch information about connected peers.
     fetchPeers()
-
-    // fetch LN network from nodes POV.
-    fetchDescribeNetwork()
 
     // ensure previous timer is cleared if it exists
     this.clearFetchTimer()

--- a/app/reducers/channels.js
+++ b/app/reducers/channels.js
@@ -5,6 +5,7 @@ import { requestSuggestedNodes } from 'lib/utils/api'
 import { setError } from './error'
 import { fetchBalance } from './balance'
 import { walletSelectors } from './wallet'
+import { updateNodeData } from './network'
 
 // ------------------------------------
 // Constants
@@ -290,8 +291,13 @@ const throttledFetchChannels = throttle(dispatch => dispatch(fetchChannels()), 1
 export const channelGraphData = (event, data) => (dispatch, getState) => {
   const { info, channels } = getState()
   const {
-    channelGraphData: { channel_updates }
+    channelGraphData: { channel_updates, node_updates }
   } = data
+
+  // Process node updates.
+  if (node_updates.length) {
+    dispatch(updateNodeData(node_updates))
+  }
 
   // if there are any new channel updates
   let hasUpdates = false

--- a/app/reducers/network.js
+++ b/app/reducers/network.js
@@ -33,9 +33,18 @@ export const GET_INFO_AND_QUERY_ROUTES = 'GET_INFO_AND_QUERY_ROUTES'
 export const RECEIVE_INFO_AND_QUERY_ROUTES = 'RECEIVE_INFO_AND_QUERY_ROUTES'
 export const CLEAR_QUERY_ROUTES = 'CLEAR_QUERY_ROUTES'
 
+export const UPDATE_NODE_DATA = 'UPDATE_NODE_DATA'
+
 // ------------------------------------
 // Actions
 // ------------------------------------
+export function updateNodeData(nodeData) {
+  return {
+    type: UPDATE_NODE_DATA,
+    nodeData
+  }
+}
+
 export function getDescribeNetwork() {
   return {
     type: GET_DESCRIBE_NETWORK
@@ -161,9 +170,38 @@ export const receiveInvoiceAndQueryRoutes = (event, { routes }) => dispatch =>
   dispatch({ type: RECEIVE_INFO_AND_QUERY_ROUTES, routes })
 
 // ------------------------------------
+// Helpers
+// ------------------------------------
+const mergeNodeUpdates = (state, nodeData) => {
+  const { nodes: originalNodes } = state
+  // Check if this is an existing node
+  const index = originalNodes.findIndex(item => item.pub_key === nodeData.identity_key)
+  // If we didn't find the node, add it to the end of the nodes list.
+  // Otherwise update existing.
+  const nodes =
+    index < 0
+      ? [...originalNodes, nodeData]
+      : [
+          ...originalNodes.slice(0, index),
+          {
+            ...originalNodes[index],
+            ...nodeData,
+            last_update: Math.round(new Date() / 1000)
+          },
+          ...originalNodes.slice(index)
+        ]
+
+  return {
+    ...state,
+    nodes
+  }
+}
+
+// ------------------------------------
 // Action Handlers
 // ------------------------------------
 const ACTION_HANDLERS = {
+  [UPDATE_NODE_DATA]: (state, { nodeData }) => nodeData.reduce(mergeNodeUpdates, state),
   [GET_DESCRIBE_NETWORK]: state => ({ ...state, networkLoading: true }),
   [RECEIVE_DESCRIBE_NETWORK]: (state, { nodes, edges }) => ({
     ...state,


### PR DESCRIPTION
## Description:

Rather than calling describe network periodically and replacing our entire node list with an updated list, subscribe to channel updates and only update node data for specific nodes that have been updated or added.

## Motivation and Context:

Pulled commit out of https://github.com/LN-Zap/zap-desktop/pull/1352 to make it easier to review in isolation

## How Has This Been Tested?

Enable component update highlighting in react dev tools and connect to a wallet with several channels and transactions.

Compare renders before and after the patch.

## Types of changes:

Performance improvement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
