### PR TITLE
fix(forms): more robust handling for amount inputs

### DIFF
--- a/app/components/UI/CryptoAmountInput.js
+++ b/app/components/UI/CryptoAmountInput.js
@@ -7,6 +7,7 @@ import * as yup from 'yup'
 import { convert } from 'lib/utils/btc'
 import { formatValue, parseNumber } from 'lib/utils/crypto'
 import Input from 'components/UI/Input'
+import withNumberInputMask from 'components/withNumberInputMask'
 
 /**
  * @render react
@@ -80,45 +81,16 @@ class CryptoAmountInput extends React.Component {
     }
   }
 
-  handleKeyDown = e => {
-    let { value } = e.target
-
-    // Do nothing if the key press includes a meta key (support copy/paste etc)
-    if (e.metaKey || e.ctrlKey) {
-      return
-    }
-
-    // Prevent non-numeric values.
-    if (e.key.length === 1 && !e.key.match(/^[0-9.]$/)) {
-      e.preventDefault()
-      return
-    }
-
-    // Do not allow multiple dots.
-    if (e.key === '.') {
-      if (value.search(/\./) >= 0) {
-        e.preventDefault()
-      }
-      return
-    }
-  }
-
   render() {
     const rules = this.getRules()
 
     return (
-      <Input
-        {...this.props}
-        type="text"
-        placeholder={rules.placeholder}
-        pattern={rules.pattern}
-        onKeyDown={this.handleKeyDown}
-      />
+      <Input {...this.props} type="text" placeholder={rules.placeholder} pattern={rules.pattern} />
     )
   }
 }
 
-const CryptoAmountInputAsField = asField(CryptoAmountInput)
+const CryptoAmountInputAsField = CryptoAmountInput
 
 class WrappedCryptoAmountInputAsField extends React.Component {
   validate = value => {
@@ -152,4 +124,4 @@ class WrappedCryptoAmountInputAsField extends React.Component {
   }
 }
 
-export default WrappedCryptoAmountInputAsField
+export default asField(withNumberInputMask(WrappedCryptoAmountInputAsField))

--- a/app/components/UI/FiatAmountInput.js
+++ b/app/components/UI/FiatAmountInput.js
@@ -7,6 +7,7 @@ import * as yup from 'yup'
 import { convert } from 'lib/utils/btc'
 import { formatValue, parseNumber } from 'lib/utils/crypto'
 import Input from 'components/UI/Input'
+import withNumberInputMask from 'components/withNumberInputMask'
 
 /**
  * @render react
@@ -59,44 +60,15 @@ class FiatAmountInput extends React.Component {
     }
   }
 
-  handleKeyDown = e => {
-    let { value } = e.target
-
-    // Do nothing if the key press includes a meta key (support copy/paste etc)
-    if (e.metaKey || e.ctrlKey) {
-      return
-    }
-
-    // Prevent non-numeric values.
-    if (e.key.length === 1 && !e.key.match(/^[0-9.]$/)) {
-      e.preventDefault()
-      return
-    }
-
-    // Do not allow multiple dots.
-    if (e.key === '.') {
-      if (value.search(/\./) >= 0) {
-        e.preventDefault()
-      }
-      return
-    }
-  }
-
   render() {
     const rules = this.getRules()
     return (
-      <Input
-        {...this.props}
-        type="text"
-        placeholder={rules.placeholder}
-        pattern={rules.pattern}
-        onKeyDown={this.handleKeyDown}
-      />
+      <Input {...this.props} type="text" placeholder={rules.placeholder} pattern={rules.pattern} />
     )
   }
 }
 
-const FiatAmountInputAsField = asField(FiatAmountInput)
+const FiatAmountInputAsField = FiatAmountInput
 
 class WrappedFiatAmountInputAsField extends React.Component {
   validate = value => {
@@ -130,4 +102,4 @@ class WrappedFiatAmountInputAsField extends React.Component {
   }
 }
 
-export default WrappedFiatAmountInputAsField
+export default asField(withNumberInputMask(WrappedFiatAmountInputAsField))

--- a/app/components/withNumberInputMask/index.js
+++ b/app/components/withNumberInputMask/index.js
@@ -1,0 +1,3 @@
+import withNumberInputMask from './withNumberInputMask'
+
+export default withNumberInputMask

--- a/app/components/withNumberInputMask/withNumberInputMask.js
+++ b/app/components/withNumberInputMask/withNumberInputMask.js
@@ -1,0 +1,61 @@
+import React from 'react'
+import getDisplayName from 'lib/utils/getDisplayName'
+
+/**
+ * A HOC that will add validation of a `required` property to a field.
+ * @param {React.Component} Component Component to wrap
+ */
+const withNumberInputMask = Component =>
+  class extends React.Component {
+    static displayName = `WithNumberInputMask(${getDisplayName(Component)})`
+
+    handleKeyDown = e => {
+      const { fieldApi } = this.props
+      const { value } = e.target
+      const currentSelection = window.getSelection().toString()
+
+      // Do nothing if the key press includes a meta key (support copy/paste etc)
+      if (e.metaKey || e.ctrlKey) {
+        return
+      }
+
+      // Prevent non-numeric values.
+      if (e.key.length === 1 && !e.key.match(/^[0-9.]$/)) {
+        e.preventDefault()
+        return
+      }
+
+      // Special handling for period character.
+      if (e.key === '.') {
+        const isIncludedInValue = value.search(/\./) >= 0
+        const isIncludedInCurrentSelection = currentSelection.search(/\./) >= 0
+        const isValueEmpty = value.length === 0
+        const isStartOfStringSelected = currentSelection && value.startsWith(currentSelection)
+
+        // Prevent change of value if there is already a period and that period is not in the current selection.
+        if (isIncludedInValue && !isIncludedInCurrentSelection) {
+          e.preventDefault()
+          return
+        }
+
+        // If this is the first character, or the start of the string is selected, turn it into a valid number.
+        if (isValueEmpty || isStartOfStringSelected) {
+          e.preventDefault()
+          fieldApi.setValue('0.')
+          return
+        }
+      }
+
+      // Run any additional onKeyDown handlers provided by the caller.
+      const { onKeyDown } = this.props
+      if (onKeyDown) {
+        return onKeyDown(e)
+      }
+    }
+
+    render() {
+      return <Component {...this.props} onKeyDown={this.handleKeyDown} />
+    }
+  }
+
+export default withNumberInputMask

