### PR TITLE
fix(launcher): do not double notify startup errors

### DIFF
--- a/app/components/Home/WalletLauncher.js
+++ b/app/components/Home/WalletLauncher.js
@@ -50,7 +50,7 @@ class WalletLauncher extends React.Component {
 
     // If we got lnd start errors, show as a global error.
     if (startLndError && !prevProps.startLndError) {
-      Object.keys(startLndError).forEach(key => setError(startLndError.startLndError[key]))
+      Object.keys(startLndError).forEach(key => setError(startLndError[key]))
       setStartLndError(null)
     }
 

--- a/app/components/Onboarding/Onboarding.js
+++ b/app/components/Onboarding/Onboarding.js
@@ -52,6 +52,7 @@ class Onboarding extends React.Component {
     setConnectionCert: PropTypes.func.isRequired,
     setConnectionMacaroon: PropTypes.func.isRequired,
     setConnectionString: PropTypes.func.isRequired,
+    setStartLndError: PropTypes.func.isRequired,
     setLndconnect: PropTypes.func.isRequired,
     setName: PropTypes.func.isRequired,
     setPassword: PropTypes.func.isRequired,
@@ -96,6 +97,7 @@ class Onboarding extends React.Component {
       setConnectionCert,
       setConnectionMacaroon,
       setConnectionString,
+      setStartLndError,
       setName,
       setUnlockWalletError,
       setPassword,
@@ -168,6 +170,7 @@ class Onboarding extends React.Component {
               setConnectionHost,
               setConnectionCert,
               setConnectionMacaroon,
+              setStartLndError,
               validateHost,
               validateCert,
               validateMacaroon

--- a/app/components/Onboarding/Steps/ConnectionDetails.js
+++ b/app/components/Onboarding/Steps/ConnectionDetails.js
@@ -77,6 +77,11 @@ class ConnectionDetails extends React.Component {
     }
   }
 
+  componentWillUnmount() {
+    const { setStartLndError } = this.props
+    setStartLndError(null)
+  }
+
   handleConnectionHostChange = () => {
     const formState = this.formApi.getState()
     delete formState.asyncErrors.connectionHost
@@ -145,6 +150,7 @@ class ConnectionDetails extends React.Component {
       setConnectionCert,
       setConnectionMacaroon,
       setLndconnect,
+      setStartLndError,
       startLndHostError,
       startLndCertError,
       startLndMacaroonError,

--- a/app/containers/Onboarding.js
+++ b/app/containers/Onboarding.js
@@ -19,6 +19,7 @@ import {
 } from 'reducers/onboarding'
 import {
   setUnlockWalletError,
+  setStartLndError,
   startLnd,
   stopLnd,
   fetchSeed,
@@ -57,6 +58,7 @@ const mapDispatchToProps = {
   setConnectionCert,
   setConnectionMacaroon,
   setConnectionString,
+  setStartLndError,
   setName,
   setPassword,
   setSeed,

--- a/app/lib/zap/controller.js
+++ b/app/lib/zap/controller.js
@@ -482,17 +482,24 @@ class ZapController {
         await this.startLnd(options)
       } catch (e) {
         mainLog.error('Unable to start lnd: %s', e.message)
+
+        // Return back to the start of the onboarding process.
+        return this.startOnboarding()
       }
     })
-    ipcMain.on('startLightningWallet', () =>
-      this.startLightningWallet().catch(e => {
+    ipcMain.on('startLightningWallet', async () => {
+      try {
+        await this.startLightningWallet()
+      } catch (e) {
+        mainLog.error('Unable to connect to lightning wallet: %s', e.message)
+
         // Notify the app of errors.
         this.sendMessage('startLndError', e.message)
 
         // Return back to the start of the onboarding process.
         return this.startOnboarding()
-      })
-    )
+      }
+    })
     ipcMain.on('stopLnd', () => this.stopLnd())
 
     ipcMain.on('killLnd', (event, signal = 'SIGKILL') => {


### PR DESCRIPTION
## Description:

Do not double notify startup errors.

## Motivation and Context:

Errors connecting to a wallet can be shown twice, or not at all.

## How Has This Been Tested?

1. Set up a new remote connection using the onboarding process
2. Enter an incorrect port as part of the hostname
3. Wait 20 seconds for the connection attempt to timeout
4. You will be taken back to the connection details form with the timeout error showing below the host field.
5. Close the modal
6. The same error will now show at the top of the screen ads a global error.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
