### PR TITLE
fix(wallet): support updated lndconnect link format

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -88,7 +88,7 @@ const handleLightningLink = input => {
 const handleLndconnectLink = input => {
   const parsedUrl = url.parse(input)
   const { host, cert, macaroon } = querystring.parse(parsedUrl.query)
-  zap.sendMessage('lndconnectUri', { host, cert, macaroon })
+  zap.sendMessage('lndconnectUri', { host: host || parsedUrl.host, cert, macaroon })
   mainWindow.show()
 }
 


### PR DESCRIPTION
## Description:

Add support for current lndconnect link format (support host:port from origin)

## Motivation and Context:

Currently we support the old zapconnect format, like:

```
lndconnect://?cert=...&macaroon=...&host=1.23.4:10009
```

We will be depreciating this in the future and want users to transition to the updated format:

```
lndconnect://1.2.3.4:10009?cert=...&macaroon=...
```

This PR adds support for the latest format whilst retaining the legacy support, which will give users a chance to upgrade prior to v0.4.0 which may no longer support the old link format.

## How Has This Been Tested?

Manually - verify that both link formats work.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
