### PR TITLE
refactor: make logout route redirect declarative

### DIFF
--- a/app/containers/Logout.js
+++ b/app/containers/Logout.js
@@ -1,38 +1,27 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { withRouter } from 'react-router'
+import { Redirect } from 'react-router'
 import { stopLnd } from 'reducers/lnd'
 import { resetApp } from 'reducers/app'
 import { setIsWalletOpen } from 'reducers/wallet'
 import { startOnboarding } from 'reducers/onboarding'
 
-/**
- * Root component that deals with mounting the app and managing top level routing.
- */
-class Logout extends React.Component {
-  static propTypes = {
-    resetApp: PropTypes.func.isRequired,
-    setIsWalletOpen: PropTypes.func.isRequired,
-    startOnboarding: PropTypes.func.isRequired,
-    stopLnd: PropTypes.func.isRequired,
-    history: PropTypes.shape({
-      push: PropTypes.func.isRequired
-    })
-  }
-
-  async componentDidMount() {
-    const { history, resetApp, setIsWalletOpen, startOnboarding, stopLnd } = this.props
+function Logout({ resetApp, setIsWalletOpen, startOnboarding, stopLnd }) {
+  useEffect(() => {
     stopLnd()
     setIsWalletOpen(false)
     resetApp()
     startOnboarding()
-    history.push('/')
-  }
+  }, [])
+  return <Redirect to="/" />
+}
 
-  render() {
-    return null
-  }
+Logout.propTypes = {
+  resetApp: PropTypes.func.isRequired,
+  setIsWalletOpen: PropTypes.func.isRequired,
+  startOnboarding: PropTypes.func.isRequired,
+  stopLnd: PropTypes.func.isRequired
 }
 
 const mapDispatchToProps = {
@@ -45,4 +34,4 @@ const mapDispatchToProps = {
 export default connect(
   null,
   mapDispatchToProps
-)(withRouter(Logout))
+)(Logout)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Refactor `Logout` route to use declarative redirect approach as was done for the `Initializer` route in #1561
<!--- Describe your changes in detail -->


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
## Types of changes:
Refactor
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
