### PR TITLE
chore(devops): set db name based on app version

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,9 @@ module.exports = {
     browser: true,
     node: true
   },
+  globals: {
+    CONFIG: 'readable'
+  },
   rules: {
     'prettier/prettier': 'error',
     'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx'] }],

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ resources/bin/
 
 # Storybook
 storybook-static
+
+# Local config overrides
+config/local*

--- a/app/index.js
+++ b/app/index.js
@@ -5,7 +5,8 @@ import jstz from 'jstimezonedetect'
 import { configureStore, history } from './store/configureStore'
 import { getDefaultLocale } from './lib/i18n'
 import Root from './containers/Root'
-import db from './store/db'
+import { getDb } from './store/db'
+import { getDbName } from './lib/utils/db'
 
 // Register supported locales.
 import './lib/i18n/locale'
@@ -14,10 +15,10 @@ import './lib/i18n/locale'
 import translations from './lib/i18n/translation'
 
 // Make the db globally accessible.
-window.db = db
+window.db = getDb(getDbName(CONFIG))
 
 // Initialise the database.
-db.open()
+window.db.open()
 
 // Default the locale to English.
 const defaultLocale = getDefaultLocale()

--- a/app/lib/lnd/config.js
+++ b/app/lib/lnd/config.js
@@ -328,7 +328,7 @@ class LndConfig {
         })
         _lndConnect.set(this, connectionstring)
         return true
-      } catch {
+      } catch (e) {
         return true
       }
     }

--- a/app/lib/utils/db.js
+++ b/app/lib/utils/db.js
@@ -1,0 +1,8 @@
+export const getDbName = config => {
+  const {
+    db: { namespace, domain }
+  } = config
+  const env = process.env.NODE_ENV || 'development'
+
+  return [namespace, domain, env].filter(item => Boolean(item)).join('.')
+}

--- a/app/main.js
+++ b/app/main.js
@@ -22,7 +22,17 @@ import ZapMenuBuilder from './lib/zap/menuBuilder'
 import ZapController from './lib/zap/controller'
 import ZapUpdater from './lib/zap/updater'
 import themes from './themes'
-import { getDbName } from './store/db'
+import { getDbName } from './lib/utils/db'
+
+// When we run in production mode, this file is processd with webpack and our config is made available in the
+// global CONFIG object. If this is not set then we must be running in development mode (where this file is loaded
+// directly without processing with webpack), so we require the config module directly in this case.
+let config
+try {
+  config = CONFIG
+} catch (e) {
+  config = require('config')
+}
 
 // Set the Electron userDir to a temporary directory if the ELECTRON_USER_DIR_TEMP env var is set.
 // This provides an easy way to run the app with a completely fresh environment, useful for e2e tests.
