### PR TITLE
fix(launchpad): disable launch button when launch is in progress

### DIFF
--- a/app/components/Home/Home.js
+++ b/app/components/Home/Home.js
@@ -24,6 +24,7 @@ class Home extends React.Component {
     deleteWallet: PropTypes.func.isRequired,
     lndConnect: PropTypes.object,
     startLndError: PropTypes.object,
+    startingLnd: PropTypes.bool,
     lightningGrpcActive: PropTypes.bool.isRequired,
     walletUnlockerGrpcActive: PropTypes.bool.isRequired,
     wallets: PropTypes.array.isRequired,
@@ -65,6 +66,7 @@ class Home extends React.Component {
       deleteWallet,
       startLnd,
       startLndError,
+      startingLnd,
       unlockWallet,
       wallets,
       setActiveWallet,
@@ -117,6 +119,7 @@ class Home extends React.Component {
                     wallet={wallet}
                     startLnd={startLnd}
                     stopLnd={stopLnd}
+                    startingLnd={startingLnd}
                     lightningGrpcActive={lightningGrpcActive}
                     walletUnlockerGrpcActive={walletUnlockerGrpcActive}
                     startLndError={startLndError}

--- a/app/components/Home/WalletLauncher.js
+++ b/app/components/Home/WalletLauncher.js
@@ -12,6 +12,7 @@ class WalletLauncher extends React.Component {
     wallet: PropTypes.object.isRequired,
     deleteWallet: PropTypes.func.isRequired,
     startLnd: PropTypes.func.isRequired,
+    startingLnd: PropTypes.bool.isRequired,
     lightningGrpcActive: PropTypes.bool.isRequired,
     walletUnlockerGrpcActive: PropTypes.bool.isRequired,
     startLndError: PropTypes.object,
@@ -75,7 +76,7 @@ class WalletLauncher extends React.Component {
   }
 
   render() {
-    const { startLnd, wallet } = this.props
+    const { startLnd, startingLnd, wallet } = this.props
 
     return (
       <Box>
@@ -84,7 +85,14 @@ class WalletLauncher extends React.Component {
             <WalletHeader wallet={wallet} />
           </Box>
           <Flex ml="auto" justifyContent="flex-end" flexDirection="column">
-            <Button type="submit" size="small" form={`wallet-settings-form-${wallet.id}`} ml={2}>
+            <Button
+              type="submit"
+              size="small"
+              disabled={startingLnd}
+              processing={startingLnd}
+              form={`wallet-settings-form-${wallet.id}`}
+              ml={2}
+            >
               <FormattedMessage {...messages.launch_wallet_button_text} />
             </Button>
           </Flex>

--- a/app/containers/Home.js
+++ b/app/containers/Home.js
@@ -18,6 +18,7 @@ const mapStateToProps = state => ({
   lightningGrpcActive: state.lnd.lightningGrpcActive,
   walletUnlockerGrpcActive: state.lnd.walletUnlockerGrpcActive,
   startLndError: state.lnd.startLndError,
+  startingLnd: state.lnd.startingLnd,
   unlockingWallet: state.lnd.unlockingWallet,
   unlockWalletError: state.lnd.unlockWalletError
 })


### PR DESCRIPTION
## Description:

Disable the wallet `launch` button when launch is in progress to give the user some indication that something is happening.

## Motivation and Context:

When you click the launch button to connect to a wallet, there is no feedback in the UI to indicate that anything happened. This is especially problematic if you try to connect to a node that isn't actually online because the user has to wait upto 20 seconds in order to receive any feedback about the error.

## How Has This Been Tested?

Manually

1. click the launch wallet button - the button should become disabled with a processing spinner icon
2. also try the above, connecting to a remote node that is offline.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/200251/52488944-51a59780-2bc1-11e9-9b2e-f71237af4e45.png)

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
