### PR TITLE
refactor(channels): remove old network sidebar

### DIFF
--- a/app/components/App/App.js
+++ b/app/components/App/App.js
@@ -1,14 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Form from 'components/Form'
-import ChannelForm from 'components/Contacts/ChannelForm'
-import Network from 'components/Contacts/Network'
-import AddChannel from 'components/Contacts/AddChannel'
 import ReceiveModal from 'components/Wallet/ReceiveModal'
 import ActivityModal from 'containers/Activity/ActivityModal'
 import Activity from 'containers/Activity'
 import Wallet from 'containers/Wallet'
-import { MainContent, Sidebar } from 'components/UI'
+import { MainContent } from 'components/UI'
 
 // Initial refetch after 2 seconds.
 const INITIAL_REFETCH_INTERVAL = 2000
@@ -28,10 +25,7 @@ class App extends React.Component {
     formProps: PropTypes.object.isRequired,
     closeForm: PropTypes.func.isRequired,
     currentTicker: PropTypes.object,
-    contactsFormProps: PropTypes.object,
-    networkTabProps: PropTypes.object,
     receiveModalProps: PropTypes.object,
-    channelFormProps: PropTypes.object,
     setIsWalletOpen: PropTypes.func.isRequired,
     fetchPeers: PropTypes.func.isRequired,
     fetchDescribeNetwork: PropTypes.func.isRequired
@@ -83,22 +77,12 @@ class App extends React.Component {
   }
 
   render() {
-    const {
-      currentTicker,
-      form,
-      formProps,
-      closeForm,
-      contactsFormProps,
-      networkTabProps,
-      receiveModalProps,
-      channelFormProps
-    } = this.props
+    const { currentTicker, form, formProps, closeForm, receiveModalProps } = this.props
 
     return (
       <>
         {currentTicker && (
           <>
-            <ChannelForm {...channelFormProps} />
             <ReceiveModal {...receiveModalProps} />
             <ActivityModal />
             <Form formType={form.formType} formProps={formProps} closeForm={closeForm} />
@@ -109,14 +93,6 @@ class App extends React.Component {
           <Wallet />
           <Activity />
         </MainContent>
-
-        <Sidebar.medium>
-          {contactsFormProps.contactsform.isOpen ? (
-            <AddChannel {...contactsFormProps} />
-          ) : (
-            <Network {...networkTabProps} />
-          )}
-        </Sidebar.medium>
       </>
     )
   }

--- a/app/components/Settings/Fiat/Fiat.js
+++ b/app/components/Settings/Fiat/Fiat.js
@@ -6,7 +6,7 @@ import messages from './messages'
 
 const Fiat = ({ fiatTicker, fiatTickers, disableSubMenu, setFiatTicker }) => (
   <MenuContainer>
-    <Menu>
+    <Menu justify="right">
       <MenuItem
         item={{ key: 'fiat', name: <FormattedMessage {...messages.title} /> }}
         onClick={disableSubMenu}

--- a/app/components/Settings/Locale/Locale.js
+++ b/app/components/Settings/Locale/Locale.js
@@ -12,7 +12,7 @@ const Translate = ({ locales, disableSubMenu, currentLocale, setLocale }) => {
 
   return (
     <MenuContainer>
-      <Menu>
+      <Menu justify="right">
         <MenuItem
           item={{ key: 'fiat', name: <FormattedMessage {...messages.title} /> }}
           onClick={disableSubMenu}

--- a/app/components/Settings/Menu/Menu.js
+++ b/app/components/Settings/Menu/Menu.js
@@ -7,7 +7,7 @@ import messages from './messages'
 
 const SettingsMenu = ({ history, setActiveSubMenu, setFormType }) => (
   <MenuContainer>
-    <Menu>
+    <Menu justify="right">
       <MenuItem
         item={{ key: 'fiat', name: <FormattedMessage {...messages.fiat} /> }}
         onClick={() => setActiveSubMenu('fiat')}

--- a/app/components/Settings/Settings.js
+++ b/app/components/Settings/Settings.js
@@ -71,10 +71,10 @@ class Settings extends React.Component {
   }
 
   render() {
-    const { activeWalletSettings, isSettingsOpen } = this.props
+    const { activeWalletSettings, isSettingsOpen, ...rest } = this.props
 
     return (
-      <Box css={{ position: 'relative' }}>
+      <Box {...rest}>
         <Flex
           ref={this.setButtonRef}
           alignItems="center"

--- a/app/components/Settings/Theme/Theme.js
+++ b/app/components/Settings/Theme/Theme.js
@@ -6,7 +6,7 @@ import messages from './messages'
 
 const Theme = ({ currentTheme, disableSubMenu, setTheme, themes }) => (
   <MenuContainer>
-    <Menu>
+    <Menu justify="right">
       <MenuItem
         item={{ key: 'fiat', name: <FormattedMessage {...messages.title} /> }}
         onClick={disableSubMenu}

--- a/app/components/UI/Dropdown.js
+++ b/app/components/UI/Dropdown.js
@@ -45,22 +45,24 @@ DropdownButton.defaultProps = {
 /**
  * Menu
  */
-export const MenuContainer = styled(Box)({
-  position: 'relative'
-})
+export const MenuContainer = styled(Box)`
+  position: relative;
+`
 
-export const Menu = styled(Box)({
-  cursor: 'pointer',
-  display: 'inline-block',
-  position: 'absolute',
-  'z-index': '40',
-  'min-width': '70px',
-  'max-height': '300px',
-  'overflow-y': 'auto',
-  'list-style-type': 'none',
-  'border-radius': '3px',
-  'box-shadow': '0 3px 4px 0 rgba(30, 30, 30, 0.5)'
-})
+export const Menu = styled(Box)`
+  cursor: pointer;
+  display: inline-block;
+  position: absolute;
+  z-index: 40;
+  min-width: 70px;
+  max-height: 300px;
+  overflow-y: auto;
+  list-style-type: none;
+  border-radius: 3px;
+  box-shadow: 0 3px 4px 0 rgba(30, 30, 30, 0.5);
+  right: ${props => (props.justify === 'right' ? 0 : null)};
+`
+
 Menu.defaultProps = {
   as: 'ul',
   m: 0,
@@ -192,7 +194,7 @@ class Dropdown extends React.Component {
           </DropdownButton>
           {isOpen && (
             <MenuContainer>
-              <Menu css={justify === 'right' ? { right: 0 } : null}>
+              <Menu justify={justify}>
                 {items.map(item => {
                   return (
                     <MenuItem

--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -1,34 +1,10 @@
 import { withRouter } from 'react-router'
 import { connect } from 'react-redux'
 import get from 'lodash.get'
-import { setCurrency, tickerSelectors } from 'reducers/ticker'
+import { tickerSelectors } from 'reducers/ticker'
 import { closeWalletModal } from 'reducers/address'
 import { setFormType } from 'reducers/form'
-import { createInvoice, fetchInvoice } from 'reducers/invoice'
 import { infoSelectors } from 'reducers/info'
-import { lndSelectors } from 'reducers/lnd'
-import {
-  fetchChannels,
-  fetchSuggestedNodes,
-  openChannel,
-  closeChannel,
-  channelsSelectors,
-  changeFilter,
-  updateChannelSearchQuery,
-  setSelectedChannel
-} from 'reducers/channels'
-import {
-  openContactsForm,
-  closeContactsForm,
-  openManualForm,
-  closeManualForm,
-  openSubmitChannelForm,
-  closeSubmitChannelForm,
-  updateContactFormSearchQuery,
-  setNode,
-  contactFormSelectors
-} from 'reducers/contactsform'
-import { fetchBalance } from 'reducers/balance'
 import { fetchPeers } from 'reducers/peers'
 import { fetchDescribeNetwork } from 'reducers/network'
 import { showNotification, removeNotification } from 'reducers/notification'
@@ -37,30 +13,10 @@ import App from 'components/App'
 import withLoading from 'components/withLoading'
 
 const mapDispatchToProps = {
-  setCurrency,
   closeWalletModal,
   setFormType,
-  createInvoice,
-  fetchInvoice,
   removeNotification,
-  fetchBalance,
   fetchPeers,
-  fetchChannels,
-  fetchSuggestedNodes,
-  openChannel,
-  closeChannel,
-  changeFilter,
-  updateChannelSearchQuery,
-  setSelectedChannel,
-  openContactsForm,
-  closeContactsForm,
-  openSubmitChannelForm,
-  closeSubmitChannelForm,
-  openManualForm,
-  closeManualForm,
-  updateContactFormSearchQuery,
-  setNode,
-  contactFormSelectors,
   fetchDescribeNetwork,
   setIsWalletOpen,
   showNotification
@@ -74,7 +30,6 @@ const mapStateToProps = state => ({
   payment: state.payment,
   transaction: state.transaction,
   channels: state.channels,
-  contactsform: state.contactsform,
   balance: state.balance,
   form: state.form,
   requestform: state.requestform,
@@ -94,17 +49,8 @@ const mapStateToProps = state => ({
   currentTicker: tickerSelectors.currentTicker(state),
   currencyFilters: tickerSelectors.currencyFilters(state),
   currencyName: tickerSelectors.currencyName(state),
-  syncPercentage: lndSelectors.syncPercentage(state),
   cryptoName: tickerSelectors.cryptoName(state),
-
-  filteredNetworkNodes: contactFormSelectors.filteredNetworkNodes(state),
-  showManualForm: contactFormSelectors.showManualForm(state),
-
-  networkInfo: infoSelectors.networkInfo(state),
-  currentChannels: channelsSelectors.currentChannels(state),
-  activeChannelPubkeys: channelsSelectors.activeChannelPubkeys(state),
-  nonActiveChannelPubkeys: channelsSelectors.nonActiveChannelPubkeys(state),
-  pendingOpenChannelPubkeys: channelsSelectors.pendingOpenChannelPubkeys(state)
+  networkInfo: infoSelectors.networkInfo(state)
 })
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
@@ -113,43 +59,6 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
       return {}
     }
     return {}
-  }
-
-  const networkTabProps = {
-    currentChannels: stateProps.currentChannels,
-    channels: stateProps.channels,
-    channelBalance: stateProps.balance.channelBalance,
-    currentTicker: stateProps.currentTicker,
-    contactsform: stateProps.contactsform,
-    nodes: stateProps.network.nodes,
-    searchQuery: stateProps.channels.searchQuery,
-    networkInfo: stateProps.networkInfo,
-    currencyName: stateProps.currencyName,
-
-    fetchChannels: dispatchProps.fetchChannels,
-    openContactsForm: dispatchProps.openContactsForm,
-    contactFormSelectors: dispatchProps.contactFormSelectors,
-    changeFilter: dispatchProps.changeFilter,
-    updateChannelSearchQuery: dispatchProps.updateChannelSearchQuery,
-    setSelectedChannel: dispatchProps.setSelectedChannel,
-    closeChannel: dispatchProps.closeChannel
-  }
-
-  const contactsFormProps = {
-    closeContactsForm: dispatchProps.closeContactsForm,
-    openSubmitChannelForm: dispatchProps.openSubmitChannelForm,
-    updateContactFormSearchQuery: dispatchProps.updateContactFormSearchQuery,
-    setNode: dispatchProps.setNode,
-    openChannel: dispatchProps.openChannel,
-    openManualForm: dispatchProps.openManualForm,
-
-    contactsform: stateProps.contactsform,
-    filteredNetworkNodes: stateProps.filteredNetworkNodes,
-    loadingChannelPubkeys: stateProps.channels.loadingChannelPubkeys,
-    showManualForm: stateProps.showManualForm,
-    activeChannelPubkeys: stateProps.activeChannelPubkeys,
-    nonActiveChannelPubkeys: stateProps.nonActiveChannelPubkeys,
-    pendingOpenChannelPubkeys: stateProps.pendingOpenChannelPubkeys
   }
 
   const receiveModalProps = {
@@ -164,27 +73,13 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     showNotification: dispatchProps.showNotification
   }
 
-  const channelFormProps = {
-    formType: stateProps.contactsform.formType,
-    closeForm: () => {
-      dispatchProps.closeManualForm()
-      dispatchProps.closeSubmitChannelForm()
-    }
-  }
-
   return {
     ...stateProps,
     ...dispatchProps,
     ...ownProps,
 
-    // props for the network sidebar
-    networkTabProps,
-    // props for the contacts form
-    contactsFormProps,
     // props for the receive modal
     receiveModalProps,
-    // props for the channel form wrapper
-    channelFormProps,
     // Props to pass to the request form
     formProps: formProps(stateProps.form.formType),
     // action to close form

--- a/app/main.js
+++ b/app/main.js
@@ -219,7 +219,7 @@ app.on('ready', async () => {
     show: false,
     useContentSize: true,
     titleBarStyle: 'hidden',
-    width: 1020,
+    width: 900,
     height: 680,
     minWidth: 900,
     minHeight: 425,


### PR DESCRIPTION
## Description:

Remove the old network sidebar from the UI. This PR does not fully remove all the old network related code as we have not yet finished reimplementing everything but instead focuses on removing the network list from the UI.

Will follow with a PR to remove all old/unused code at a later point.

Ideally, we should merge #1568 prior to this one since we need that in place to ensure that we can still do all basic channel management through the new UI.

## Motivation and Context:

Resolves #1426

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/200251/52913826-0591db80-32c2-11e9-8353-5f60918acb23.png)


## Types of changes:

Refactor

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
