### PR TITLE
feat(channels): implement new channel summary list

### DIFF
--- a/app/components/Channels/ChannelBalance.js
+++ b/app/components/Channels/ChannelBalance.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { FormattedMessage } from 'react-intl'
+import { Flex } from 'rebass'
+import { Text } from 'components/UI'
+import { CryptoSelector, CryptoValue } from 'containers/UI'
+import messages from './messages'
+
+const ChannelBalance = ({ channelBalance, ...rest }) => {
+  return (
+    <Flex as="section" alignItems="center" {...rest}>
+      <Text fontWeight="normal" mr={2}>
+        <FormattedMessage {...messages.total_capacity} />
+      </Text>
+      <CryptoValue value={channelBalance} />
+      <CryptoSelector ml={2} />
+    </Flex>
+  )
+}
+
+ChannelBalance.propTypes = {
+  channelBalance: PropTypes.number.isRequired
+}
+
+export default ChannelBalance

--- a/app/components/Channels/ChannelCount.js
+++ b/app/components/Channels/ChannelCount.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { FormattedMessage } from 'react-intl'
+import { Flex } from 'rebass'
+import { Text } from 'components/UI'
+import messages from './messages'
+
+const ChannelCount = ({ channels, ...rest }) => {
+  return (
+    <Flex as="section" alignItems="center" {...rest}>
+      <Text fontWeight="normal" mr={2}>
+        <FormattedMessage {...messages.channels} />
+      </Text>
+      <Text>{channels.length}</Text>
+    </Flex>
+  )
+}
+
+ChannelCount.propTypes = {
+  channels: PropTypes.array.isRequired
+}
+
+export default ChannelCount

--- a/app/components/Channels/ChannelSummaryList.js
+++ b/app/components/Channels/ChannelSummaryList.js
@@ -14,12 +14,11 @@ const ChannelSummaryList = ({ channels, showChannelDetail, ...rest }) => (
           showChannelDetail={showChannelDetail}
           channelId={channel.chan_id}
           channelName={channel.display_name}
-          channelPubKey={channel.remote_pubkey}
-          channelPubKeyShort={channel.remote_pubkey_short}
+          channelPubKey={channel.display_pubkey}
           localBalance={channel.local_balance}
           remoteBalance={channel.remote_balance}
-          status={channel.status}
-          isAvailable={channel.isAvailable}
+          status={channel.display_status}
+          isAvailable={Boolean(channel.active)}
           mb={3}
         />
       )