--- a/app/components/withRequiredValidation/withRequiredValidation.js
+++ b/app/components/withRequiredValidation/withRequiredValidation.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import * as yup from 'yup'
+import getDisplayName from 'lib/utils/getDisplayName'
 
 /**
  * A HOC that will add validation of a `required` property to a field.
@@ -7,7 +8,7 @@ import * as yup from 'yup'
  */
 const withRequiredValidation = Component =>
   class extends React.Component {
-    static displayName = 'withRequiredValidation'
+    static displayName = `WithRequiredValidation(${getDisplayName(Component)})`
 
     validate = value => {
       const { disabled, required } = this.props
@@ -31,7 +32,7 @@ const withRequiredValidation = Component =>
     }
 
     render() {
-      return <Component validate={this.validate} {...this.props} />
+      return <Component {...this.props} validate={this.validate} />
     }
   }
 

--- a/app/lib/utils/getDisplayName.js
+++ b/app/lib/utils/getDisplayName.js
@@ -1,0 +1,5 @@
+const getDisplayName = WrappedComponent => {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component'
+}
+
+export default getDisplayName


### PR DESCRIPTION
## Description:

- Improve input mask masking for crypto/fiat amount input fields when a period character is entered
- Extract duplicate code from `FiatAmountInput` and `CryptoAmountInput` components into a reusable HOC.

## Motivation and Context:

Fix #1547 in which entering `.` into the crypto amount input would cause the app to crash.

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):

## Types of changes:
Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
