### PR TITLE
test(e2e): force kill lnd after e2e tests

### DIFF
--- a/app/lib/lnd/neutrino.js
+++ b/app/lib/lnd/neutrino.js
@@ -161,8 +161,8 @@ class Neutrino extends EventEmitter {
           code,
           signal
         )
-        this.process = null
         this.emit(EXIT, code, signal, this.lastError)
+        this.process = null
       })
 
     // Listen for when neutrino prints data to stderr.

--- a/app/preload.js
+++ b/app/preload.js
@@ -80,7 +80,10 @@ async function getLocalWallets(chain, network) {
 }
 
 function killLnd() {
-  return ipcRenderer.sendSync('killLnd')
+  return new Promise(resolve => {
+    ipcRenderer.once('killLndSuccess', resolve)
+    ipcRenderer.send('killLnd', { signal: 'SIGKILL', timeout: 2500 })
+  })
 }
 
 /**


### PR DESCRIPTION
## Description:

Wait for lnd to finish terminating before attempting to run next e2e test, and try to force kill it if it doesn't kill within 50ms.

## Motivation and Context:

e2e tests often fail when run on travis/appveyor

## How Has This Been Tested?

Run `yarn test-e2e` several times and ensure that they complete each time
Rerun build on ci several times and ensure that e2e tests are consistently passing.

## Types of changes:

Test improvement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
