### PR TITLE
perf(ui): reduce wallet & activity re-renders

### DIFF
--- a/app/components/Activity/Activity.js
+++ b/app/components/Activity/Activity.js
@@ -7,7 +7,6 @@ import { Bar, Button, Form, Heading, Input, Panel, Spinner, Text } from 'compone
 import Search from 'components/Icon/Search'
 import X from 'components/Icon/X'
 
-import Wallet from 'components/Wallet'
 import messages from './messages'
 import ActivityListItem from './ActivityListItem'
 
@@ -127,14 +126,7 @@ class Activity extends Component {
   }
 
   renderActivityList = () => {
-    const {
-      currentActivity,
-      currencyName,
-      ticker,
-      currentTicker,
-      showActivityModal,
-      network
-    } = this.props
+    const { currentActivity, currencyName, ticker, currentTicker, showActivityModal } = this.props
 
     if (!currencyName) {
       return null
@@ -154,7 +146,6 @@ class Activity extends Component {
               currencyName,
               currentTicker,
               showActivityModal,
-              network,
               ticker
             }}
           />
@@ -181,22 +172,18 @@ class Activity extends Component {
   render() {
     const {
       activity: { searchActive },
-      balance,
       currentActivity,
       currentTicker,
-      walletProps,
       showExpiredToggle
     } = this.props
 
-    if (!currentTicker || balance.channelBalance === null || balance.walletBalance === null) {
+    if (!currentTicker) {
       return null
     }
 
     return (
       <Panel>
         <Panel.Header>
-          <Wallet {...walletProps} />
-
           <Flex
             as="nav"
             justifyContent="space-between"
@@ -224,25 +211,19 @@ class Activity extends Component {
 }
 
 Activity.propTypes = {
-  fetchActivityHistory: PropTypes.func.isRequired,
-
-  ticker: PropTypes.object.isRequired,
-  currentTicker: PropTypes.object,
-  network: PropTypes.object.isRequired,
-
-  showActivityModal: PropTypes.func.isRequired,
-  changeFilter: PropTypes.func.isRequired,
-  updateSearchActive: PropTypes.func.isRequired,
-  updateSearchText: PropTypes.func.isRequired,
-  toggleExpiredRequests: PropTypes.func.isRequired,
-
   activity: PropTypes.object.isRequired,
   currentActivity: PropTypes.array.isRequired,
+  currencyName: PropTypes.string,
+  currentTicker: PropTypes.object,
+  ticker: PropTypes.object.isRequired,
   showExpiredToggle: PropTypes.bool.isRequired,
-  balance: PropTypes.object.isRequired,
-  walletProps: PropTypes.object.isRequired,
 
-  currencyName: PropTypes.string
+  changeFilter: PropTypes.func.isRequired,
+  fetchActivityHistory: PropTypes.func.isRequired,
+  showActivityModal: PropTypes.func.isRequired,
+  toggleExpiredRequests: PropTypes.func.isRequired,
+  updateSearchActive: PropTypes.func.isRequired,
+  updateSearchText: PropTypes.func.isRequired
 }
 
 export default injectIntl(Activity)

--- a/app/components/Activity/ActivityListItem.js
+++ b/app/components/Activity/ActivityListItem.js
@@ -2,13 +2,14 @@ import React, { PureComponent } from 'react'
 import { Box, Flex } from 'rebass'
 import PropTypes from 'prop-types'
 
+import InvoiceContainer from 'containers/Activity/InvoiceContainer'
+import PaymentContainer from 'containers/Activity/PaymentContainer'
+import TransactionContainer from 'containers/Activity/TransactionContainer'
+
 import ChainLink from 'components/Icon/ChainLink'
 import Clock from 'components/Icon/Clock'
 import Zap from 'components/Icon/Zap'
 import { Text } from 'components/UI'
-import Transaction from './Transaction'
-import Invoice from './Invoice'
-import Payment from './Payment'
 
 const ActivityIcon = ({ activity }) => {
   switch (activity.type) {
@@ -29,56 +30,20 @@ export default class ActivityListItem extends PureComponent {
     showActivityModal: PropTypes.func.isRequired,
     currencyName: PropTypes.string,
     ticker: PropTypes.object.isRequired,
-    network: PropTypes.object.isRequired,
     activity: PropTypes.object.isRequired
   }
 
   render() {
-    const {
-      activity,
-      currencyName,
-      currentTicker,
-      network,
-      ticker,
-      showActivityModal,
-      ...rest
-    } = this.props
+    const { activity, currencyName, currentTicker, ticker, showActivityModal, ...rest } = this.props
     return (
       <Flex justifyContent="space-between" alignItems="center" {...rest}>
         <Text width={24} ml={-35} color="gray" textAlign="center">
           <ActivityIcon activity={activity} />
         </Text>
         <Box width={1} css={!activity.sending ? { cursor: 'pointer' } : null}>
-          {activity.type === 'transaction' && (
-            <Transaction
-              transaction={activity}
-              ticker={ticker}
-              currentTicker={currentTicker}
-              showActivityModal={showActivityModal}
-              currencyName={currencyName}
-            />
-          )}
-
-          {activity.type === 'invoice' && (
-            <Invoice
-              invoice={activity}
-              ticker={ticker}
-              currentTicker={currentTicker}
-              showActivityModal={showActivityModal}
-              currencyName={currencyName}
-            />
-          )}
-
-          {activity.type === 'payment' && (
-            <Payment
-              payment={activity}
-              ticker={ticker}
-              currentTicker={currentTicker}
-              showActivityModal={showActivityModal}
-              nodes={network.nodes}
-              currencyName={currencyName}
-            />
-          )}
+          {activity.type === 'transaction' && <TransactionContainer transaction={activity} />}
+          {activity.type === 'invoice' && <InvoiceContainer invoice={activity} />}
+          {activity.type === 'payment' && <PaymentContainer payment={activity} />}
         </Box>
       </Flex>
     )

--- a/app/components/App/App.js
+++ b/app/components/App/App.js
@@ -1,14 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-
 import Form from 'components/Form'
 import ChannelForm from 'components/Contacts/ChannelForm'
 import Network from 'components/Contacts/Network'
 import AddChannel from 'components/Contacts/AddChannel'
 import ReceiveModal from 'components/Wallet/ReceiveModal'
 import { ActivityModalContainer } from 'containers/Activity/ActivityModalContainer'
-
 import Activity from 'containers/Activity'
+import Wallet from 'containers/Wallet'
 import { MainContent, Sidebar } from 'components/UI'
 
 // Initial refetch after 2 seconds.
@@ -106,6 +105,7 @@ class App extends React.Component {
         )}
 
         <MainContent>
+          <Wallet />
           <Activity />
         </MainContent>
 

--- a/app/components/Contacts/Network/Network.js
+++ b/app/components/Contacts/Network/Network.js
@@ -65,7 +65,7 @@ class Network extends Component {
         pendingChannels: { pending_open_channels }
       },
       currentChannels,
-      balance,
+      channelBalance,
       ticker,
       currentTicker,
       nodes,
@@ -156,7 +156,7 @@ class Network extends Component {
       return 'online'
     }
 
-    const fiatAmount = satoshisToFiat(balance.channelBalance, currentTicker[ticker.fiatTicker])
+    const fiatAmount = satoshisToFiat(channelBalance || 0, currentTicker[ticker.fiatTicker])
     const { refreshing } = this.state
     const hasChannels = Boolean(
       loadingChannelPubkeys.length || pending_open_channels.length || channels.length
@@ -185,7 +185,7 @@ class Network extends Component {
           <Box mx={3}>
             <Text>
               <Value
-                value={balance.channelBalance || 0}
+                value={channelBalance || 0}
                 currency={ticker.currency}
                 currentTicker={currentTicker}
                 fiatTicker={ticker.fiatTicker}
@@ -437,7 +437,7 @@ Network.propTypes = {
   currentChannels: PropTypes.array.isRequired,
   nodes: PropTypes.array.isRequired,
   channels: PropTypes.object.isRequired,
-  balance: PropTypes.object.isRequired,
+  channelBalance: PropTypes.number,
   currentTicker: PropTypes.object,
   ticker: PropTypes.object.isRequired,
   suggestedNodesProps: PropTypes.object.isRequired,

--- a/app/components/Wallet/Wallet.js
+++ b/app/components/Wallet/Wallet.js
@@ -10,7 +10,7 @@ import { FormattedNumber, FormattedMessage } from 'react-intl'
 import messages from './messages'
 
 const Wallet = ({
-  balance,
+  totalBalance,
   currencyFilters,
   currentTicker,
   info,
@@ -19,19 +19,11 @@ const Wallet = ({
   setCurrency,
   setFormType
 }) => {
-  if (
-    !currentTicker ||
-    !ticker.currency ||
-    balance.channelBalance === null ||
-    balance.walletBalance === null
-  ) {
+  if (!currentTicker || !ticker.currency) {
     return null
   }
 
-  const fiatAmount = btc.satoshisToFiat(
-    parseInt(balance.walletBalance, 10) + parseInt(balance.channelBalance, 10),
-    currentTicker[ticker.fiatTicker]
-  )
+  const fiatAmount = btc.satoshisToFiat(totalBalance, currentTicker[ticker.fiatTicker])
 
   return (
     <Box pt={3} px={5} pb={3} bg="secondaryColor">
@@ -62,7 +54,7 @@ const Wallet = ({
               <Flex alignItems="baseline">
                 <Text fontSize="xxl">
                   <Value
-                    value={parseFloat(balance.walletBalance) + parseFloat(balance.channelBalance)}
+                    value={totalBalance}
                     currency={ticker.currency}
                     currentTicker={currentTicker}
                     fiatTicker={ticker.fiatTicker}
@@ -75,16 +67,10 @@ const Wallet = ({
                   ml={1}
                 />
               </Flex>
-              {Boolean(fiatAmount) && (
-                <Text color="gray">
-                  {'≈ '}
-                  <FormattedNumber
-                    currency={ticker.fiatTicker}
-                    style="currency"
-                    value={fiatAmount}
-                  />
-                </Text>
-              )}
+              <Text color="gray">
+                {'≈ '}
+                <FormattedNumber currency={ticker.fiatTicker} style="currency" value={fiatAmount} />
+              </Text>
             </Box>
           </Flex>
         </Box>
@@ -103,7 +89,7 @@ const Wallet = ({
 
 Wallet.propTypes = {
   // Store props
-  balance: PropTypes.object.isRequired,
+  totalBalance: PropTypes.number,
   currencyFilters: PropTypes.array.isRequired,
   currentTicker: PropTypes.object,
   info: PropTypes.object.isRequired,

--- a/app/components/Wallet/Wallet.js
+++ b/app/components/Wallet/Wallet.js
@@ -11,16 +11,20 @@ import messages from './messages'
 
 const Wallet = ({
   balance,
-  info,
-  openReceiveModal,
-  ticker,
-  currentTicker,
-  openPayForm,
-  openRequestForm,
   currencyFilters,
-  setCurrency
+  currentTicker,
+  info,
+  ticker,
+  openWalletModal,
+  setCurrency,
+  setFormType
 }) => {
-  if (!ticker.currency) {
+  if (
+    !currentTicker ||
+    !ticker.currency ||
+    balance.channelBalance === null ||
+    balance.walletBalance === null
+  ) {
     return null
   }
 
@@ -48,7 +52,7 @@ const Wallet = ({
       <Flex as="header" justifyContent="space-between" mt={4}>
         <Box as="section">
           <Flex alignItems="center">
-            <Box onClick={openReceiveModal} mr={3}>
+            <Box onClick={openWalletModal} mr={3}>
               <Button variant="secondary">
                 <Qrcode width="21px" height="21px" />
               </Button>
@@ -85,10 +89,10 @@ const Wallet = ({
           </Flex>
         </Box>
         <Box as="section">
-          <Button onClick={openPayForm} mr={2} width={145}>
+          <Button onClick={() => setFormType('PAY_FORM')} mr={2} width={145}>
             <FormattedMessage {...messages.pay} />
           </Button>
-          <Button onClick={openRequestForm} width={145}>
+          <Button onClick={() => setFormType('REQUEST_FORM')} width={145}>
             <FormattedMessage {...messages.request} />
           </Button>
         </Box>
@@ -98,16 +102,17 @@ const Wallet = ({
 }
 
 Wallet.propTypes = {
+  // Store props
   balance: PropTypes.object.isRequired,
+  currencyFilters: PropTypes.array.isRequired,
+  currentTicker: PropTypes.object,
   info: PropTypes.object.isRequired,
   ticker: PropTypes.object.isRequired,
-  currentTicker: PropTypes.object.isRequired,
-  openPayForm: PropTypes.func.isRequired,
-  openRequestForm: PropTypes.func.isRequired,
-  openReceiveModal: PropTypes.func.isRequired,
-  network: PropTypes.object.isRequired,
-  currencyFilters: PropTypes.array.isRequired,
-  setCurrency: PropTypes.func.isRequired
+
+  // Dispatch props
+  openWalletModal: PropTypes.func.isRequired,
+  setCurrency: PropTypes.func.isRequired,
+  setFormType: PropTypes.func.isRequired
 }
 
 export default Wallet

--- a/app/containers/Activity.js
+++ b/app/containers/Activity.js
@@ -1,86 +1,36 @@
 import { connect } from 'react-redux'
-
-import { setCurrency, tickerSelectors } from 'reducers/ticker'
-import { setInvoice, invoiceSelectors } from 'reducers/invoice'
-import { paymentSelectors } from 'reducers/payment'
-import { fetchActivityHistory } from 'reducers/activity'
-
+import { tickerSelectors } from 'reducers/ticker'
 import {
   showActivityModal,
-  hideActivityModal,
   changeFilter,
   toggleExpiredRequests,
   activitySelectors,
   updateSearchActive,
-  updateSearchText
+  updateSearchText,
+  fetchActivityHistory
 } from 'reducers/activity'
-import { walletAddress, openWalletModal } from 'reducers/address'
-import { setFormType } from 'reducers/form'
 
 import Activity from 'components/Activity'
 
 const mapDispatchToProps = {
-  setCurrency,
-  setInvoice,
+  changeFilter,
   fetchActivityHistory,
   showActivityModal,
-  hideActivityModal,
-  changeFilter,
   toggleExpiredRequests,
-  walletAddress,
-  openWalletModal,
   updateSearchActive,
-  updateSearchText,
-  setFormType
+  updateSearchText
 }
 
 const mapStateToProps = state => ({
   activity: state.activity,
-  balance: state.balance,
-  address: state.address,
-  info: state.info,
-  payment: state.payment,
-  transaction: state.transaction,
-  invoice: state.invoice,
-  invoices: invoiceSelectors.invoices(state),
-  ticker: state.ticker,
-  network: state.network,
-  paymentModalOpen: paymentSelectors.paymentModalOpen(state),
-  invoiceModalOpen: invoiceSelectors.invoiceModalOpen(state),
-  currentTicker: tickerSelectors.currentTicker(state),
-  currencyFilters: tickerSelectors.currencyFilters(state),
-  currencyName: tickerSelectors.currencyName(state),
   currentActivity: activitySelectors.currentActivity(state)(state),
-  nonActiveFilters: activitySelectors.nonActiveFilters(state),
-  showExpiredToggle: activitySelectors.showExpiredToggle(state)
-})
-
-const mergeProps = (stateProps, dispatchProps, ownProps) => ({
-  ...stateProps,
-  ...dispatchProps,
-  ...ownProps,
-
-  walletProps: {
-    balance: stateProps.balance,
-    activeWalletSettings: stateProps.activeWalletSettings,
-    address: stateProps.address.address,
-    info: stateProps.info,
-    ticker: stateProps.ticker,
-    currentTicker: stateProps.currentTicker,
-    currencyFilters: stateProps.currencyFilters,
-    currencyName: stateProps.currencyName,
-    network: stateProps.info.network,
-    theme: stateProps.currentTheme,
-    setCurrency: dispatchProps.setCurrency,
-    walletAddress: dispatchProps.walletAddress,
-    openReceiveModal: dispatchProps.openWalletModal,
-    openPayForm: () => dispatchProps.setFormType('PAY_FORM'),
-    openRequestForm: () => dispatchProps.setFormType('REQUEST_FORM')
-  }
+  currencyName: tickerSelectors.currencyName(state),
+  currentTicker: tickerSelectors.currentTicker(state),
+  showExpiredToggle: activitySelectors.showExpiredToggle(state),
+  ticker: state.ticker
 })
 
 export default connect(
   mapStateToProps,
-  mapDispatchToProps,
-  mergeProps
+  mapDispatchToProps
 )(Activity)

--- a/app/containers/Activity/InvoiceContainer.js
+++ b/app/containers/Activity/InvoiceContainer.js
@@ -1,0 +1,21 @@
+import { connect } from 'react-redux'
+import { tickerSelectors } from 'reducers/ticker'
+import { showActivityModal } from 'reducers/activity'
+
+import Invoice from 'components/Activity/Invoice'
+
+const mapDispatchToProps = {
+  showActivityModal
+}
+
+const mapStateToProps = state => ({
+  currencyName: tickerSelectors.currencyName(state),
+  currentTicker: tickerSelectors.currentTicker(state),
+  nodes: state.network.nodes,
+  ticker: state.ticker
+})
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Invoice)

--- a/app/containers/Activity/PaymentContainer.js
+++ b/app/containers/Activity/PaymentContainer.js
@@ -1,0 +1,21 @@
+import { connect } from 'react-redux'
+import { tickerSelectors } from 'reducers/ticker'
+import { showActivityModal } from 'reducers/activity'
+
+import Payment from 'components/Activity/Payment'
+
+const mapDispatchToProps = {
+  showActivityModal
+}
+
+const mapStateToProps = state => ({
+  currencyName: tickerSelectors.currencyName(state),
+  currentTicker: tickerSelectors.currentTicker(state),
+  nodes: state.network.nodes,
+  ticker: state.ticker
+})
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Payment)

--- a/app/containers/Activity/TransactionContainer.js
+++ b/app/containers/Activity/TransactionContainer.js
@@ -1,0 +1,21 @@
+import { connect } from 'react-redux'
+import { tickerSelectors } from 'reducers/ticker'
+import { showActivityModal } from 'reducers/activity'
+
+import Transaction from 'components/Activity/Transaction'
+
+const mapDispatchToProps = {
+  showActivityModal
+}
+
+const mapStateToProps = state => ({
+  currencyName: tickerSelectors.currencyName(state),
+  currentTicker: tickerSelectors.currentTicker(state),
+  nodes: state.network.nodes,
+  ticker: state.ticker
+})
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Transaction)

--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -116,7 +116,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const networkTabProps = {
     currentChannels: stateProps.currentChannels,
     channels: stateProps.channels,
-    balance: stateProps.balance,
+    channelBalance: stateProps.balance.channelBalance,
     currentTicker: stateProps.currentTicker,
     contactsform: stateProps.contactsform,
     nodes: stateProps.network.nodes,

--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -72,7 +72,6 @@ const mapStateToProps = state => ({
   info: state.info,
   payment: state.payment,
   transaction: state.transaction,
-  peers: state.peers,
   channels: state.channels,
   contactsform: state.contactsform,
   balance: state.balance,

--- a/app/containers/Wallet.js
+++ b/app/containers/Wallet.js
@@ -2,6 +2,7 @@ import { connect } from 'react-redux'
 import { setCurrency, tickerSelectors } from 'reducers/ticker'
 import { openWalletModal } from 'reducers/address'
 import { setFormType } from 'reducers/form'
+import { balanceSelectors } from 'reducers/balance'
 import Wallet from 'components/Wallet'
 
 const mapDispatchToProps = {
@@ -11,9 +12,9 @@ const mapDispatchToProps = {
 }
 
 const mapStateToProps = state => ({
-  balance: state.balance,
   info: state.info,
   ticker: state.ticker,
+  totalBalance: balanceSelectors.totalBalance(state),
   currentTicker: tickerSelectors.currentTicker(state),
   currencyFilters: tickerSelectors.currencyFilters(state)
 })

--- a/app/containers/Wallet.js
+++ b/app/containers/Wallet.js
@@ -1,0 +1,24 @@
+import { connect } from 'react-redux'
+import { setCurrency, tickerSelectors } from 'reducers/ticker'
+import { openWalletModal } from 'reducers/address'
+import { setFormType } from 'reducers/form'
+import Wallet from 'components/Wallet'
+
+const mapDispatchToProps = {
+  openWalletModal,
+  setCurrency,
+  setFormType
+}
+
+const mapStateToProps = state => ({
+  balance: state.balance,
+  info: state.info,
+  ticker: state.ticker,
+  currentTicker: tickerSelectors.currentTicker(state),
+  currencyFilters: tickerSelectors.currencyFilters(state)
+})
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Wallet)

--- a/app/reducers/balance.js
+++ b/app/reducers/balance.js
@@ -1,3 +1,4 @@
+import { createSelector } from 'reselect'
 import { send } from 'redux-electron-ipc'
 
 // ------------------------------------
@@ -38,6 +39,20 @@ const ACTION_HANDLERS = {
     channelBalance
   })
 }
+
+const channelBalanceSelector = state => state.balance.channelBalance
+const walletBalanceSelector = state => state.balance.walletBalance
+
+// Selectors
+const balanceSelectors = {}
+
+balanceSelectors.totalBalance = createSelector(
+  channelBalanceSelector,
+  walletBalanceSelector,
+  (channelBalance, walletBalance) => (channelBalance || 0) + (walletBalance || 0)
+)
+
+export { balanceSelectors }
 
 // ------------------------------------
 // Reducer


### PR DESCRIPTION
## Description:

Separate out the Wallet and Activity containers in order to reduce unnecessary re-renders of these components.

## Motivation and Context:

Pulling commit out of https://github.com/LN-Zap/zap-desktop/pull/1352 to make it easier to review in isolation.

## How Has This Been Tested?

Enable component update highlighting in react dev tools and connect to a wallet with several channels and transactions.

Compare renders before and after the patch.

## Types of changes:

Performance improvement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
