### PR TITLE
fix(wallet): do not crash after paying msat invoices

### DIFF
--- a/app/components/Pay/Pay.js
+++ b/app/components/Pay/Pay.js
@@ -225,7 +225,7 @@ class Pay extends React.Component {
    * @param  {Object} values submitted form values.
    */
   onSubmit = values => {
-    const { currentStep, isOnchain, invoice } = this.state
+    const { currentStep, isOnchain } = this.state
     const { cryptoCurrency, onchainFees, payInvoice, routes, sendCoins } = this.props
     if (currentStep === 'summary') {
       if (isOnchain) {
@@ -238,8 +238,7 @@ class Pay extends React.Component {
       } else {
         return payInvoice({
           payReq: values.payReq,
-          value: invoice.satoshis || invoice.millisatoshis ? null : values.amountCrypto,
-          currency: cryptoCurrency,
+          amt: this.amountInSats(),
           feeLimit: getMaxFee(routes)
         })
       }

--- a/app/reducers/activity.js
+++ b/app/reducers/activity.js
@@ -5,6 +5,7 @@ import { fetchTransactions } from './transaction'
 import { fetchPayments } from './payment'
 import { fetchInvoices } from './invoice'
 import { fetchBalance } from './balance'
+
 // ------------------------------------
 // Initial State
 // ------------------------------------
@@ -144,7 +145,7 @@ const paymentsSending = createSelector(
       return {
         type: 'payment',
         creation_date: payment.timestamp,
-        value: invoice.satoshis || payment.amt,
+        value: payment.amt,
         path: [invoice.payeeNodeKey],
         payment_hash: invoice.tags.find(t => t.tagName === 'payment_hash').data,
         sending: true,

--- a/app/reducers/payment.js
+++ b/app/reducers/payment.js
@@ -1,6 +1,5 @@
 import { createSelector } from 'reselect'
 import { send } from 'redux-electron-ipc'
-import { convert } from 'lib/utils/btc'
 import errorToUserFriendly from 'lib/utils/userFriendlyErrors'
 import { fetchBalance } from './balance'
 import { setFormType } from './form'
@@ -70,13 +69,7 @@ export const receivePayments = (event, { payments }) => dispatch => {
   dispatch({ type: RECEIVE_PAYMENTS, payments })
 }
 
-export const payInvoice = ({ payReq, value, currency = 'sats', feeLimit }) => dispatch => {
-  // If a custom value has been passed, convert it to sats as this is what is expected by the backend.
-  let amt
-  if (value) {
-    amt = convert(currency, 'sats', value)
-  }
-
+export const payInvoice = ({ payReq, amt, feeLimit }) => dispatch => {
   const data = { paymentRequest: payReq, feeLimit, amt }
   dispatch(send('lnd', { msg: 'sendPayment', data }))
   dispatch(sendPayment(data))


### PR DESCRIPTION
## Description:

Do not crash after paying msat invoices by ensuring that the data that we pass to the activity list always has a valid amount to display.

## Motivation and Context:

Fix #1568

## How Has This Been Tested?

Try paying this invoice (it's expired so your payment wont go through fully):

```
lnbc1336679810p1pwx5kefpp5nz4su9aezl8k77yakmpnvlg2fr3mg4y39a9cjyf72w4yxeum4jusdr2gfkx7cmtwd68yetpd5s9xar0wfjn5gp59cunjgz42dzzqen0wgszy3r0dcnhggz5wf6hxapwyptx2unfveujug3q2d6xjcmtv4ezq7pqxycqp2rzjqthv88m958rhnzyscgwuqay3dg7tsmvqp02cm62wzjy65tsu7q65kzyk3cqq20gqqyqqqqlgqqqqqqgqjqxuga2vz6ycmttj82cka76hdtj5682ahca2cxm9ezly6tzdrnd0jxyvzzelemgt67a6vrygt2tq5l2lup6a4syknmcs8klrgrchsxuhspndzpf5
```

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
