### PR TITLE
fix(ui): introduce singleton loading screen

### DIFF
--- a/app/components/LoadingBolt/LoadingBolt.js
+++ b/app/components/LoadingBolt/LoadingBolt.js
@@ -20,6 +20,15 @@ const gradientMotion = keyframes`
   }
 `
 
+const Container = styled(animated.div)`
+  z-index: 1000;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+`
+
 const FullPageGradient = styled(Flex)`
   position: absolute;
   z-index: 1000;
@@ -61,7 +70,7 @@ class LoadingBolt extends React.PureComponent {
         {show =>
           show &&
           (springStyles => (
-            <animated.div style={springStyles}>
+            <Container style={springStyles}>
               <FullPageGradient justifyContent="center" alignItems="center" color="primaryText">
                 <Flex alignItems="center" flexDirection="column">
                   <CloudLightning height="140px" width="140px" />
@@ -70,7 +79,7 @@ class LoadingBolt extends React.PureComponent {
                   </Heading.h2>
                 </Flex>
               </FullPageGradient>
-            </animated.div>
+            </Container>
           ))
         }
       </Transition>

--- a/app/components/withLoading/withLoading.js
+++ b/app/components/withLoading/withLoading.js
@@ -24,8 +24,8 @@ const withLoading = Component =>
       const { isLoading, theme, children, ...rest } = this.props
       return (
         <React.Fragment>
-          <LoadingBoltWithTheme isLoading={isLoading} />
           <Component {...rest}>{children}</Component>
+          <LoadingBoltWithTheme isLoading={isLoading} />
         </React.Fragment>
       )
     }

--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -34,7 +34,6 @@ import { fetchDescribeNetwork } from 'reducers/network'
 import { showNotification, removeNotification } from 'reducers/notification'
 import { setIsWalletOpen } from 'reducers/wallet'
 import App from 'components/App'
-import withLoading from 'components/withLoading'
 
 const mapDispatchToProps = {
   setCurrency,
@@ -83,13 +82,6 @@ const mapStateToProps = state => ({
   network: state.network,
   settings: state.settings,
   wallet: state.wallet,
-
-  isLoading:
-    !tickerSelectors.currentTicker(state) ||
-    !tickerSelectors.currencyName(state) ||
-    state.balance.channelBalance === null ||
-    state.balance.walletBalance === null,
-
   currentTicker: tickerSelectors.currentTicker(state),
   currencyFilters: tickerSelectors.currencyFilters(state),
   currencyName: tickerSelectors.currencyName(state),
@@ -196,5 +188,5 @@ export default withRouter(
     mapStateToProps,
     mapDispatchToProps,
     mergeProps
-  )(withLoading(App))
+  )(App)
 )

--- a/app/containers/Root.js
+++ b/app/containers/Root.js
@@ -8,7 +8,7 @@ import { ThemeProvider } from 'styled-components'
 import { removeNotification, notificationSelectors } from 'reducers/notification'
 import { initTheme, themeSelectors } from 'reducers/theme'
 import { walletSelectors } from 'reducers/wallet'
-import { isLoading } from 'reducers/utils'
+import { isLoading, isLoadingPerPath } from 'reducers/utils'
 import { setLoading, setMounted, appSelectors } from 'reducers/app'
 
 import { Page, Titlebar, GlobalStyle, Modal } from 'components/UI'
@@ -110,7 +110,7 @@ const mapStateToProps = state => ({
   hasWallets: walletSelectors.hasWallets(state),
   notifications: notificationSelectors.getNotificationState(state),
   theme: themeSelectors.currentThemeSettings(state),
-  isLoading: isLoading(state),
+  isLoading: isLoading(state) || isLoadingPerPath(state),
   isMounted: appSelectors.isMounted(state)
 })
 

--- a/app/containers/Syncing.js
+++ b/app/containers/Syncing.js
@@ -5,7 +5,6 @@ import { lndSelectors } from 'reducers/lnd'
 import { setIsWalletOpen } from 'reducers/wallet'
 import { showNotification } from 'reducers/notification'
 import { Syncing } from 'components/Syncing'
-import withLoading from 'components/withLoading'
 
 const mapStateToProps = state => ({
   address: state.address.address,
@@ -15,13 +14,7 @@ const mapStateToProps = state => ({
   blockHeight: state.lnd.blockHeight,
   lndBlockHeight: state.lnd.lndBlockHeight,
   lndCfilterHeight: state.lnd.lndCfilterHeight,
-  lightningGrpcActive: state.lnd.lightningGrpcActive,
-  isLoading:
-    infoSelectors.infoLoading(state) ||
-    state.lnd.syncStatus === 'pending' ||
-    !state.lnd.lightningGrpcActive ||
-    !state.lnd.blockHeight ||
-    !state.lnd.lndBlockHeight
+  lightningGrpcActive: state.lnd.lightningGrpcActive
 })
 
 const mapDispatchToProps = {
@@ -32,4 +25,4 @@ const mapDispatchToProps = {
 export default connect(
   mapStateToProps,
   mapDispatchToProps
-)(withLoading(withTheme(Syncing)))
+)(withTheme(Syncing))

--- a/app/reducers/utils.js
+++ b/app/reducers/utils.js
@@ -2,7 +2,7 @@ import { createSelector } from 'reselect'
 import { walletSelectors } from './wallet'
 import { lndSelectors } from './lnd'
 import { appSelectors } from './app'
-
+import { tickerSelectors } from './ticker'
 /**
  * Aggregated isLoading selector that accounts for current wallet and lnd state
  */
@@ -12,3 +12,29 @@ export const isLoading = createSelector(
   lndSelectors.isStartingLnd,
   (isAppLoading, isWalletOpen, isStartingLnd) => isAppLoading || (isStartingLnd && isWalletOpen)
 )
+
+/**
+ * Allows to specify custom loading condition on a per router path basis
+ * Add custom isLoading rules here
+ * @param {} state
+ */
+export const isLoadingPerPath = state => {
+  const { pathname } = state.router.location
+
+  if (pathname === '/app') {
+    const { walletBalance, channelBalance } = state.balance
+    return (
+      !tickerSelectors.currentTicker(state) ||
+      !tickerSelectors.currencyName(state) ||
+      channelBalance === null ||
+      walletBalance === null
+    )
+  }
+
+  if (pathname === '/syncing') {
+    const { syncStatus, lightningGrpcActive, blockHeight, lndBlockHeight } = state.lnd
+    return syncStatus === 'pending' || !lightningGrpcActive || !blockHeight || !lndBlockHeight
+  }
+
+  return false
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Introduce singleton loading screen
<!--- Describe your changes in detail -->

## Motivation and Context:
Under certain circumstances loading screen animation restarts (because currently it's possible to have multiple instances of them at a time). This PR leaves `withLoading` HOC only to be applied to `Root`. Other location must handle `isLoading` state by adding corresponding conditions to `reducers/utils/isLoadingPerPath`
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes:
Bugfix/Refactor
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
