### PR TITLE
refactor(ui): add new ChannelCapacity component

### DIFF
--- a/app/components/Channels/ChannelCapacity.js
+++ b/app/components/Channels/ChannelCapacity.js
@@ -1,0 +1,81 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { FormattedMessage } from 'react-intl'
+import { Box, Flex } from 'rebass'
+import { Dropdown, Heading, ProgressBar, Text, Value } from 'components/UI'
+import ZapSolid from 'components/Icon/ZapSolid'
+import messages from './messages'
+
+const ChannelCapacity = ({
+  cryptoCurrency,
+  cryptoCurrencies,
+  localBalance,
+  remoteBalance,
+  setCryptoCurrency
+}) => {
+  const totalBalance = localBalance + remoteBalance
+  const localBalancePercent = localBalance / totalBalance
+  const remoteBalancePercent = remoteBalance / totalBalance
+
+  return (
+    <Box as="article">
+      <Flex as="header" justifyContent="space-between" alignItems="center">
+        <Text width={1 / 3}>
+          <Heading.h4 fontWeight="normal">
+            <FormattedMessage {...messages.local_balance} />
+          </Heading.h4>
+        </Text>
+        <Text width={1 / 3} textAlign="center">
+          <Heading.h4 fontWeight="normal">
+            <FormattedMessage {...messages.capacity} />
+          </Heading.h4>
+        </Text>
+        <Text width={1 / 3} textAlign="right">
+          <Heading.h4 fontWeight="normal">
+            <FormattedMessage {...messages.remote_balance} />
+          </Heading.h4>
+        </Text>
+      </Flex>
+
+      <Flex as="section" justifyContent="space-between" alignItems="center" my={2}>
+        <Box width="calc(50% - 15px)">
+          <ProgressBar progress={localBalancePercent} />
+        </Box>
+        <Text width={30} textAlign="center" color="lightningOrange">
+          <ZapSolid height="20px" fill="currentColor" />
+        </Text>
+        <Box width="calc(50% - 15px)">
+          <ProgressBar progress={remoteBalancePercent} justify="right" color="superBlue" />
+        </Box>
+      </Flex>
+
+      <Flex as="footer" justifyContent="space-between">
+        <Text width={1 / 3}>
+          <Value value={localBalance} currency={cryptoCurrency} />
+        </Text>
+        <Text width={1 / 3} textAlign="center">
+          <Value value={totalBalance} currency={cryptoCurrency} />
+          <Dropdown
+            items={cryptoCurrencies}
+            activeKey={cryptoCurrency}
+            onChange={setCryptoCurrency}
+            ml={1}
+          />
+        </Text>
+        <Text width={1 / 3} textAlign="right">
+          <Value value={remoteBalance} currency={cryptoCurrency} />
+        </Text>
+      </Flex>
+    </Box>
+  )
+}
+
+ChannelCapacity.propTypes = {
+  cryptoCurrency: PropTypes.string.isRequired,
+  cryptoCurrencies: PropTypes.array.isRequired,
+  localBalance: PropTypes.number.isRequired,
+  remoteBalance: PropTypes.number.isRequired,
+  setCryptoCurrency: PropTypes.func.isRequired
+}
+
+export default ChannelCapacity

--- a/app/components/Channels/messages.js
+++ b/app/components/Channels/messages.js
@@ -1,0 +1,7 @@
+import { defineMessages } from 'react-intl'
+
+export default defineMessages({
+  local_balance: 'Local Balance',
+  remote_balance: 'Remote Balance',
+  capacity: 'Capacity'
+})

