### PR TITLE
fix(wallet): prevent crash on currency conversions

### DIFF
--- a/app/components/Pay/Pay.js
+++ b/app/components/Pay/Pay.js
@@ -618,6 +618,7 @@ class Pay extends React.Component {
       onchainFees,
       payInvoice,
       sendCoins,
+      setPayReq,
       setCryptoCurrency,
       setFiatCurrency,
       queryFees,

--- a/app/components/UI/Value.js
+++ b/app/components/UI/Value.js
@@ -1,8 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { FormattedNumber } from 'react-intl'
 import { convert } from 'lib/utils/btc'
 
-const forcePositive = amount => (amount >= 0 ? amount : amount * -1)
+const forcePositiveNumber = amount => (amount >= 0 ? amount * 1 : amount * -1)
 
 /**
  * Renders a satoshi amount into a specific currency/unit.
@@ -11,29 +12,36 @@ const forcePositive = amount => (amount >= 0 ? amount : amount * -1)
  * @param {[type]} currentTicker Current fiat ticker info.
  * @param {[type]} fiatTicker    Key of fiat ticker to use for fiat conversions.
  */
-const Value = ({ value, currency, currentTicker, fiatTicker }) => {
+const Value = ({ value, currency, currentTicker, fiatTicker, style }) => {
   let price
   if (currency === 'fiat') {
     price = currentTicker[fiatTicker]
   }
 
   // Convert the satoshi amount to the requested currency
-  const convertedAmount = convert('sats', currency, forcePositive(value), price)
+  const convertedAmount = convert('sats', currency, forcePositiveNumber(value), price)
 
   // Truncate the amount to the most relevant number of decimal places:
   let dp = 11
   switch (currency) {
     case 'btc':
+    case 'ltc':
       dp = 8
       break
     case 'bits':
+    case 'phots':
       dp = 5
       break
     case 'sats':
+    case 'lits':
       dp = 3
       break
     case 'msats':
+    case 'mlits':
       dp = 0
+      break
+    case 'fiat':
+      dp = 2
       break
   }
 
@@ -41,14 +49,26 @@ const Value = ({ value, currency, currentTicker, fiatTicker }) => {
 
   // Convert to a string and remove all trailing zeros.
   const trimmedAmount = String(truncatedAmount).replace(/\.?0+$/, '')
-  return <span>{trimmedAmount}</span>
+  return (
+    <FormattedNumber
+      value={trimmedAmount}
+      maximumFractionDigits={dp}
+      style={style}
+      currency={fiatTicker}
+    />
+  )
 }
 
 Value.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   currency: PropTypes.string.isRequired,
   currentTicker: PropTypes.object,
-  fiatTicker: PropTypes.string
+  fiatTicker: PropTypes.string,
+  style: PropTypes.oneOf(['decimal', 'currency'])
+}
+
+Value.defaultProps = {
+  style: 'decimal'
 }
 
 export default Value

--- a/test/unit/components/Pay/__snapshots__/PaySummaryLightning.spec.js.snap
+++ b/test/unit/components/Pay/__snapshots__/PaySummaryLightning.spec.js.snap
@@ -22,6 +22,7 @@ exports[`component.Form.PaySummaryLightning should render correctly 1`] = `
             >
               <Value
                 currency="btc"
+                style="decimal"
                 value={10000}
               />
             </Text>
@@ -137,6 +138,7 @@ exports[`component.Form.PaySummaryLightning should render correctly 1`] = `
       <React.Fragment>
         <Value
           currency="btc"
+          style="decimal"
           value={10000}
         />
          

--- a/test/unit/components/Pay/__snapshots__/PaySummaryOnchain.spec.js.snap
+++ b/test/unit/components/Pay/__snapshots__/PaySummaryOnchain.spec.js.snap
@@ -36,6 +36,7 @@ exports[`component.Form.PaySummaryOnchain should render correctly 1`] = `
             >
               <Value
                 currency="btc"
+                style="decimal"
                 value={1000}
               />
             </Text>
@@ -145,6 +146,7 @@ exports[`component.Form.PaySummaryOnchain should render correctly 1`] = `
       <React.Fragment>
         <Value
           currency="btc"
+          style="decimal"
           value={1000}
         />
          

--- a/yarn.lock
+++ b/yarn.lock
@@ -12846,7 +12846,7 @@ react-virtualized@9.21.0:
     prop-types "^15.6.0"
     react-lifecycles-compat "^3.0.4"
 
-react@16.7.0, react@^16.6.3, react@^16.7.0:
+react@16.7.0, react@^16.6.3:
   version "16.7.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.7.0.tgz#b674ec396b0a5715873b350446f7ea0802ab6381"
   integrity sha512-StCz3QY8lxTb5cl2HJxjwLFOXPIFQp+p+hxQfc8WE0QiLfCtIlKj8/+5tjjKm8uSTlAW+fCPaavGFS06V9Ar3A==


### PR DESCRIPTION
## Description:

Ensure that strings are coerced into numbers in the Value component prior to formatting them for output.

Additionally, use `FormattedNumber` to output properly formatted numbers.

## Motivation and Context:

Fix #1452

## How Has This Been Tested?

Follow reproduction steps in #1452

## Types of changes:

Bug fix / Enhancement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
