### PR TITLE
fix(wallet): handle lndconnect links when app closed (mac)

### DIFF
--- a/app/components/Pay/Pay.js
+++ b/app/components/Pay/Pay.js
@@ -114,6 +114,8 @@ class Pay extends React.Component {
     setCryptoCurrency: PropTypes.func.isRequired,
     /** Set the current fiat currency */
     setFiatCurrency: PropTypes.func.isRequired,
+    /** Set the current payment request. */
+    setPayReq: PropTypes.func.isRequired,
     /** Method to process onChain transactions. Called when the form is submitted. */
     sendCoins: PropTypes.func.isRequired,
     /** Method to fetch fee information for onchain transactions. */
@@ -146,16 +148,19 @@ class Pay extends React.Component {
   payReqInput = React.createRef()
 
   componentDidMount() {
-    const { payReq: initialPayReq } = this.props
+    const { payReq, setPayReq } = this.props
     // If we mount with a payReq, set it in the state in order to trigger form submission once the form is loaded..
     // See componentDidUpdate().
-    if (initialPayReq) {
-      this.setState({ initialPayReq })
+    if (payReq) {
+      this.setState({ initialPayReq: payReq })
+
+      // Clear payReq now that it has been applied.
+      setPayReq(null)
     }
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { payReq, queryRoutes } = this.props
+    const { setPayReq, payReq, queryRoutes } = this.props
     const { currentStep, initialPayReq, invoice, isOnchain } = this.state
 
     // If initialPayReq was been set in the state when the component mounted, reset the form and submit as new.
@@ -163,6 +168,9 @@ class Pay extends React.Component {
       this.formApi.reset()
       this.formApi.setValue('payReq', initialPayReq)
       this.handlePayReqChange()
+
+      // Clear payReq now that it has been applied.
+      setPayReq(null)
     }
 
     // If payReq has changed, reset the form and submit as new.
@@ -170,6 +178,9 @@ class Pay extends React.Component {
       this.formApi.reset()
       this.formApi.setValue('payReq', payReq)
       this.handlePayReqChange()
+
+      // Clear payReq now that it has been applied.
+      setPayReq(null)
     }
 
     // If we have gone back to the address step, unmark all fields from being touched.

--- a/app/containers/Initializer.js
+++ b/app/containers/Initializer.js
@@ -21,6 +21,7 @@ class Initializer extends React.Component {
     isWalletOpen: PropTypes.bool.isRequired,
     isReady: PropTypes.bool.isRequired,
     lightningGrpcActive: PropTypes.bool.isRequired,
+    lndConnect: PropTypes.string,
     walletUnlockerGrpcActive: PropTypes.bool.isRequired,
     startLndError: PropTypes.object,
     startActiveWallet: PropTypes.func.isRequired,
@@ -58,13 +59,20 @@ class Initializer extends React.Component {
       hasWallets,
       history,
       lightningGrpcActive,
+      lndConnect,
       startLndError,
       walletUnlockerGrpcActive,
       startActiveWallet
     } = this.props
     // If the wallet settings have just been loaded, redirect the user to the most relevant location.
     if (isReady && !prevProps.isReady) {
-      if (activeWalletSettings) {
+      // If we have an lndConnect link, send the user to the onboarding process.
+      if (lndConnect) {
+        this.nextLocation = '/onboarding'
+      }
+
+      // Otherwise, attempt to handle their current active wallet.
+      else if (activeWalletSettings) {
         if (isWalletOpen) {
           // Catch the error and swallow it with a noop.
           // Errors are handled below by listening for updates to the startLndError prop.
@@ -74,9 +82,11 @@ class Initializer extends React.Component {
         }
       }
 
-      // If we have an at least one wallet send the user to the homepage.
+      // If we have at least one wallet send the user to the homepage.
       // Otherwise send them to the onboarding processes.
-      this.nextLocation = hasWallets ? '/home' : '/onboarding'
+      else {
+        this.nextLocation = hasWallets ? '/home' : '/onboarding'
+      }
     }
 
     // If there was a problem starting lnd, swich to the wallet launcher.
@@ -111,6 +121,7 @@ class Initializer extends React.Component {
 
 const mapStateToProps = state => ({
   onboarding: state.onboarding.onboarding,
+  lndConnect: state.onboarding.lndConnect,
   activeWallet: walletSelectors.activeWallet(state),
   activeWalletSettings: walletSelectors.activeWalletSettings(state),
   hasWallets: walletSelectors.hasWallets(state),

--- a/app/containers/Pay.js
+++ b/app/containers/Pay.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux'
 import { Pay } from 'components/Pay'
 import { tickerSelectors, setCurrency, setFiatTicker } from 'reducers/ticker'
-import { queryFees, queryRoutes } from 'reducers/pay'
+import { setPayReq, queryFees, queryRoutes } from 'reducers/pay'
 import { infoSelectors } from 'reducers/info'
 import { sendCoins } from 'reducers/transaction'
 import { payInvoice } from 'reducers/payment'
@@ -30,6 +30,7 @@ const mapDispatchToProps = {
   payInvoice,
   setCryptoCurrency: setCurrency,
   setFiatCurrency: setFiatTicker,
+  setPayReq,
   sendCoins,
   queryFees,
   queryRoutes

--- a/app/lib/zap/controller.js
+++ b/app/lib/zap/controller.js
@@ -82,6 +82,7 @@ class ZapController {
 
     // Once the winow content has fully loaded, bootstrap the app.
     this.mainWindow.webContents.on('did-finish-load', () => {
+      mainLog.trace('webContents.did-finish-load')
       // Initialise a state machine that we will use to control application state transitions.
       this.fsm = new StateMachine({
         transitions: [

--- a/app/reducers/pay.js
+++ b/app/reducers/pay.js
@@ -56,9 +56,6 @@ export const lightningPaymentUri = (event, { payReq }) => dispatch => {
   // Then load it fresh and set the payment request.
   dispatch(setFormType('PAY_FORM'))
   dispatch(setPayReq(payReq))
-
-  // Finally, clear the payment request.
-  dispatch(setPayReq(null))
 }
 
 // ------------------------------------


### PR DESCRIPTION
## Description:

If a lightning link is used when the app is closed, wait for the the app to finish loading before passing the link onto the app.

## Motivation and Context:

Fix #1401 

This PR resolves for mac users. Issue persists for Windows.

## How Has This Been Tested?

1. Build the app (`yarn package`)
2. Install the app (on the mac, for example, you must copy the app out of the release dir and replace your app in `/Applications`). You need to ensure that the version that you just built will be opened when using the lightning link.
3. Test lightning links when the app is closed
4. Test lightning links when the app is already open

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
