### PR TITLE
fix(linux): support lightning/lndconnect protocol links

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,20 @@
         ]
       }
     ],
+    "protocols": [
+      {
+        "name": "Lightning",
+        "schemes": [
+          "lightning"
+        ]
+      },
+      {
+        "name": "Lnd Connect",
+        "schemes": [
+          "lndconnect"
+        ]
+      }
+    ],
     "artifactName": "${productName}-${platform}-${arch}-v${version}.${ext}",
     "mac": {
       "category": "public.app-category.finance",


### PR DESCRIPTION
## Description:

Add support for `lightning` and `lndconnect` protocol links on linux. Additional config is needed for electron-builder in order to support these.

## Motivation and Context:

`lightning` and `lndconnect` protocol links don't work on linux. 

## How Has This Been Tested?

Test `lightning` and `lndconnect`protocol links on linux.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
