### PR TITLE
test(e2e): delete lnd data dir after test fixtures

### DIFF
--- a/app/preload.js
+++ b/app/preload.js
@@ -181,6 +181,10 @@ async function fileExists(path) {
   return fsReadFile(untildify(path))
 }
 
+function getUserDataDir() {
+  return remote.app.getPath('userData')
+}
+
 // Expose a bridging API to by setting an global on `window`.
 //
 // !CAREFUL! do not expose any functionality or APIs that could compromise the
@@ -190,6 +194,7 @@ window.Zap = {
   openHelpPage,
   getLocalWallets,
   deleteLocalWallet,
+  getUserDataDir,
   validateHost,
   fileExists,
   killLnd

--- a/test/e2e/onboarding-btcpay.spec.js
+++ b/test/e2e/onboarding-btcpay.spec.js
@@ -1,5 +1,11 @@
 import { waitForReact } from 'testcafe-react-selectors'
-import { getBaseUrl, assertNoConsoleErrors, cleanTestEnvironment } from './utils/helpers'
+import {
+  getBaseUrl,
+  getUserDataDir,
+  assertNoConsoleErrors,
+  cleanTestEnvironment,
+  cleanElectronEnvironment
+} from './utils/helpers'
 import Onboarding from './pages/onboarding'
 import Loading from './pages/loading'
 
@@ -8,12 +14,16 @@ const loading = new Loading()
 
 fixture('Onboarding (btcpay)')
   .page(getBaseUrl())
-  .beforeEach(async () => {
+  .beforeEach(async t => {
     await waitForReact()
+    t.fixtureCtx.userDataDir = await getUserDataDir()
   })
   .afterEach(async t => {
     await assertNoConsoleErrors(t)
     await cleanTestEnvironment()
+  })
+  .after(async ctx => {
+    await cleanElectronEnvironment(ctx)
   })
 
 test('should connect to a btcpayserver wallet', async t => {

--- a/test/e2e/onboarding-connect.spec.js
+++ b/test/e2e/onboarding-connect.spec.js
@@ -1,6 +1,12 @@
 import path from 'path'
 import { waitForReact } from 'testcafe-react-selectors'
-import { getBaseUrl, assertNoConsoleErrors, cleanTestEnvironment } from './utils/helpers'
+import {
+  getBaseUrl,
+  getUserDataDir,
+  assertNoConsoleErrors,
+  cleanTestEnvironment,
+  cleanElectronEnvironment
+} from './utils/helpers'
 import Onboarding from './pages/onboarding'
 import Loading from './pages/loading'
 
@@ -9,12 +15,16 @@ const loading = new Loading()
 
 fixture('Onboarding (connect)')
   .page(getBaseUrl())
-  .beforeEach(async () => {
+  .beforeEach(async t => {
     await waitForReact()
+    t.fixtureCtx.userDataDir = await getUserDataDir()
   })
   .afterEach(async t => {
     await assertNoConsoleErrors(t)
     await cleanTestEnvironment()
+  })
+  .after(async ctx => {
+    await cleanElectronEnvironment(ctx)
   })
 
 test('should connect to an external wallet (readonly)', async t => {

--- a/test/e2e/onboarding-create.spec.js
+++ b/test/e2e/onboarding-create.spec.js
@@ -1,5 +1,11 @@
 import { waitForReact } from 'testcafe-react-selectors'
-import { getBaseUrl, assertNoConsoleErrors, cleanTestEnvironment } from './utils/helpers'
+import {
+  getBaseUrl,
+  getUserDataDir,
+  assertNoConsoleErrors,
+  cleanTestEnvironment,
+  cleanElectronEnvironment
+} from './utils/helpers'
 import Onboarding from './pages/onboarding'
 import Syncing from './pages/syncing'
 import Loading from './pages/loading'
@@ -10,12 +16,16 @@ const loading = new Loading()
 
 fixture('Onboarding (create)')
   .page(getBaseUrl())
-  .beforeEach(async () => {
+  .beforeEach(async t => {
     await waitForReact()
+    t.fixtureCtx.userDataDir = await getUserDataDir()
   })
   .afterEach(async t => {
     await assertNoConsoleErrors(t)
     await cleanTestEnvironment()
+  })
+  .after(async ctx => {
+    await cleanElectronEnvironment(ctx)
   })
 
 test('should create a new wallet', async t => {

--- a/test/e2e/onboarding-import.spec.js
+++ b/test/e2e/onboarding-import.spec.js
@@ -1,17 +1,27 @@
 import { waitForReact } from 'testcafe-react-selectors'
-import { getBaseUrl, assertNoConsoleErrors, cleanTestEnvironment } from './utils/helpers'
+import {
+  getBaseUrl,
+  getUserDataDir,
+  assertNoConsoleErrors,
+  cleanTestEnvironment,
+  cleanElectronEnvironment
+} from './utils/helpers'
 import Onboarding from './pages/onboarding'
 
 const onboarding = new Onboarding()
 
 fixture('Onboarding (import)')
   .page(getBaseUrl())
-  .beforeEach(async () => {
+  .beforeEach(async t => {
     await waitForReact()
+    t.fixtureCtx.userDataDir = await getUserDataDir()
   })
   .afterEach(async t => {
     await assertNoConsoleErrors(t)
     await cleanTestEnvironment()
+  })
+  .after(async ctx => {
+    await cleanElectronEnvironment(ctx)
   })
 
 test('should import a wallet from an existing seed', async t => {

--- a/test/e2e/utils/helpers.js
+++ b/test/e2e/utils/helpers.js
@@ -1,4 +1,6 @@
 import { ClientFunction } from 'testcafe'
+import path from 'path'
+import rimraf from 'rimraf'
 
 // Get the path to the index page.
 export const getBaseUrl = () => '../../app/dist/index.html'
@@ -6,13 +8,11 @@ export const getBaseUrl = () => '../../app/dist/index.html'
 // Get the current page title.
 export const getPageTitle = ClientFunction(() => document.title)
 
+// Get the electron user data directory.
+export const getUserDataDir = ClientFunction(() => window.Zap.getUserDataDir())
+
 // Kill the client's active lnd instance, if there is one
 export const killLnd = ClientFunction(() => window.Zap.killLnd())
-
-// Delete wallets that may have been created in the tests.
-export const deleteUserData = ClientFunction(() =>
-  window.Zap.deleteLocalWallet('bitcoin', 'testnet', 'wallet-1', true)
-)
 
 // Delete persistent data from indexeddb.
 export const deleteDatabase = ClientFunction(() => window.db.delete())
@@ -29,9 +29,14 @@ export const delay = time => new Promise(resolve => setTimeout(() => resolve(), 
 // Clean out test environment.
 export const cleanTestEnvironment = async () => {
   await killLnd()
-  await delay(1000)
-  await deleteUserData()
-  await delay(1000)
+  await delay(3000)
   await deleteDatabase()
-  await delay(1000)
+  await delay(3000)
+}
+
+// Clean out test environment.
+export const cleanElectronEnvironment = async ctx => {
+  if (ctx.userDataDir) {
+    rimraf.sync(path.join(ctx.userDataDir, 'lnd'), { disableGlob: false })
+  }
 }


### PR DESCRIPTION
## Description:

Wait until tests have fully finished before deleing lnd data, and ensure that when we do delete it, we delete all lnd data rather than a single wallet.

## Motivation and Context:

When investigating test failures on travis I fond that sometimes there can be a javascript error in the browser console due to the fact that we were deleting the wallet data whist the app was still running. This can fail the tests.

## How Has This Been Tested?

Run tests locally and on travis.

## Types of changes:

test/ci improvement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