--- a/app/components/Channels/ChannelSummaryListItem.js
+++ b/app/components/Channels/ChannelSummaryListItem.js
@@ -13,7 +13,6 @@ const ChannelSummaryListItem = ({
   channelId,
   channelName,
   channelPubKey,
-  channelPubKeyShort,
   localBalance,
   remoteBalance,
   status,
@@ -28,7 +27,7 @@ const ChannelSummaryListItem = ({
         <Box width={8 / 20}>
           <ChannelStatus status={status} />
           <ClippedHeading my={1} opacity={opacity}>
-            {channelName || channelPubKeyShort}
+            {channelName}
           </ClippedHeading>
           <ClippedText fontSize="xs" opacity={opacity}>
             {channelPubKey}
@@ -45,7 +44,9 @@ const ChannelSummaryListItem = ({
         />
 
         <Flex width={2 / 20}>
-          <ChannelMoreButton onClick={() => showChannelDetail(channelId)} ml="auto" my="auto" />
+          {channelId && (
+            <ChannelMoreButton onClick={() => showChannelDetail(channelId)} ml="auto" my="auto" />
+          )}
         </Flex>
       </Flex>
     </Card>
@@ -54,10 +55,9 @@ const ChannelSummaryListItem = ({
 
 ChannelSummaryListItem.propTypes = {
   isAvailable: PropTypes.bool.isRequired,
-  channelId: PropTypes.string.isRequired,
+  channelId: PropTypes.number,
   channelName: PropTypes.string,
   channelPubKey: PropTypes.string.isRequired,
-  channelPubKeyShort: PropTypes.string.isRequired,
   localBalance: PropTypes.number.isRequired,
   remoteBalance: PropTypes.number.isRequired,
   status: PropTypes.string.isRequired,

--- a/app/components/Channels/Channels.js
+++ b/app/components/Channels/Channels.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Panel } from 'components/UI'
+import { ChannelsHeader, ChannelSummaryList } from 'components/Channels'
+
+const Channels = ({
+  channels,
+  channelBalance,
+  cryptoCurrency,
+  cryptoCurrencies,
+  setCryptoCurrency,
+  showChannelDetail,
+  ...rest
+}) => (
+  <Panel {...rest}>
+    <Panel.Header mx={4}>
+      <ChannelsHeader channels={channels} channelBalance={channelBalance} />
+    </Panel.Header>
+    <Panel.Body px={4} css={{ 'overflow-y': 'auto' }}>
+      <ChannelSummaryList channels={channels} showChannelDetail={showChannelDetail} />
+    </Panel.Body>
+  </Panel>
+)
+
+Channels.propTypes = {
+  channels: PropTypes.array,
+  channelBalance: PropTypes.number.isRequired,
+  showChannelDetail: PropTypes.func.isRequired
+}
+
+Channels.defaultProps = {
+  channels: []
+}
+
+export default Channels

--- a/app/components/Channels/ChannelsHeader.js
+++ b/app/components/Channels/ChannelsHeader.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Flex } from 'rebass'
+import { ChannelBalance, ChannelCount } from 'components/Channels'
+
+const Channels = ({
+  channels,
+  channelBalance,
+  cryptoCurrency,
+  cryptoCurrencies,
+  setCryptoCurrency,
+  ...rest
+}) => (
+  <Flex as="header" mb={3} alignItems="center" {...rest}>
+    <ChannelCount channels={channels} mr={4} />
+    <ChannelBalance channelBalance={channelBalance} />
+  </Flex>
+)
+
+Channels.propTypes = {
+  channels: PropTypes.array,
+  channelBalance: PropTypes.number.isRequired
+}
+
+Channels.defaultProps = {
+  channels: []
+}
+
+export default Channels

--- a/app/components/Channels/index.js
+++ b/app/components/Channels/index.js
@@ -2,6 +2,7 @@ import Channels from './Channels'
 
 export default Channels
 export ChannelBalance from './ChannelBalance'
+export ChannelCount from './ChannelCount'
 export ChannelCapacity from './ChannelCapacity'
 export ChannelMoreButton from './ChannelMoreButton'
 export ChannelStatus from './ChannelStatus'

--- a/app/components/Channels/index.js
+++ b/app/components/Channels/index.js
@@ -1,5 +1,10 @@
+import Channels from './Channels'
+
+export default Channels
+export ChannelBalance from './ChannelBalance'
 export ChannelCapacity from './ChannelCapacity'
 export ChannelMoreButton from './ChannelMoreButton'
 export ChannelStatus from './ChannelStatus'
 export ChannelSummaryList from './ChannelSummaryList'
 export ChannelSummaryListItem from './ChannelSummaryListItem'
+export ChannelsHeader from './ChannelsHeader'

--- a/app/components/Channels/messages.js
+++ b/app/components/Channels/messages.js
@@ -5,6 +5,7 @@ export default defineMessages({
   remote_balance: 'Remote Balance',
   channels: 'Channels',
   capacity: 'Capacity',
+  total_capacity: 'Total Capacity',
   more_button_text: 'More',
   loading: 'loading',
   pending_open: 'pending open',

--- a/app/components/Channels/messages.js
+++ b/app/components/Channels/messages.js
@@ -3,6 +3,7 @@ import { defineMessages } from 'react-intl'
 export default defineMessages({
   local_balance: 'Local Balance',
   remote_balance: 'Remote Balance',
+  channels: 'Channels',
   capacity: 'Capacity',
   more_button_text: 'More',
   loading: 'loading',

--- a/app/components/Contacts/Network/Network.js
+++ b/app/components/Contacts/Network/Network.js
@@ -157,7 +157,7 @@ class Network extends Component {
                   const channel = channelObj.channel || channelObj
                   const {
                     display_name,
-                    display_status,
+                    legacy_staus,
                     chan_id,
                     closing_txid,
                     channel_point,
@@ -176,8 +176,8 @@ class Network extends Component {
                       pb={1}
                     >
                       <ChannelItem
-                        statusTooltip={intl.formatMessage({ ...messages[display_status] })}
-                        status={display_status}
+                        statusTooltip={intl.formatMessage({ ...messages[legacy_staus] })}
+                        status={legacy_staus}
                         name={display_name}
                         isSelected={isSelected}
                         onBrowseClick={() =>
@@ -192,7 +192,7 @@ class Network extends Component {
                         <ChannelDetails
                           isClosing={closingChannelIds.includes(chan_id)}
                           canClose={
-                            ['online', 'offline'].includes(display_status) &&
+                            ['online', 'offline'].includes(legacy_staus) &&
                             !closingChannelIds.includes(chan_id)
                           }
                           payLimitMsg={messages.pay_limit}
@@ -205,7 +205,7 @@ class Network extends Component {
                           pubkey={display_name}
                           status={
                             messages[
-                              display_status === 'online' ? 'channel_close' : 'channel_force_close'
+                              legacy_staus === 'online' ? 'channel_close' : 'channel_force_close'
                             ]
                           }
                         />

--- a/app/components/Form/Form.js
+++ b/app/components/Form/Form.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { Modal } from 'components/UI'
 import Pay from 'containers/Pay'
 import Request from 'containers/Request'
+import Channels from 'containers/Channels'
 
 const Form = ({ formType, closeForm }) => {
   if (!formType) {
@@ -21,6 +22,13 @@ const Form = ({ formType, closeForm }) => {
       return (
         <Modal onClose={closeForm}>
           <Request width={9 / 16} mx="auto" />
+        </Modal>
+      )
+
+    case 'CHANNELS':
+      return (
+        <Modal onClose={closeForm} mt={-3} mx={-4}>
+          <Channels />
         </Modal>
       )
   }

--- a/app/components/Settings/Menu/Menu.js
+++ b/app/components/Settings/Menu/Menu.js
@@ -5,7 +5,7 @@ import { FormattedMessage } from 'react-intl'
 import { MenuContainer, Menu, MenuItem } from 'components/UI/Dropdown'
 import messages from './messages'
 
-const SettingsMenu = ({ history, setActiveSubMenu }) => (
+const SettingsMenu = ({ history, setActiveSubMenu, setFormType }) => (
   <MenuContainer>
     <Menu>
       <MenuItem
@@ -27,6 +27,11 @@ const SettingsMenu = ({ history, setActiveSubMenu }) => (
       />
 
       <MenuItem
+        item={{ key: 'channels', name: <FormattedMessage {...messages.channels} /> }}
+        onClick={() => setFormType('CHANNELS')}
+      />
+
+      <MenuItem
         item={{ key: 'logout', name: <FormattedMessage {...messages.logout} /> }}
         onClick={() => history.push('/logout')}
       />
@@ -36,6 +41,7 @@ const SettingsMenu = ({ history, setActiveSubMenu }) => (
 
 SettingsMenu.propTypes = {
   setActiveSubMenu: PropTypes.func.isRequired,
+  setFormType: PropTypes.func.isRequired,
   history: PropTypes.object.isRequired
 }
 

--- a/app/components/Settings/Menu/messages.js
+++ b/app/components/Settings/Menu/messages.js
@@ -5,5 +5,6 @@ export default defineMessages({
   fiat: 'Fiat Currency',
   locale: 'Language',
   theme: 'Theme',
+  channels: 'Manage Channels',
   logout: 'Logout'
 })

--- a/app/components/Settings/Settings.js
+++ b/app/components/Settings/Settings.js
@@ -50,7 +50,14 @@ class Settings extends React.Component {
   }
 
   renderSettings = () => {
-    const { activeSubMenu, fiatProps, localeProps, themeProps, setActiveSubMenu } = this.props
+    const {
+      activeSubMenu,
+      fiatProps,
+      localeProps,
+      themeProps,
+      setActiveSubMenu,
+      setFormType
+    } = this.props
     switch (activeSubMenu) {
       case 'fiat':
         return <Fiat {...fiatProps} />
@@ -59,7 +66,7 @@ class Settings extends React.Component {
       case 'theme':
         return <Theme {...themeProps} />
       default:
-        return <Menu setActiveSubMenu={setActiveSubMenu} />
+        return <Menu setActiveSubMenu={setActiveSubMenu} setFormType={setFormType} />
     }
   }
 
@@ -93,6 +100,7 @@ Settings.propTypes = {
   localeProps: PropTypes.object.isRequired,
   themeProps: PropTypes.object.isRequired,
   setActiveSubMenu: PropTypes.func.isRequired,
+  setFormType: PropTypes.func.isRequired,
   openSettings: PropTypes.func.isRequired,
   closeSettings: PropTypes.func.isRequired
 }

--- a/app/containers/Channels.js
+++ b/app/containers/Channels.js
@@ -1,0 +1,17 @@
+import { connect } from 'react-redux'
+import Channels from 'components/Channels'
+import { channelsSelectors, showChannelDetail } from 'reducers/channels'
+
+const mapStateToProps = state => ({
+  channels: channelsSelectors.currentChannels(state),
+  channelBalance: state.balance.channelBalance
+})
+
+const mapDispatchToProps = {
+  showChannelDetail
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Channels)

--- a/app/containers/Settings.js
+++ b/app/containers/Settings.js
@@ -3,6 +3,7 @@ import { setLocale } from 'reducers/locale'
 import { setFiatTicker } from 'reducers/ticker'
 import { openSettings, closeSettings, setActiveSubMenu, disableSubMenu } from 'reducers/settings'
 import { setTheme } from 'reducers/theme'
+import { setFormType } from 'reducers/form'
 import { walletSelectors } from 'reducers/wallet'
 
 import Settings from 'components/Settings'
@@ -23,6 +24,7 @@ const mapDispatchToProps = {
   openSettings,
   closeSettings,
   setActiveSubMenu,
+  setFormType,
   disableSubMenu,
   setFiatTicker,
   setLocale,
@@ -36,6 +38,7 @@ const mergeProps = (stateProps, dispatchProps) => ({
   openSettings: dispatchProps.openSettings,
   closeSettings: dispatchProps.closeSettings,
   setActiveSubMenu: dispatchProps.setActiveSubMenu,
+  setFormType: dispatchProps.setFormType,
 
   fiatProps: {
     fiatTicker: stateProps.fiatTicker,

--- a/app/lib/lnd/methods/channelController.js
+++ b/app/lib/lnd/methods/channelController.js
@@ -135,7 +135,7 @@ export function pendingChannels(lnd) {
 /**
  * Returns the latest authenticated network announcement for the given channel
  * @param  {[type]} lnd       [description]
- * @param  {[type]} channelId [description]
+ * @param  {[type]} chanId    [description]
  * @return {[type]}           [description]
  */
 export function getChanInfo(lnd, { chanId }) {

--- a/app/translations/af-ZA.json
+++ b/app/translations/af-ZA.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/af-ZA.json
+++ b/app/translations/af-ZA.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/af-ZA.json
+++ b/app/translations/af-ZA.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/ar-SA.json
+++ b/app/translations/ar-SA.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/ar-SA.json
+++ b/app/translations/ar-SA.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/ar-SA.json
+++ b/app/translations/ar-SA.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/bg-BG.json
+++ b/app/translations/bg-BG.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "Изпратени",
   "components.Activity.show_expired": "Покажи изтеклите заявки",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/bg-BG.json
+++ b/app/translations/bg-BG.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "Свържи се ръчно",

--- a/app/translations/bg-BG.json
+++ b/app/translations/bg-BG.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "Fiat валута",
   "components.Settings.Locale.title": "Език",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "Fiat валута",
   "components.Settings.Menu.locale": "Език",
   "components.Settings.Menu.logout": "",

--- a/app/translations/ca-ES.json
+++ b/app/translations/ca-ES.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/ca-ES.json
+++ b/app/translations/ca-ES.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/ca-ES.json
+++ b/app/translations/ca-ES.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/cs-CZ.json
+++ b/app/translations/cs-CZ.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/cs-CZ.json
+++ b/app/translations/cs-CZ.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/cs-CZ.json
+++ b/app/translations/cs-CZ.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/da-DK.json
+++ b/app/translations/da-DK.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/da-DK.json
+++ b/app/translations/da-DK.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/da-DK.json
+++ b/app/translations/da-DK.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/de-DE.json
+++ b/app/translations/de-DE.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "Manuell verbinden",

--- a/app/translations/de-DE.json
+++ b/app/translations/de-DE.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "Fiat-Währung",
   "components.Settings.Locale.title": "Sprache",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "Fiat-Währung",
   "components.Settings.Menu.locale": "Sprache",
   "components.Settings.Menu.logout": "",

--- a/app/translations/de-DE.json
+++ b/app/translations/de-DE.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "Gesendet",
   "components.Activity.show_expired": "Zeige abgelaufene Anfragen",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/el-GR.json
+++ b/app/translations/el-GR.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/el-GR.json
+++ b/app/translations/el-GR.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/el-GR.json
+++ b/app/translations/el-GR.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "pending force close",
   "components.Channels.pending_open": "pending open",
   "components.Channels.remote_balance": "Remote Balance",
+  "components.Channels.total_capacity": "Total Capacity",
   "components.Channels.waiting_close": "closing",
   "components.Contacts.AddChannel.connect": "Connect",
   "components.Contacts.AddChannel.manual_button": "Connect Manually",

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "Sent",
   "components.Activity.show_expired": "Show Expired Requests",
   "components.Channels.capacity": "Capacity",
+  "components.Channels.channels": "Channels",
   "components.Channels.loading": "loading",
   "components.Channels.local_balance": "Local Balance",
   "components.Channels.more_button_text": "More",

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -261,6 +261,7 @@
   "components.Request.total": "Total",
   "components.Settings.Fiat.title": "Fiat Currency",
   "components.Settings.Locale.title": "Language",
+  "components.Settings.Menu.channels": "Manage Channels",
   "components.Settings.Menu.fiat": "Fiat Currency",
   "components.Settings.Menu.locale": "Language",
   "components.Settings.Menu.logout": "Logout",

--- a/app/translations/es-ES.json
+++ b/app/translations/es-ES.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/es-ES.json
+++ b/app/translations/es-ES.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/es-ES.json
+++ b/app/translations/es-ES.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/fi-FI.json
+++ b/app/translations/fi-FI.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/fi-FI.json
+++ b/app/translations/fi-FI.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/fi-FI.json
+++ b/app/translations/fi-FI.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/fr-FR.json
+++ b/app/translations/fr-FR.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/fr-FR.json
+++ b/app/translations/fr-FR.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/fr-FR.json
+++ b/app/translations/fr-FR.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/ga-IE.json
+++ b/app/translations/ga-IE.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/ga-IE.json
+++ b/app/translations/ga-IE.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/ga-IE.json
+++ b/app/translations/ga-IE.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/he-IL.json
+++ b/app/translations/he-IL.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/he-IL.json
+++ b/app/translations/he-IL.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/he-IL.json
+++ b/app/translations/he-IL.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/hi-IN.json
+++ b/app/translations/hi-IN.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/hi-IN.json
+++ b/app/translations/hi-IN.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/hi-IN.json
+++ b/app/translations/hi-IN.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/hr-HR.json
+++ b/app/translations/hr-HR.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "Fiat valuta",
   "components.Settings.Locale.title": "Jezik",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "Fiat valuta",
   "components.Settings.Menu.locale": "Jezik",
   "components.Settings.Menu.logout": "",

--- a/app/translations/hr-HR.json
+++ b/app/translations/hr-HR.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "Poslano",
   "components.Activity.show_expired": "Prikaži istekle zahtjeve",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/hr-HR.json
+++ b/app/translations/hr-HR.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "Ručno povezivanje",

--- a/app/translations/hu-HU.json
+++ b/app/translations/hu-HU.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/hu-HU.json
+++ b/app/translations/hu-HU.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/hu-HU.json
+++ b/app/translations/hu-HU.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/it-IT.json
+++ b/app/translations/it-IT.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/it-IT.json
+++ b/app/translations/it-IT.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/it-IT.json
+++ b/app/translations/it-IT.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/ja-JP.json
+++ b/app/translations/ja-JP.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/ja-JP.json
+++ b/app/translations/ja-JP.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/ja-JP.json
+++ b/app/translations/ja-JP.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/ko-KR.json
+++ b/app/translations/ko-KR.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/ko-KR.json
+++ b/app/translations/ko-KR.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/ko-KR.json
+++ b/app/translations/ko-KR.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/nl-NL.json
+++ b/app/translations/nl-NL.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/nl-NL.json
+++ b/app/translations/nl-NL.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/nl-NL.json
+++ b/app/translations/nl-NL.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/no-NO.json
+++ b/app/translations/no-NO.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/no-NO.json
+++ b/app/translations/no-NO.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/no-NO.json
+++ b/app/translations/no-NO.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/pl-PL.json
+++ b/app/translations/pl-PL.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/pl-PL.json
+++ b/app/translations/pl-PL.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/pl-PL.json
+++ b/app/translations/pl-PL.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/pt-BR.json
+++ b/app/translations/pt-BR.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/pt-BR.json
+++ b/app/translations/pt-BR.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/pt-BR.json
+++ b/app/translations/pt-BR.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/pt-PT.json
+++ b/app/translations/pt-PT.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/pt-PT.json
+++ b/app/translations/pt-PT.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/pt-PT.json
+++ b/app/translations/pt-PT.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/ro-RO.json
+++ b/app/translations/ro-RO.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/ro-RO.json
+++ b/app/translations/ro-RO.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/ro-RO.json
+++ b/app/translations/ro-RO.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/ru-RU.json
+++ b/app/translations/ru-RU.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/ru-RU.json
+++ b/app/translations/ru-RU.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/ru-RU.json
+++ b/app/translations/ru-RU.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/sr-SP.json
+++ b/app/translations/sr-SP.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/sr-SP.json
+++ b/app/translations/sr-SP.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/sr-SP.json
+++ b/app/translations/sr-SP.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/sv-SE.json
+++ b/app/translations/sv-SE.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/sv-SE.json
+++ b/app/translations/sv-SE.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/sv-SE.json
+++ b/app/translations/sv-SE.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/tr-TR.json
+++ b/app/translations/tr-TR.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/tr-TR.json
+++ b/app/translations/tr-TR.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/tr-TR.json
+++ b/app/translations/tr-TR.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/uk-UA.json
+++ b/app/translations/uk-UA.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/uk-UA.json
+++ b/app/translations/uk-UA.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/uk-UA.json
+++ b/app/translations/uk-UA.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/vi-VN.json
+++ b/app/translations/vi-VN.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/vi-VN.json
+++ b/app/translations/vi-VN.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/vi-VN.json
+++ b/app/translations/vi-VN.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/zh-CN.json
+++ b/app/translations/zh-CN.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/zh-CN.json
+++ b/app/translations/zh-CN.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/zh-CN.json
+++ b/app/translations/zh-CN.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/app/translations/zh-TW.json
+++ b/app/translations/zh-TW.json
@@ -67,6 +67,7 @@
   "components.Channels.pending_force_close": "",
   "components.Channels.pending_open": "",
   "components.Channels.remote_balance": "",
+  "components.Channels.total_capacity": "",
   "components.Channels.waiting_close": "",
   "components.Contacts.AddChannel.connect": "",
   "components.Contacts.AddChannel.manual_button": "",

--- a/app/translations/zh-TW.json
+++ b/app/translations/zh-TW.json
@@ -261,6 +261,7 @@
   "components.Request.total": "",
   "components.Settings.Fiat.title": "",
   "components.Settings.Locale.title": "",
+  "components.Settings.Menu.channels": "",
   "components.Settings.Menu.fiat": "",
   "components.Settings.Menu.locale": "",
   "components.Settings.Menu.logout": "",

--- a/app/translations/zh-TW.json
+++ b/app/translations/zh-TW.json
@@ -57,6 +57,7 @@
   "components.Activity.sent": "",
   "components.Activity.show_expired": "",
   "components.Channels.capacity": "",
+  "components.Channels.channels": "",
   "components.Channels.loading": "",
   "components.Channels.local_balance": "",
   "components.Channels.more_button_text": "",

--- a/stories/containers/channels/channel-balance.stories.js
+++ b/stories/containers/channels/channel-balance.stories.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { number } from '@storybook/addon-knobs'
+import { ChannelBalance } from 'components/Channels'
+import { Provider } from '../../Provider'
+
+storiesOf('Containers.Channels', module)
+  .addParameters({ info: { disable: true } })
+  .addDecorator(story => <Provider story={story()} />)
+  .addWithChapters('ChannelBalance', {
+    chapters: [
+      {
+        sections: [
+          {
+            sectionFn: () => {
+              const channelBalance = number('Channel Balance', 1237474)
+              return <ChannelBalance channelBalance={channelBalance} />
+            }
+          }
+        ]
+      }
+    ]
+  })

--- a/stories/containers/channels/channel-count.stories.js
+++ b/stories/containers/channels/channel-count.stories.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { ChannelCount } from 'components/Channels'
+import { Provider } from '../../Provider'
+
+storiesOf('Containers.Channels', module)
+  .addParameters({ info: { disable: true } })
+  .addDecorator(story => <Provider story={story()} />)
+  .addWithChapters('ChannelCount', {
+    chapters: [
+      {
+        sections: [
+          {
+            sectionFn: () => {
+              const channels = [
+                {
+                  key: 1
+                },
+                {
+                  key: 2
+                },
+                {
+                  key: 3
+                }
+              ]
+              return <ChannelCount channels={channels} />
+            }
+          }
+        ]
+      }
+    ]
+  })

--- a/stories/containers/channels/channel-summary-list-item.stories.js
+++ b/stories/containers/channels/channel-summary-list-item.stories.js
@@ -19,10 +19,9 @@ storiesOf('Containers.Channels', module)
             options: { allowPropTablesToggling: false },
             sectionFn: () => {
               const channelName = 'lnd1.zaphq.io'
-              const channelId = '123'
+              const channelId = 123
               const channelPubKey =
                 '0228e4b5e00a05f400411a0b556fa0fd4d7609555dc687bebb9b70419aff15cc3e'
-              const channelPubKeyShort = '0228e4b5e0'
 
               const groupId1 = 'Node with alias'
               const localBalance1 = number('Local Balance 1', 150400, {}, groupId1)
@@ -46,10 +45,10 @@ storiesOf('Containers.Channels', module)
                 channelId,
                 channelName,
                 channelPubKey,
-                channelPubKeyShort,
                 localBalance: localBalance1,
                 remoteBalance: remoteBalance1,
-                status: status1
+                status: status1,
+                isAvailable: true
               }
 
               const dispatchProps = {
@@ -64,10 +63,9 @@ storiesOf('Containers.Channels', module)
             options: { allowPropTablesToggling: false },
             sectionFn: () => {
               const channelName = ''
-              const channelId = '456'
+              const channelId = undefined
               const channelPubKey =
                 '4ab79fd8b15c53ddb19307826c74a030171377ee7fea9f6fb5f27c06ab163853'
-              const channelPubKeyShort = '4ab79fd8b1'
 
               const groupId2 = 'Node without alias'
               const localBalance2 = number('Local Balance 2', 1856825, {}, groupId2)
@@ -91,10 +89,10 @@ storiesOf('Containers.Channels', module)
                 channelId,
                 channelName,
                 channelPubKey,
-                channelPubKeyShort,
                 localBalance: localBalance2,
                 remoteBalance: remoteBalance2,
-                status: status2
+                status: status2,
+                isAvailable: false
               }
 
               const dispatchProps = {

--- a/stories/containers/channels/channel-summary-list.stories.js
+++ b/stories/containers/channels/channel-summary-list.stories.js
@@ -6,9 +6,9 @@ import { Provider } from '../../Provider'
 
 const channels = [
   {
-    chan_id: 'channel3',
+    chan_id: 1,
     display_name: 'Spudnik',
-    remote_pubkey: '03cf5a37ed661e3c61c7943941834771631cd880985340ed7543ad79a968cea454',
+    display_id: '03cf5a37ed661e3c61c7943941834771631cd880985340ed7543ad79a968cea454',
     remote_pubkey_short: '03cf5a37ed',
     local_balance: 686679,
     remote_balance: 75000,
@@ -16,9 +16,9 @@ const channels = [
     isAvailable: true
   },
   {
-    chan_id: 'channel33',
+    chan_id: 2,
     display_name: '😋 Extra-Terrestrial Waste Collection Technology 😋',
-    remote_pubkey: '03cf5a37ed661e3c61c7943941834771631cd880985340ed7543ad79a968cea454',
+    display_id: '03cf5a37ed661e3c61c7943941834771631cd880985340ed7543ad79a968cea454',
     remote_pubkey_short: '03cf5a37ed',
     local_balance: 1000,
     remote_balance: 10909,
@@ -26,9 +26,9 @@ const channels = [
     isAvailable: true
   },
   {
-    chan_id: 'channel1',
+    chan_id: 3,
     display_name: 'Mechanized Diplomacy Emulator',
-    remote_pubkey: '0228e4b5e00a05f400411a0b556fa0fd4d7609555dc687bebb9b70419aff15cc3e',
+    display_id: '0228e4b5e00a05f400411a0b556fa0fd4d7609555dc687bebb9b70419aff15cc3e',
     remote_pubkey_short: '0228e4b5e0',
     local_balance: 48887,
     remote_balance: 89987,
@@ -36,9 +36,9 @@ const channels = [
     isAvailable: false
   },
   {
-    chan_id: 'channel2',
+    // chan_id: 4,
     display_name: 'Sparky',
-    remote_pubkey: '03cf5a37ed661e3c61c7943941834771631cd880985340ed7543ad79a968cea454',
+    display_id: '03cf5a37ed661e3c61c7943941834771631cd880985340ed7543ad79a968cea454',
     remote_pubkey_short: '03cf5a37ed',
     local_balance: 686679,
     remote_balance: 75000,
@@ -46,9 +46,9 @@ const channels = [
     isAvailable: false
   },
   {
-    chan_id: 'channel4',
+    // chan_id: 5,
     display_name: 'Scyther',
-    remote_pubkey: '0258f227eb1ab11f70bb0749fb016cd818154d8b0b6cec303165958650febd8700',
+    display_id: '0258f227eb1ab11f70bb0749fb016cd818154d8b0b6cec303165958650febd8700',
     remote_pubkey_short: '0258f227eb',
     local_balance: 345,
     remote_balance: 5607,
@@ -56,9 +56,9 @@ const channels = [
     isAvailable: false
   },
   {
-    chan_id: 'channel5',
+    // chan_id: 6,
     display_name: null,
-    remote_pubkey: '0258f227eb1ab11f70bb0749fb016cd818154d8b0b6cec303165958650febd8700',
+    display_id: '0258f227eb1ab11f70bb0749fb016cd818154d8b0b6cec303165958650febd8700',
     remote_pubkey_short: '0258f227eb',
     local_balance: 1345,
     remote_balance: 65435,
@@ -66,9 +66,9 @@ const channels = [
     isAvailable: false
   },
   {
-    chan_id: 'channel6',
+    // chan_id: 7,
     display_name: 'Tobor',
-    remote_pubkey: '0258f227eb1ab11f70bb0749fb016cd818154d8b0b6cec303165958650febd8700',
+    display_id: '0258f227eb1ab11f70bb0749fb016cd818154d8b0b6cec303165958650febd8700',
     remote_pubkey_short: '0258f227eb',
     local_balance: 6932868,
     remote_balance: 4346674,
@@ -76,9 +76,9 @@ const channels = [
     isAvailable: false
   },
   {
-    chan_id: 'channel7',
+    chan_id: 8,
     display_name: null,
-    remote_pubkey: '0258f227eb1ab11f70bb0749fb016cd818154d8b0b6cec303165958650febd8700',
+    display_id: '0258f227eb1ab11f70bb0749fb016cd818154d8b0b6cec303165958650febd8700',
     remote_pubkey_short: '0258f227eb',
     local_balance: 4677,
     remote_balance: 465,

--- a/stories/containers/channels/channels-header.stories.js
+++ b/stories/containers/channels/channels-header.stories.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { number } from '@storybook/addon-knobs'
+import { ChannelsHeader } from 'components/Channels'
+import { Provider } from '../../Provider'
+
+storiesOf('Containers.Channels', module)
+  .addParameters({ info: { disable: true } })
+  .addDecorator(story => <Provider story={story()} />)
+  .addWithChapters('ChannelsHeader', {
+    chapters: [
+      {
+        sections: [
+          {
+            sectionFn: () => {
+              const channelBalance = number('Channel', 2343455)
+              const channels = [
+                {
+                  key: 1
+                },
+                {
+                  key: 2
+                },
+                {
+                  key: 3
+                }
+              ]
+              return <ChannelsHeader channels={channels} channelBalance={channelBalance} />
+            }
+          }
+        ]
+      }
+    ]
+  })


### PR DESCRIPTION
## Description:

- Build new `ChannelBalance` component
- Build new `ChannelCount` component
- Build new `ChannelsHeader` component
- Build new `Modal` that combines channel components into a basic channel summary view.
- Add "Manage Channels" menu item where it can be accessed from
- Refactor channels reducer to provide necessary data.

This PR implements a basic version of the new channel ui summary view. This is meant as a first pass implementation that we can start to use within the app environment in order to start get a feel for how it feels with real data.

Additional features such as searching, filtering, changing view mode, etc will be added in separate PRs.

**NOTE: This PR builds on #1454 which should be reviewed / merged prior to this.**

## Motivation and Context:

https://github.com/LN-Zap/zap-desktop/issues/1425

## How Has This Been Tested?

- `yarn storybook` and review updated channels components.
- review new channel summary list accessible from the wallet menu

## Types of changes:

New feature

## Screenshots

![image](https://user-images.githubusercontent.com/200251/52240272-bbc3f100-28d0-11e9-83f1-174cb4a5a218.png)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
