### PR TITLE
fix(btc): use rounding in fiat conversions

### DIFF
--- a/app/lib/utils/btc.js
+++ b/app/lib/utils/btc.js
@@ -29,7 +29,7 @@ export function btcToMillisatoshis(btc) {
 export function btcToFiat(btc, price) {
   if (isEmptyAmount(btc)) return null
 
-  return (btc * price).toFixed(2)
+  return Math.round(btc * price * 100) / 100
 }
 
 ////////////////////////////

--- a/test/unit/components/Pay/__snapshots__/PaySummaryLightning.spec.js.snap
+++ b/test/unit/components/Pay/__snapshots__/PaySummaryLightning.spec.js.snap
@@ -55,7 +55,7 @@ exports[`component.Form.PaySummaryLightning should render correctly 1`] = `
           <FormattedNumber
             currency="USD"
             style="currency"
-            value="0.65"
+            value={0.65}
           />
         </Text>
       </styled.div>

--- a/test/unit/components/Pay/__snapshots__/PaySummaryOnchain.spec.js.snap
+++ b/test/unit/components/Pay/__snapshots__/PaySummaryOnchain.spec.js.snap
@@ -69,7 +69,7 @@ exports[`component.Form.PaySummaryOnchain should render correctly 1`] = `
           <FormattedNumber
             currency="USD"
             style="currency"
-            value="0.06"
+            value={0.06}
           />
         </Text>
       </styled.div>


### PR DESCRIPTION
## Description:

When converting crypto amounts to fiat, use rounding rather than string conversion to ensure that the result remains as a Number type.

Fix #1334

## Motivation and Context:

In #1374 we changed how we handle conversions to fiat to use `toFixed`, which results in a String. We want to the the result as a number so that we can work with it as a number. Conversion top string with fixed dp should happen at display time rather than at time of conversion.

## How Has This Been Tested?

This fixes a bug that has broken the Request page. Currently in master, the app crashes when trying to create an invoice because in the `Value` component (which we use for displaying value amount) we convert numbers to the correct number of decimal places. But in the case of fiat the value is already a string. This causes a fatal error since `toString` can not be called on a string.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
