### PR TITLE
refactor(main): run app in development mode by default

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -32,6 +32,11 @@ if (process.env.ELECTRON_USER_DIR_TEMP) {
   app.setPath('userData', folder)
 }
 
+// By default, run the app in development mode.
+if (!process.env.NODE_ENV) {
+  process.env.NODE_ENV = 'development'
+}
+
 /**
  * Handler for open-link events.
  */
@@ -240,7 +245,7 @@ app.on('ready', async () => {
   /**
    * In development mode or when DEBUG_PROD is set, enable debugging tools.
    */
-  if (process.env.NODE_ENV !== 'production' || process.env.DEBUG_PROD) {
+  if (process.env.NODE_ENV === 'development' || process.env.DEBUG_PROD) {
     installExtension(REACT_DEVELOPER_TOOLS)
       .then(name => mainLog.debug(`Added Extension: ${name}`))
       .catch(err => mainLog.warn(`An error occurred when installing REACT_DEVELOPER_TOOLS: ${err}`))

--- a/internals/webpack/webpack.config.main.prod.js
+++ b/internals/webpack/webpack.config.main.prod.js
@@ -4,6 +4,7 @@
 
 import path from 'path'
 import merge from 'webpack-merge'
+import { EnvironmentPlugin } from 'webpack'
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer'
 import baseConfig, { rootDir } from './webpack.config.base'
 
@@ -22,9 +23,10 @@ export default merge.smart(baseConfig, {
   },
 
   plugins: [
-    /**
-     * Babli is an ES6+ aware minifier based on the Babel toolchain (beta)
-     */
+    new EnvironmentPlugin({
+      NODE_ENV: 'production'
+    }),
+
     new BundleAnalyzerPlugin({
       analyzerMode: process.env.OPEN_ANALYZER === 'true' ? 'server' : 'disabled',
       openAnalyzer: process.env.OPEN_ANALYZER === 'true'


### PR DESCRIPTION
## Description:

Default `NODE_ENV` to `development` in the main process.

We already do this for the renderer process via `EnvironmentPlugin` (See [here](https://github.com/LN-Zap/zap-desktop/blob/master/internals/webpack/webpack.config.renderer.prod.js#L53-L55) and [here](https://github.com/LN-Zap/zap-desktop/blob/master/internals/webpack/webpack.config.renderer.prod.js#L53-L55)). Ensure that we do the same for the main process.

## Motivation and Context:

`NODE_ENV` was unset in the main process, preventing development related menu items from showing up (they only show when `NODE_ENV` is set to `development`)

## How Has This Been Tested?

Start up the app in development mode and verify that development menu items are visible and that `cmd+r` reloads the app.

Run app in production mode and ensure that development menu items are not visible

## Types of changes:

devtools fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