--- a/app/components/Icon/FolderOpen.js
+++ b/app/components/Icon/FolderOpen.js
@@ -1,14 +1,7 @@
 import React from 'react'
 
 const SvgFolderOpen = props => (
-  <svg
-    viewBox="0 0 50 50"
-    width="1em"
-    height="1em"
-    stroke="currentColor"
-    strokeWidth={2}
-    {...props}
-  >
+  <svg viewBox="0 0 50 50" width="1em" height="1em" {...props}>
     <path
       style={{
         lineHeight: 'normal',

--- a/app/components/Icon/ZapSolid.js
+++ b/app/components/Icon/ZapSolid.js
@@ -1,0 +1,13 @@
+import React from 'react'
+
+const SvgZapSolid = props => (
+  <svg width="1em" height="1em" viewBox="0 0 13 20" {...props}>
+    <path
+      fill="currentColor"
+      fillRule="evenodd"
+      d="M0 11.645h6.212L4.14 19.533l8.282-11.645H6.626L8.696 0z"
+    />
+  </svg>
+)
+
+export default SvgZapSolid

--- a/app/components/UI/ProgressBar.js
+++ b/app/components/UI/ProgressBar.js
@@ -12,6 +12,7 @@ const EmptyBar = ({ children, ...rest }) => (
     {children}
   </SystemCard>
 )
+
 EmptyBar.propTypes = {
   children: PropTypes.node
 }

--- a/app/components/UI/Value.js
+++ b/app/components/UI/Value.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { FormattedNumber } from 'react-intl'
 import { convert } from 'lib/utils/btc'
 
 const forcePositive = amount => (amount >= 0 ? amount : amount * -1)
@@ -41,7 +42,7 @@ const Value = ({ value, currency, currentTicker, fiatTicker }) => {
 
   // Convert to a string and remove all trailing zeros.
   const trimmedAmount = String(truncatedAmount).replace(/\.?0+$/, '')
-  return <span>{trimmedAmount}</span>
+  return <FormattedNumber value={trimmedAmount} />
 }
 
 Value.propTypes = {

--- a/app/icons/zap-solid.svg
+++ b/app/icons/zap-solid.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="13" height="20" viewBox="0 0 13 20">
+    <path fill="currentColor" fill-rule="evenodd" d="M0 11.645h6.212L4.14 19.533l8.282-11.645H6.626L8.696 0z"/>
+</svg>

--- a/stories/containers/channels/channel-capacity.stories.js
+++ b/stories/containers/channels/channel-capacity.stories.js
@@ -1,0 +1,60 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { number } from '@storybook/addon-knobs'
+import { State, Store } from '@sambego/storybook-state'
+import ChannelCapacity from 'components/Channels/ChannelCapacity'
+
+const store = new Store({
+  /** Currently selected cryptocurrency (key). */
+  cryptoCurrency: 'sats',
+  /** List of supported cryptocurrencies. */
+  cryptoCurrencies: [
+    {
+      key: 'btc',
+      name: 'BTC'
+    },
+    {
+      key: 'bits',
+      name: 'bits'
+    },
+    {
+      key: 'sats',
+      name: 'satoshis'
+    }
+  ]
+})
+
+const setCryptoCurrency = key => {
+  const items = store.get('cryptoCurrencies')
+  const item = items.find(i => i.key === key)
+  store.set({ cryptoCurrency: item.key })
+  store.set({ cryptoCurrencyTicker: item.name })
+}
+
+storiesOf('Containers.Channels', module)
+  .addParameters({
+    info: {
+      disable: true
+    }
+  })
+  .add('ChannelCapacity', () => {
+    const localBalance = number('Local Balance', 150000)
+    const remoteBalance = number('Remote Balance', 75000)
+
+    const stateProps = {
+      localBalance,
+      remoteBalance
+    }
+
+    const dispatchProps = {
+      setCryptoCurrency
+    }
+
+    return (
+      <State store={store}>
+        {state => {
+          return <ChannelCapacity {...state} {...stateProps} {...dispatchProps} />
+        }}
+      </State>
+    )
+  })


### PR DESCRIPTION
## Description:

Add a new ChannelCapacity component that can be used to display channel capacity information using progress bars to visualise the channel state.

**Note: This builds on the work in #1433, which should be reviewed / merged first**

## Motivation and Context:

Re #1425

Part of the new Channel UI

## How Has This Been Tested?

Storybook

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/200251/51796125-af45e700-21b2-11e9-8bc1-e8f2d05126b8.png)

## Types of changes:

New component

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