@@ -114,7 +124,7 @@ const fetchSettings = () => {
   // Once we have fetched (or failed to fetch) the user settings, destroy the window.
   win.on('load-settings-done', () => process.nextTick(() => win.destroy()))
 
-  const dbName = getDbName()
+  const dbName = getDbName(config)
   mainLog.debug(`Fetching user settings from indexedDb (using database "%s")`, dbName)
 
   return win.webContents

--- a/app/preload.js
+++ b/app/preload.js
@@ -18,14 +18,6 @@ const fsReaddir = promisify(fs.readdir)
 const fsRimraf = promisify(rimraf)
 
 /**
- * Reference to the require method for Spectron to access (see e2e tests)
- * @type {Array}
- */
-if (process.env.NODE_ENV === 'test') {
-  window.electronRequire = require
-}
-
-/**
  * List of domains that we will allow users to be redirected to.
  * @type {Array}
  */

--- a/app/reducers/address.js
+++ b/app/reducers/address.js
@@ -1,5 +1,4 @@
 import { send } from 'redux-electron-ipc'
-import db from 'store/db'
 
 // ------------------------------------
 // Constants
@@ -47,7 +46,7 @@ export const walletAddress = type => async (dispatch, getState) => {
   const pubKey = state.info.data.identity_pubkey
 
   if (pubKey) {
-    const node = await db.nodes.get({ id: pubKey })
+    const node = await window.db.nodes.get({ id: pubKey })
     if (node) {
       address = node.getCurrentAddress(type)
     }
@@ -75,11 +74,11 @@ export const receiveAddress = (event, data) => async (dispatch, getState) => {
   // If we know the node's public key, store the address for reuse.
   if (pubKey) {
     const type = Object.keys(addressTypes).find(key => addressTypes[key] === data.type)
-    const node = await db.nodes.get(pubKey)
+    const node = await window.db.nodes.get(pubKey)
     if (node) {
       await node.setCurrentAddress(type, data.address)
     } else {
-      await db.nodes.put({ id: pubKey, addresses: { [type]: data.address } })
+      await window.db.nodes.put({ id: pubKey, addresses: { [type]: data.address } })
     }
   }
 

--- a/app/reducers/info.js
+++ b/app/reducers/info.js
@@ -1,7 +1,6 @@
 import { createSelector } from 'reselect'
 import { send } from 'redux-electron-ipc'
 import get from 'lodash.get'
-import db from 'store/db'
 import { networks } from 'lib/utils/crypto'
 import { walletAddress } from './address'
 import { putWallet, walletSelectors } from './wallet'
@@ -78,7 +77,7 @@ export const receiveInfo = (event, data) => async (dispatch, getState) => {
   const state = getState()
 
   if (typeof state.info.hasSynced === 'undefined') {
-    const node = await db.nodes.get({ id: data.identity_pubkey })
+    const node = await window.db.nodes.get({ id: data.identity_pubkey })
     const hasSynced = node ? node.hasSynced : false
     dispatch(setHasSynced(hasSynced))
   }

--- a/app/reducers/lnd.js
+++ b/app/reducers/lnd.js
@@ -1,7 +1,6 @@
 import { send } from 'redux-electron-ipc'
 import { createSelector } from 'reselect'
 import { showSystemNotification } from 'lib/utils/notifications'
-import db from 'store/db'
 import { fetchBalance } from './balance'
 import { fetchInfo, setHasSynced, infoSelectors } from './info'
 import { putWallet, setActiveWallet, walletSelectors } from './wallet'
@@ -57,9 +56,9 @@ export const lndSyncStatus = (event, status) => async (dispatch, getState) => {
   const hasSynced = infoSelectors.hasSynced(state)
 
   if (pubKey && !hasSynced) {
-    const updated = await db.nodes.update(pubKey, { hasSynced: true })
+    const updated = await window.db.nodes.update(pubKey, { hasSynced: true })
     if (!updated) {
-      await db.nodes.add({ id: pubKey, hasSynced: true })
+      await window.db.nodes.add({ id: pubKey, hasSynced: true })
     }
   }
 

--- a/app/reducers/locale.js
+++ b/app/reducers/locale.js
@@ -1,7 +1,6 @@
 import { send } from 'redux-electron-ipc'
 import { updateIntl } from 'react-intl-redux'
 import translations from 'lib/i18n/translation'
-import db from 'store/db'
 import { setFiatTicker } from './ticker'
 
 // ------------------------------------
@@ -20,7 +19,7 @@ export const setLocale = locale => (dispatch, getState) => {
   )
 
   // Save the new locale sa our language preference.
-  db.settings.put({ key: 'locale', value: locale })
+  window.db.settings.put({ key: 'locale', value: locale })
 
   // Let the main process know the locale has changed.
   dispatch(send('setLocale', locale))
@@ -31,7 +30,7 @@ export const receiveLocale = (event, locale) => dispatch => {
 }
 
 export const initLocale = () => async (dispatch, getState) => {
-  const userLocale = await db.settings.get({ key: 'locale' })
+  const userLocale = await window.db.settings.get({ key: 'locale' })
   const state = getState()
   const currentLocale = localeSelectors.currentLocale(state)
 
@@ -44,7 +43,7 @@ export const initLocale = () => async (dispatch, getState) => {
 }
 
 export const initCurrency = () => async dispatch => {
-  const userCurrency = await db.settings.get({ key: 'fiatTicker' })
+  const userCurrency = await window.db.settings.get({ key: 'fiatTicker' })
   if (userCurrency && userCurrency.value) {
     dispatch(setFiatTicker(userCurrency.value))
   }

--- a/app/reducers/theme.js
+++ b/app/reducers/theme.js
@@ -1,6 +1,5 @@
 import { createSelector } from 'reselect'
 import { dark, light } from 'themes'
-import db from 'store/db'
 
 // ------------------------------------
 // Constants
@@ -16,7 +15,7 @@ const DEFAULT_THEME = 'dark'
 export const initTheme = () => async (dispatch, getState) => {
   let theme
   try {
-    const userTheme = await db.settings.get({ key: 'theme' })
+    const userTheme = await window.db.settings.get({ key: 'theme' })
     theme = userTheme.value || DEFAULT_THEME
   } catch (e) {
     theme = DEFAULT_THEME
@@ -32,7 +31,7 @@ export const initTheme = () => async (dispatch, getState) => {
 
 export function setTheme(currentTheme) {
   // Persist the new fiatTicker in our ticker store
-  db.settings.put({ key: 'theme', value: currentTheme })
+  window.db.settings.put({ key: 'theme', value: currentTheme })
 
   return {
     type: SET_THEME,

--- a/app/reducers/ticker.js
+++ b/app/reducers/ticker.js
@@ -1,7 +1,6 @@
 import { createSelector } from 'reselect'
 import { requestTickers } from 'lib/utils/api'
 import { currencies, getDefaultCurrency } from 'lib/i18n'
-import db from 'store/db'
 import { infoSelectors } from './info'
 
 // ------------------------------------
@@ -44,7 +43,7 @@ export function setCrypto(crypto) {
 
 export function setFiatTicker(fiatTicker) {
   // Persist the new fiatTicker in our ticker store
-  db.settings.put({ key: 'fiatTicker', value: fiatTicker })
+  window.db.settings.put({ key: 'fiatTicker', value: fiatTicker })
 
   return {
     type: SET_FIAT_TICKER,

--- a/app/reducers/wallet.js
+++ b/app/reducers/wallet.js
@@ -1,6 +1,5 @@
 import { createSelector } from 'reselect'
 import get from 'lodash.get'
-import db from 'store/db'
 import { showError } from './notification'
 // ------------------------------------
 // Constants
@@ -36,7 +35,7 @@ export function setWalletsLoaded() {
 export const getWallets = () => async dispatch => {
   let wallets
   try {
-    wallets = await db.wallets.toArray()
+    wallets = await window.db.wallets.toArray()
   } catch (e) {
     wallets = []
   }
@@ -49,7 +48,7 @@ export const setActiveWallet = activeWallet => async dispatch => {
     type: SET_ACTIVE_WALLET,
     activeWallet
   })
-  await db.settings.put({
+  await window.db.settings.put({
     key: 'activeWallet',
     value: activeWallet
   })
@@ -60,7 +59,7 @@ export const setIsWalletOpen = isWalletOpen => async dispatch => {
     type: SET_IS_WALLET_OPEN,
     isWalletOpen
   })
-  await db.settings.put({
+  await window.db.settings.put({
     key: 'isWalletOpen',
     value: isWalletOpen
   })
@@ -68,7 +67,7 @@ export const setIsWalletOpen = isWalletOpen => async dispatch => {
 
 export const putWallet = wallet => async dispatch => {
   dispatch({ type: PUT_WALLET, wallet })
-  wallet.id = await db.wallets.put(wallet)
+  wallet.id = await window.db.wallets.put(wallet)
   await dispatch(getWallets())
   return wallet
 }
@@ -94,7 +93,7 @@ export const deleteWallet = () => async (dispatch, getState) => {
       }
 
       // Delete the wallet from the database.
-      await db.wallets.delete(walletId)
+      await window.db.wallets.delete(walletId)
 
       // Dispatch success message.
       dispatch({ type: DELETE_WALLET_SUCCESS, walletId })
@@ -115,8 +114,8 @@ export const deleteWallet = () => async (dispatch, getState) => {
 export const initWallets = () => async dispatch => {
   // Fetch the current wallet settings.
   let [activeWallet, isWalletOpen, dbWallets] = await Promise.all([
-    db.settings.get({ key: 'activeWallet' }),
-    db.settings.get({ key: 'isWalletOpen' }),
+    window.db.settings.get({ key: 'activeWallet' }),
+    window.db.settings.get({ key: 'isWalletOpen' }),
     dispatch(getWallets())
   ])
 

--- a/app/store/db.js
+++ b/app/store/db.js
@@ -1,71 +1,67 @@
 import Dexie from 'dexie'
 
-// Suffex the database name with NODE_ENV so that wer can have per-env databases.
-export const getDbName = () => {
-  const env = process.env.NODE_ENV || 'development'
-  return `ZapDesktop.${env}`
-}
+export const getDb = name => {
+  // Define the database.
+  const db = new Dexie(name)
 
-// Define the database.
-const db = new Dexie(getDbName())
+  db.version(1).stores({
+    settings: 'key',
+    wallets: '++id, type, chain, network',
+    nodes: 'id'
+  })
 
-db.version(1).stores({
-  settings: 'key',
-  wallets: '++id, type, chain, network',
-  nodes: 'id'
-})
+  /**
+   * @class Wallet
+   * Wallet helper class.
+   */
+  const Wallet = db.wallets.defineClass({
+    id: Number,
+    type: String,
+    network: String,
+    chain: String,
+    alias: String,
+    name: String,
+    autopilot: Boolean,
+    cert: String,
+    host: String,
+    macaroon: String
+  })
 
-/**
- * @class Wallet
- * Wallet helper class.
- */
-export const Wallet = db.wallets.defineClass({
-  id: Number,
-  type: String,
-  network: String,
-  chain: String,
-  alias: String,
-  name: String,
-  autopilot: Boolean,
-  cert: String,
-  host: String,
-  macaroon: String
-})
+  Object.defineProperty(Wallet.prototype, 'wallet', {
+    get: function wallet() {
+      return `wallet-${this.id}`
+    }
+  })
 
-Object.defineProperty(Wallet.prototype, 'wallet', {
-  get: function wallet() {
-    return `wallet-${this.id}`
+  /**
+   * @class Node
+   * Node helper class.
+   */
+  const Node = db.nodes.defineClass({
+    id: String,
+    hasSynced: Boolean,
+    addresses: Object
+  })
+
+  /**
+   * Get current address of a given type.
+   * @param  {String} type type of address to fetch.
+   * @return {String} current address of requested type, if one exists.
+   */
+  Node.prototype.getCurrentAddress = function(type) {
+    return Dexie.getByKeyPath(this, `addresses.${type}`)
   }
-})
 
-/**
- * @class Node
- * Node helper class.
- */
-export const Node = db.nodes.defineClass({
-  id: String,
-  hasSynced: Boolean,
-  addresses: Object
-})
+  /**
+   * Set current address of a given type.
+   * @param  {String} type type of address to save.
+   * @param  {String} address address to save.
+   * @return {Node} updated node instance.
+   */
+  Node.prototype.setCurrentAddress = function(type, address) {
+    Dexie.setByKeyPath(this, `addresses.${type}`, address)
+    return db.nodes.put(this)
+  }
 
-/**
- * Get current address of a given type.
- * @param  {String} type type of address to fetch.
- * @return {String} current address of requested type, if one exists.
- */
-Node.prototype.getCurrentAddress = function(type) {
-  return Dexie.getByKeyPath(this, `addresses.${type}`)
+  return db
 }
-
-/**
- * Set current address of a given type.
- * @param  {String} type type of address to save.
- * @param  {String} address address to save.
- * @return {Node} updated node instance.
- */
-Node.prototype.setCurrentAddress = function(type, address) {
-  Dexie.setByKeyPath(this, `addresses.${type}`, address)
-  return db.nodes.put(this)
-}
-
-export default db

--- a/config/default.js
+++ b/config/default.js
@@ -1,0 +1,11 @@
+const semver = require('semver')
+const { getPackageDetails } = require('../app/lib/utils')
+
+const { version } = getPackageDetails()
+
+module.exports = {
+  db: {
+    namespace: 'ZapDesktop',
+    domain: semver.lt(version, '0.4.0-alpha') ? null : 'next'
+  }
+}

--- a/internals/webpack/webpack.config.base.js
+++ b/internals/webpack/webpack.config.base.js
@@ -3,7 +3,8 @@
  */
 
 import path from 'path'
-import { IgnorePlugin } from 'webpack'
+import { DefinePlugin, IgnorePlugin } from 'webpack'
+import config from 'config'
 
 export const rootDir = path.join(__dirname, '..', '..')
 
@@ -66,7 +67,13 @@ export default {
     modules: [path.resolve(rootDir, 'app'), 'node_modules', 'app/node_modules']
   },
 
-  plugins: [new IgnorePlugin(/^\.\/locale$/, /moment$/)],
+  plugins: [
+    new IgnorePlugin(/^\.\/locale$/, /moment$/),
+
+    // Make config object available at global CONFIG var.
+    // See https://github.com/lorenwest/node-config/wiki/Webpack-Usage#option-1
+    new DefinePlugin({ CONFIG: JSON.stringify(config) })
+  ],
 
   optimization: {
     namedModules: true

--- a/internals/webpack/webpack.config.main.prod.js
+++ b/internals/webpack/webpack.config.main.prod.js
@@ -15,6 +15,8 @@ export default merge.smart(baseConfig, {
 
   mode: 'production',
 
+  externals: ['config'],
+
   entry: {
     main: path.join(rootDir, 'app', 'main')
   },

--- a/internals/webpack/webpack.config.renderer.dev.dll.js
+++ b/internals/webpack/webpack.config.renderer.dev.dll.js
@@ -20,6 +20,7 @@ export default merge.smart(baseConfig, {
   externals: [
     '@grpc/grpc-js',
     '@grpc/proto-loader',
+    'config',
     'electron',
     'electron-is-dev',
     'get-port',

--- a/package.json
+++ b/package.json
@@ -322,6 +322,7 @@
     "bitcoinjs-lib": "4.0.2",
     "bolt11": "1.2.2",
     "coininfo": "git+https://github.com/cryptocoinjs/coininfo.git#299bf3b01a70c932772a7149837c1abe1acb2d41",
+    "config": "3.0.1",
     "connected-react-router": "5.0.1",
     "copy-to-clipboard": "3.0.8",
     "country-data-lookup": "0.0.3",

--- a/stories/Provider.js
+++ b/stories/Provider.js
@@ -7,12 +7,16 @@ import { Provider as ReduxProvider } from 'react-intl-redux'
 import jstz from 'jstimezonedetect'
 import { configureStore } from 'store/configureStore'
 import { getDefaultLocale } from 'lib/i18n'
+import { getDb } from 'store/db'
+import { getDbName } from 'lib/utils/db'
 
-export db from 'store/db'
+export const db = getDb(getDbName(CONFIG))
+db.open()
 
 window.Zap = {
   openExternal: uri => window.open(uri, '_blank')
 }
+
 window.ipcRenderer = new EventEmitter()
 
 window.env = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5306,6 +5306,13 @@ concurrently@4.1.0:
     tree-kill "^1.1.0"
     yargs "^12.0.1"
 
+config@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/config/-/config-3.0.1.tgz#c3118e2eb45fdfd135277339f87e2492559cb147"
+  integrity sha512-TBNrrk2b6AybUohqXw2AydglFBL9b/+1GG93Di6Fm6x1SyVJ5PYgo+mqY2X0KpU9m0PJDSbFaC5H95utSphtLw==
+  dependencies:
+    json5 "^1.0.1"
+
 configstore@^3.0.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/configstore/-/configstore-3.1.2.tgz#c6f25defaeef26df12dd33414b001fe81a543f8f"


### PR DESCRIPTION
## Description:

Introduce a global config system and use to to allow overriding of the database name based on user defined conditions.

By default, include the domain `next` when using the app with a version greater than 0.4.0-alpha in order to allow us to use dedicated databases for master vs next.

So, by default database names will be:

**0.3.x:**
```
ZapDesktop.development / ZapDesktop.production
```

**0.4.x:**
```
ZapDesktop.next.development / ZapDesktop.next.production
```

## Motivation and Context:

We have different database schemas in next vs master and want an easy way to work with both branches without causing conflicts.

Also, we want a global config store that we use to define global config variables (eg autopilot settings, rpc port/host) in a single location, with the ability for developers to easily override these defaults for their own development environment.

## How Has This Been Tested?

Ensure correct database is used  when running `yarn dev/start/package` on both `master` and `next` branches.

## Types of changes:

Devops improvement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
