### PR TITLE
fix(launcher): ensure wallet close on laucnhpad mount

### DIFF
--- a/app/components/Home/Home.js
+++ b/app/components/Home/Home.js
@@ -31,6 +31,7 @@ class Home extends React.Component {
     stopLnd: PropTypes.func.isRequired,
     setActiveWallet: PropTypes.func.isRequired,
     unlockWallet: PropTypes.func.isRequired,
+    setIsWalletOpen: PropTypes.func.isRequired,
     setUnlockWalletError: PropTypes.func.isRequired,
     setStartLndError: PropTypes.func.isRequired,
     setError: PropTypes.func.isRequired,
@@ -42,10 +43,12 @@ class Home extends React.Component {
    * If there is an active wallet ensure it is selected on mount.
    */
   componentDidMount() {
-    const { activeWallet, activeWalletSettings, history } = this.props
+    const { activeWallet, activeWalletSettings, history, setIsWalletOpen } = this.props
     if (activeWallet && activeWalletSettings && history.location.pathname === '/home') {
       history.push(`/home/wallet/${activeWallet}`)
     }
+
+    setIsWalletOpen(false)
   }
 
   componentDidUpdate(prevProps) {

--- a/app/containers/Home.js
+++ b/app/containers/Home.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux'
-import { setActiveWallet, walletSelectors, deleteWallet } from 'reducers/wallet'
+import { setActiveWallet, walletSelectors, setIsWalletOpen, deleteWallet } from 'reducers/wallet'
 import {
   setUnlockWalletError,
   stopLnd,
@@ -30,6 +30,7 @@ const mapDispatchToProps = {
   startLnd,
   unlockWallet,
   deleteWallet,
+  setIsWalletOpen,
   setError
 }
 


### PR DESCRIPTION
## Description:

Ensure that the active wallet is closed when the launchpad is mounted.

## Motivation and Context:

This fixes an edge case in which the app will try to connect to your previously open wallet even after it has failed to do so.

## How Has This Been Tested?

1) Connect to a remote wallet
2) Quit the app
3) Disconnect your internet connection
4) Open the app

The app will fail to connect to the remote wallet, and you will be taken to the home page.

Quit the app again, reconnect your internet connection. and relaunch the app. Again, it will try to connect to the other wallet automatically - which it should not do since when you were last in the app, you quit whilst on the lauchpad.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
