### PR TITLE
docs(storybook): ensure story font colour correctly applied

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,6 +1,8 @@
 <style>
+  .dark .story,
   .dark .story-title,
   .dark .story-subtitle,
+  .dark .story-subtitle div,
   .dark .chapter-header,
   .dark .section-header,
   .dark .section-title,
@@ -11,12 +13,13 @@
     display: block;
   }
   .dark .chapter-header {
-    border-bottom: 1px solid rgba(255, 255, 255, .5) !important;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.5) !important;
   }
 
-
+  .light .story,
   .light .story-title,
   .light .story-subtitle,
+  .light .story-subtitle div,
   .light .chapter-header,
   .light .section-header,
   .light .section-title,
@@ -27,9 +30,8 @@
     display: block;
   }
   .light .chapter-header {
-    border-bottom: 1px solid rgba(0, 0, 0, .5) !important;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.5) !important;
   }
-
 
   .chapter-header {
     margin-bottom: 30px !important;


### PR DESCRIPTION
## Description:

Use correct text colour for storybook

## Motivation and Context:

Some text elements are using the wrong colour in the storybook.

## How Has This Been Tested?

`yarn storybook`

## Screenshots (if appropriate):

**Before:**

![image](https://user-images.githubusercontent.com/200251/52234531-30dbfa00-28c2-11e9-9fe5-eff0b718240f.png)

**After:**

![image](https://user-images.githubusercontent.com/200251/52234498-1a35a300-28c2-11e9-95fe-9eed5a870395.png)

## Types of changes:

Docs improvement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
