### PR TITLE
ci(travis): skip deploy stage for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ jobs:
   include:
     - stage: deploy
       name: Deploy to Github
+      if: (NOT type IN (pull_request)) AND (branch = master)
       script: skip
       deploy:
         skip_cleanup: true
@@ -73,6 +74,7 @@ jobs:
 
     - os: osx
       name: Deploy to Github
+      if: (NOT type IN (pull_request)) AND (branch = master)
       script: skip
       deploy:
         skip_cleanup: true


### PR DESCRIPTION
## Description:

Limit deploy stage to only run on master branch builds.

## Motivation and Context:

There is no need to run the deploy stage of our builds when building PRs

## Types of changes:

CI improvement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
