### PR TITLE
fix(intl): add missing intl support to wallet recover step

### DIFF
--- a/app/components/Onboarding/Steps/SeedConfirm.js
+++ b/app/components/Onboarding/Steps/SeedConfirm.js
@@ -95,7 +95,7 @@ class SeedConfirm extends React.Component {
         <Bar my={4} />
 
         {seedWordIndexes.map((wordIndex, index) => {
-          // Only validate if the word has been entered connectly already or the form has been siubmitted.
+          // Only validate if the word has been entered correctly already or the form has been submitted.
           return (
             <Flex key={`word${index}`} justifyContent="flex-start" mb={3}>
               <Label htmlFor="alias" width={25} mt={18}>

--- a/app/components/Onboarding/Steps/WalletRecover.js
+++ b/app/components/Onboarding/Steps/WalletRecover.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { FormattedMessage } from 'react-intl'
 import { Form, Spinner, Text } from 'components/UI'
+import messages from './messages'
 
 class WalletRecover extends React.Component {
   static propTypes = {
@@ -58,7 +60,7 @@ class WalletRecover extends React.Component {
       >
         <Text textAlign="center">
           <Spinner />
-          Importing wallet...
+          <FormattedMessage {...messages.importing_wallet} />
         </Text>
       </Form>
     )

--- a/app/components/Onboarding/Steps/messages.js
+++ b/app/components/Onboarding/Steps/messages.js
@@ -83,5 +83,6 @@ export default defineMessages({
   wallet_name_title: 'What do you want to call this wallet?',
   wallet_name_label: 'Wallet Name',
   word_placeholder: 'word',
-  generating_seed: 'Generating Seed...'
+  generating_seed: 'Generating Seed...',
+  importing_wallet: 'Importing wallet...'
 })

--- a/app/translations/af-ZA.json
+++ b/app/translations/af-ZA.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "",

--- a/app/translations/ar-SA.json
+++ b/app/translations/ar-SA.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "",

--- a/app/translations/bg-BG.json
+++ b/app/translations/bg-BG.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "Хост",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "Път до lnd macaroon файла. Пример: /path/to/admin.macaroon",

--- a/app/translations/ca-ES.json
+++ b/app/translations/ca-ES.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "",

--- a/app/translations/cs-CZ.json
+++ b/app/translations/cs-CZ.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "Cesta k souboru lnd macaroon. Příklad: /path/to/admin.macaroon",

--- a/app/translations/da-DK.json
+++ b/app/translations/da-DK.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "",

--- a/app/translations/de-DE.json
+++ b/app/translations/de-DE.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "Betreiber",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "Pfad zur lnd macaroon Datei. Beispiel: /path/to/admin.macaroon",

--- a/app/translations/el-GR.json
+++ b/app/translations/el-GR.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "Διαδρομή προς το αρχείο macaroon. Παράδειγμα: /path/to/admin.macaroon",

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "Host",
   "components.Onboarding.Steps.import_description": "Recovering a wallet, nice. You don't need anyone else, you got yourself :)",
   "components.Onboarding.Steps.import_title": "Import your seed",
+  "components.Onboarding.Steps.importing_wallet": "Importing wallet...",
   "components.Onboarding.Steps.login_description": "Please enter your wallet password to unlock it.",
   "components.Onboarding.Steps.login_title": "Welcome back!",
   "components.Onboarding.Steps.macaroon_description": "Path to the lnd macaroon file. Example: /path/to/admin.macaroon",

--- a/app/translations/es-ES.json
+++ b/app/translations/es-ES.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "Ruta al archivo lnd macaroon. Ejemplo: /path/to/admin.macaroon",

--- a/app/translations/fi-FI.json
+++ b/app/translations/fi-FI.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "",

--- a/app/translations/fr-FR.json
+++ b/app/translations/fr-FR.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "Le chemin vers le fichier macaroon lnd. Exemple : /path/to/admin.macaroon",

--- a/app/translations/ga-IE.json
+++ b/app/translations/ga-IE.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "Óstach",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "Cosán go dtí an comhad lnd macaroon. Mar shampla: /path/to/admin.macaroon",

--- a/app/translations/he-IL.json
+++ b/app/translations/he-IL.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "",

--- a/app/translations/hi-IN.json
+++ b/app/translations/hi-IN.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "",

--- a/app/translations/hr-HR.json
+++ b/app/translations/hr-HR.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "Domaćin",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "Put do Lnd makaron datoteke. Primjer: /path/to/admin.macaroon",

--- a/app/translations/hu-HU.json
+++ b/app/translations/hu-HU.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "",

--- a/app/translations/it-IT.json
+++ b/app/translations/it-IT.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "",

--- a/app/translations/ja-JP.json
+++ b/app/translations/ja-JP.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "Lndマカロン ファイルへのパス。例:/path/to/admin.macaroon",

--- a/app/translations/ko-KR.json
+++ b/app/translations/ko-KR.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "",

--- a/app/translations/nl-NL.json
+++ b/app/translations/nl-NL.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "Pad naar het bestand lnd macaroon. Voorbeeld: /path/to/admin.macaroon",

--- a/app/translations/no-NO.json
+++ b/app/translations/no-NO.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "",

--- a/app/translations/pl-PL.json
+++ b/app/translations/pl-PL.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "",

--- a/app/translations/pt-BR.json
+++ b/app/translations/pt-BR.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "Path to the lnd macaroon file. Exemplo: /path/to/admin.macaroon",

--- a/app/translations/pt-PT.json
+++ b/app/translations/pt-PT.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "",

--- a/app/translations/ro-RO.json
+++ b/app/translations/ro-RO.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "Calea către fişierul de macaron lnd. Exemplu: /path/to/admin.macaroon",

--- a/app/translations/ru-RU.json
+++ b/app/translations/ru-RU.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "Импортируем кошелёк",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "Путь до файла lnd. Пример: /path/to/admin.macaroon",

--- a/app/translations/sr-SP.json
+++ b/app/translations/sr-SP.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "",

--- a/app/translations/sv-SE.json
+++ b/app/translations/sv-SE.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "Sökvägen till lnd macaroon filen. Exempel: /path/to/admin.macaroon",

--- a/app/translations/tr-TR.json
+++ b/app/translations/tr-TR.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "Lnd macaroon dosyasının konumu. Örnek: /path/to/admin.macaroon",

--- a/app/translations/uk-UA.json
+++ b/app/translations/uk-UA.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "Імпортуємо гаманець",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "Шлях до файлу lnd macaroon. Приклад: /path/to/admin.macaroon",

--- a/app/translations/vi-VN.json
+++ b/app/translations/vi-VN.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "",

--- a/app/translations/zh-CN.json
+++ b/app/translations/zh-CN.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "lnd macaroon 文件的路径。示例:/path/to/admin.macaroon",

--- a/app/translations/zh-TW.json
+++ b/app/translations/zh-TW.json
@@ -164,6 +164,7 @@
   "components.Onboarding.Steps.hostname_title": "",
   "components.Onboarding.Steps.import_description": "",
   "components.Onboarding.Steps.import_title": "",
+  "components.Onboarding.Steps.importing_wallet": "",
   "components.Onboarding.Steps.login_description": "",
   "components.Onboarding.Steps.login_title": "",
   "components.Onboarding.Steps.macaroon_description": "lnd macaroon 文件的路径。示例:/path/to/admin.macaroon",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Add intl support to  'importing wallet...' message which appears during Wallet Recover state
<!--- Describe your changes in detail -->

## Motivation and Context:
Currently intl support of that message is missing
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
## Types of changes:
bugfix
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
