### PR TITLE
perf(ui): reduce network pane re-renders

### DIFF
--- a/app/components/Contacts/Network/Network.js
+++ b/app/components/Contacts/Network/Network.js
@@ -5,6 +5,7 @@ import { FormattedNumber, FormattedMessage, injectIntl } from 'react-intl'
 import { Box, Flex } from 'rebass'
 import blockExplorer from 'lib/utils/blockExplorer'
 import { satoshisToFiat } from 'lib/utils/btc'
+import SuggestedNodes from 'containers/Contacts/SuggestedNodes'
 import ExternalLink from 'components/Icon/ExternalLink'
 import PlusCircle from 'components/Icon/PlusCircle'
 import Search from 'components/Icon/Search'
@@ -21,7 +22,6 @@ import {
   Text,
   Value
 } from 'components/UI'
-import SuggestedNodes from '../SuggestedNodes'
 import messages from './messages'
 
 class Network extends Component {
@@ -74,7 +74,6 @@ class Network extends Component {
       changeFilter,
       setSelectedChannel,
       closeChannel,
-      suggestedNodesProps,
       network,
       currencyName,
       intl
@@ -226,7 +225,7 @@ class Network extends Component {
         </Panel.Header>
 
         <Panel.Body css={{ 'overflow-y': 'auto' }}>
-          {!hasChannels && <SuggestedNodes {...suggestedNodesProps} py={3} mx={3} />}
+          {!hasChannels && <SuggestedNodes py={3} mx={3} />}
 
           {hasChannels && (
             <Box>
@@ -440,7 +439,6 @@ Network.propTypes = {
   balance: PropTypes.object.isRequired,
   currentTicker: PropTypes.object,
   ticker: PropTypes.object.isRequired,
-  suggestedNodesProps: PropTypes.object.isRequired,
   network: PropTypes.object.isRequired,
   fetchChannels: PropTypes.func.isRequired,
   openContactsForm: PropTypes.func.isRequired,

--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -131,17 +131,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     changeFilter: dispatchProps.changeFilter,
     updateChannelSearchQuery: dispatchProps.updateChannelSearchQuery,
     setSelectedChannel: dispatchProps.setSelectedChannel,
-    closeChannel: dispatchProps.closeChannel,
-
-    suggestedNodesProps: {
-      suggestedNodesLoading: stateProps.channels.suggestedNodesLoading,
-      suggestedNodes: stateProps.info.data.testnet
-        ? stateProps.channels.suggestedNodes.testnet
-        : stateProps.channels.suggestedNodes.mainnet,
-
-      setNode: dispatchProps.setNode,
-      openSubmitChannelForm: () => dispatchProps.openSubmitChannelForm()
-    }
+    closeChannel: dispatchProps.closeChannel
   }
 
   const contactsFormProps = {

--- a/app/containers/Contacts/SuggestedNodes.js
+++ b/app/containers/Contacts/SuggestedNodes.js
@@ -1,0 +1,18 @@
+import { connect } from 'react-redux'
+import { openSubmitChannelForm, setNode, contactFormSelectors } from 'reducers/contactsform'
+import SuggestedNodes from 'components/Contacts/SuggestedNodes'
+
+const mapStateToProps = state => ({
+  suggestedNodesLoading: state.channels.suggestedNodesLoading,
+  suggestedNodes: contactFormSelectors.suggestedNodes(state)
+})
+
+const mapDispatchToProps = {
+  openSubmitChannelForm,
+  setNode
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(SuggestedNodes)

--- a/app/reducers/contactsform.js
+++ b/app/reducers/contactsform.js
@@ -141,6 +141,9 @@ const nodeSelector = state => state.contactsform.node
 const channelsSelector = state => state.channels.channels
 const peersSelector = state => state.peers.peers
 const contactable = node => node.addresses.length > 0
+const testnetSelector = state => state.info.data.testnet
+const testnetNodesSelector = state => state.channels.suggestedNodes.testnet
+const mainnetNodesSelector = state => state.channels.suggestedNodes.mainnet
 
 // comparator to sort the contacts list with contactable contacts first
 const contactableFirst = (a, b) => {
@@ -151,6 +154,15 @@ const contactableFirst = (a, b) => {
   }
   return 0
 }
+
+contactFormSelectors.suggestedNodes = createSelector(
+  testnetSelector,
+  testnetNodesSelector,
+  mainnetNodesSelector,
+  (testnet, testnetNodes, mainnetNodes) => {
+    return testnet ? testnetNodes : mainnetNodes
+  }
+)
 
 contactFormSelectors.filteredNetworkNodes = createSelector(
   networkNodesSelector,


### PR DESCRIPTION
## Description:

Connect the Network component to the store directly to avoid re-renders of unrelated components when props that are only relevant to the Network component change.

## Motivation and Context:

Separate commit out of https://github.com/LN-Zap/zap-desktop/pull/1352 to make it easier to review in isolation.

## How Has This Been Tested?

Enable component update highlighting in react dev tools and connect to a wallet with several channels and transactions.

Compare renders before and after the patch.

## Types of changes:

Performance improvement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
