### PR TITLE
refactor(forms): use input labels in pay/request

### DIFF
--- a/app/components/Pay/Pay.js
+++ b/app/components/Pay/Pay.js
@@ -2,10 +2,10 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Box } from 'rebass'
 import { animated, Keyframes, Transition } from 'react-spring'
-import { FormattedMessage } from 'react-intl'
+import { FormattedMessage, injectIntl, intlShape } from 'react-intl'
 import { decodePayReq, getMinFee, getMaxFee, isOnchain, isLn } from 'lib/utils/crypto'
 import { convert } from 'lib/utils/btc'
-import { Bar, Form, Message, Label, LightningInvoiceInput, Panel, Text } from 'components/UI'
+import { Bar, Form, Message, LightningInvoiceInput, Panel, Text } from 'components/UI'
 import { CurrencyFieldGroup, CryptoValue } from 'containers/UI'
 import PaySummaryLightning from 'containers/Pay/PaySummaryLightning'
 import PaySummaryOnChain from 'containers/Pay/PaySummaryOnChain'
@@ -50,6 +50,7 @@ const ShowHideAmount = Keyframes.Spring({
  */
 class Pay extends React.Component {
   static propTypes = {
+    intl: intlShape.isRequired,
     /** The currently active chain (bitcoin, litecoin etc) */
     chain: PropTypes.string.isRequired,
     /** The currently active chain (mainnet, testnet) */
@@ -353,28 +354,24 @@ class Pay extends React.Component {
 
   renderAddressField = () => {
     const { currentStep, isLn } = this.state
-    const { chain, payReq, network } = this.props
+    const { chain, payReq, network, intl } = this.props
+
+    const payReq_label =
+      currentStep === 'address'
+        ? 'request_label_combined'
+        : isLn
+        ? 'request_label_offchain'
+        : 'request_label_onchain'
 
     return (
       <Box className={currentStep !== 'summary' ? 'element-show' : 'element-hide'}>
-        <Box pb={2}>
-          <Label htmlFor="payReq" readOnly={currentStep !== 'address'}>
-            {currentStep === 'address' ? (
-              <FormattedMessage {...messages.request_label_combined} />
-            ) : isLn ? (
-              <FormattedMessage {...messages.request_label_offchain} />
-            ) : (
-              <FormattedMessage {...messages.request_label_onchain} />
-            )}
-          </Label>
-        </Box>
-
         <ShowHidePayReq state={currentStep === 'address' || isLn ? 'big' : 'small'} context={this}>
           {styles => (
             <React.Fragment>
               <LightningInvoiceInput
                 field="payReq"
                 name="payReq"
+                label={intl.formatMessage({ ...messages[payReq_label] })}
                 style={styles}
                 initialValue={payReq}
                 required
@@ -603,4 +600,4 @@ class Pay extends React.Component {
   }
 }
 
-export default Pay
+export default injectIntl(Pay)

--- a/app/components/Request/Request.js
+++ b/app/components/Request/Request.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Box } from 'rebass'
 import { FormattedMessage, injectIntl, intlShape } from 'react-intl'
-import { Bar, Button, Form, Header, Label, Panel, Text, TextArea } from 'components/UI'
+import { Bar, Button, Form, Header, Panel, Text, TextArea } from 'components/UI'
 import { CurrencyFieldGroup } from 'containers/UI'
 import Lightning from 'components/Icon/Lightning'
 import { RequestSummary } from '.'
@@ -130,24 +130,17 @@ class Request extends React.Component {
   renderMemoField = () => {
     const { intl } = this.props
     return (
-      <Box>
-        <Box pb={2}>
-          <Label htmlFor="memo">
-            <FormattedMessage {...messages.memo} />
-          </Label>
-        </Box>
-
-        <TextArea
-          field="memo"
-          name="memo"
-          validateOnBlur
-          validateOnChange
-          placeholder={intl.formatMessage({ ...messages.memo_placeholder })}
-          width={1}
-          rows={3}
-          css={{ resize: 'vertical', 'min-height': '48px' }}
-        />
-      </Box>
+      <TextArea
+        field="memo"
+        name="memo"
+        validateOnBlur
+        validateOnChange
+        label={intl.formatMessage({ ...messages.memo })}
+        placeholder={intl.formatMessage({ ...messages.memo_placeholder })}
+        width={1}
+        rows={3}
+        css={{ resize: 'vertical', 'min-height': '48px' }}
+      />
     )
   }
 


### PR DESCRIPTION
## Description:

Use the Input/Textarea `label` prop for adding labels to form elements on the pay & request forms rather than custom implementations.

## Motivation and Context:

Pay / Request forms were built before the `Input` and `Textarea` elements had support for `label` prop. Migrate to that for consistency.

This will allow #1501 to be updated to add the tooltip directly to the Input / Textarea elements.

## How Has This Been Tested?

Manually.

## Types of changes:

Refactor.

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
