### PR TITLE
fix(wallet): resolve broken link in help menu

### DIFF
--- a/app/lib/zap/menuBuilder.js
+++ b/app/lib/zap/menuBuilder.js
@@ -188,7 +188,7 @@ export default class ZapMenuBuilder {
         {
           label: 'Community Discussions',
           click() {
-            shell.openExternal('zaphq.slack.com')
+            shell.openExternal('https://zaphq.slack.com')
           }
         },
         {


### PR DESCRIPTION
In the current version of Zap the sub-menu item Help > Community Discussions is a dead button (on macOS). The linter does not like the invite code.

<!--- Provide a general summary of your changes in the Title above -->

The sub-menu item "Community Discussions" under "Help" is a dead link. Adding the proper "https://" to the "shell.openExternal('https://zaphq.slack.com')" statement opens the url. 


## Description:

<!--- Describe your changes in detail -->

Edited the argument passed to the shell.openExternal() function. 

## Motivation and Context:

Improved user experience. Allows users to find the Slack channel easier. This should result in an increase in community interaction. 

<!--- Why is this change required? What problem does it solve? -->

Dead links aren't good. 

<!--- If it fixes an open issue, please link to the issue here. -->

I don't believe this has been submitted as an issue. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes:

<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x ] My code follows the code style of this project.
- [ x ] I have reviewed and updated the documentation accordingly.
- [ x ] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [ x ] My commits have been squashed into a concise set of changes.
