### PR TITLE
refactor(request): use correct prop type for invoice

### DIFF
--- a/app/components/Request/Request.js
+++ b/app/components/Request/Request.js
@@ -51,7 +51,7 @@ class Request extends React.Component {
     /** Boolean indicating wether the form is being processed. If true, form buttons are disabled. */
     isProcessing: PropTypes.bool,
     /** Lnd invoice object for the payment request */
-    invoice: PropTypes.bool,
+    invoice: PropTypes.object,
     /** Lightning Payment request. */
     payReq: PropTypes.string,
     /** Set the current cryptocurrency. */


### PR DESCRIPTION
## Description:

Use correct prop type for `invoice` prop in `Request` component.

## Motivation and Context:

Error in console when creating an invoice due to incorrect prop type.

## How Has This Been Tested?

Verify console error no longer appears.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
