### PR TITLE
fix(wallet): check node alias exists before using

### DIFF
--- a/app/reducers/contactsform.js
+++ b/app/reducers/contactsform.js
@@ -188,7 +188,10 @@ contactFormSelectors.filteredNetworkNodes = createSelector(
 
     // list of the nodes
     return nodes
-      .filter(node => node.alias.includes(query) || node.pub_key.includes(query))
+      .filter(node => {
+        const { alias, pub_key } = node
+        return (alias && alias.includes(query)) || (pub_key && pub_key.includes(query))
+      })
       .sort(contactableFirst)
       .slice(0, LIMIT)
   }


### PR DESCRIPTION
## Description:

Node alias is an optional property that is only set if a node operator has configured an alias for their node.

Do not assume that a node alias exists when filtering the network node list.

## Motivation and Context:

Fix #1515

## How Has This Been Tested?

I was unable to reproduce the original issue, but looking at the offending code I can clearly see that a missing node alias could/should trigger issues just like the one logged.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
