### PR TITLE
ci(node): do not build and test on node LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ os:
 
 node_js:
   - node
-  - lts/*
 
 cache:
   apt: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,6 @@ environment:
   DEBUG: electron-builder
   matrix:
     - nodejs_version: STABLE
-      publish_build: true
-    - nodejs_version: LTS
 
 cache:
   - node_modules -> package.json
@@ -35,4 +33,4 @@ test_script:
   - yarn test-ci
 
 deploy_script:
-  - cmd: powershell if (($env:appveyor_repo_name -eq 'LN-Zap/zap-desktop') -and ($env:appveyor_repo_branch -eq 'master') -and ($env:publish_build)) { yarn release --win }
+  - cmd: powershell if (($env:appveyor_repo_name -eq 'LN-Zap/zap-desktop') -and ($env:appveyor_repo_branch -eq 'master') { yarn release --win }


### PR DESCRIPTION
## Description:

Our current CI process is relatively time consuming, largely due to the fact that we currently build and test the app on node LTS in addition to the current node version.

Node LTS primarily exists to server enterprises with an inability to move fast and keep technology current. We don't fit into that category and shouldn't waste time building and testing the app on an old node LTS version.

We could cut our build times in half with this change. I don't think any developers working on this project are likely to be using LTS node.

## Types of changes:

CI improvement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
