### PR TITLE
chore: bump version to 0.4.0-alpha

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap-desktop",
   "productName": "Zap",
-  "version": "0.3.4-beta",
+  "version": "0.4.0-alpha",
   "description": "desktop application for the lightning network",
   "main": "./dist/main.prod.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap-desktop",
   "productName": "ZapDesktop",
-  "version": "0.3.4-beta",
+  "version": "0.4.0-alpha",
   "description": "desktop application for the lightning network",
   "scripts": {
     "build": "concurrently --raw \"npm:build-main\" \"npm:build-preload\" \"npm:build-renderer\"",


### PR DESCRIPTION
Bump version to `0.4.0-alpha` in preparation for the upcoming `0.4.x` release.