### PR TITLE
fix(ui): ensure amount input group has required flag

### DIFF
--- a/app/components/Contacts/SubmitChannelForm/SubmitChannelForm.js
+++ b/app/components/Contacts/SubmitChannelForm/SubmitChannelForm.js
@@ -161,6 +161,7 @@ class SubmitChannelForm extends React.Component {
                 setCryptoCurrency={setCryptoCurrency}
                 setFiatCurrency={setFiatCurrency}
                 formApi={formApi}
+                required
               />
             </Panel.Body>
 

--- a/app/components/Pay/Pay.js
+++ b/app/components/Pay/Pay.js
@@ -505,6 +505,7 @@ class Pay extends React.Component {
               setCryptoCurrency={setCryptoCurrency}
               setFiatCurrency={setFiatCurrency}
               formApi={this.formApi}
+              required
             />
           </Box>
         )}

--- a/app/components/Request/Request.js
+++ b/app/components/Request/Request.js
@@ -169,6 +169,7 @@ class Request extends React.Component {
         setCryptoCurrency={setCryptoCurrency}
         setFiatCurrency={setFiatCurrency}
         formApi={this.formApi}
+        required
         mb={3}
       />
     )

--- a/app/components/UI/CurrencyFieldGroup.js
+++ b/app/components/UI/CurrencyFieldGroup.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { Box, Flex } from 'rebass'
 import { FormattedMessage } from 'react-intl'
 import { convert } from 'lib/utils/btc'
-import { CryptoAmountInput, Dropdown, FiatAmountInput, Label, Text } from 'components/UI'
+import { CryptoAmountInput, Dropdown, FiatAmountInput } from 'components/UI'
 import messages from './messages'
 
 class CurrencyFieldGroup extends React.Component {
@@ -33,6 +33,8 @@ class CurrencyFieldGroup extends React.Component {
     initialAmountCrypto: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     /** Amount value to populate the amountFiat field with when the form first loads. */
     initialAmountFiat: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    /** Boolean indicating if form fields are required */
+    required: PropTypes.bool,
     /** Set the current cryptocurrency. */
     setCryptoCurrency: PropTypes.func.isRequired,
     /** Set the current fiat currency */
@@ -91,24 +93,22 @@ class CurrencyFieldGroup extends React.Component {
       fiatCurrencies,
       initialAmountCrypto,
       initialAmountFiat,
+      required,
       ...rest
     } = this.props
 
     return (
       <Box {...rest}>
-        <Label htmlFor="amountCrypto" pb={2}>
-          <FormattedMessage {...messages.amount} />
-        </Label>
-
-        <Flex justifyContent="space-between" alignItems="flex-start">
-          <Flex width={6 / 13}>
+        <Flex justifyContent="space-between" alignItems="center">
+          <Flex width={6 / 13} alignItems="center">
             <Box width={150}>
               <CryptoAmountInput
                 field="amountCrypto"
                 name="amountCrypto"
                 initialValue={initialAmountCrypto}
                 currency={cryptoCurrency}
-                required
+                required={required}
+                label={<FormattedMessage {...messages.amount} />}
                 width={150}
                 validateOnChange
                 validateOnBlur
@@ -125,10 +125,10 @@ class CurrencyFieldGroup extends React.Component {
               ml={2}
             />
           </Flex>
-          <Text textAlign="center" mt={3} width={1 / 11}>
+          <Flex alignItems="center" justifyContent="center" width={1 / 11} mt={3}>
             =
-          </Text>
-          <Flex width={6 / 13}>
+          </Flex>
+          <Flex width={6 / 13} alignItems="center">
             <Box width={150} ml="auto">
               <FiatAmountInput
                 field="amountFiat"
@@ -136,6 +136,7 @@ class CurrencyFieldGroup extends React.Component {
                 initialValue={initialAmountFiat}
                 currency={fiatCurrency}
                 currentTicker={currentTicker}
+                label="&nbsp;"
                 width={150}
                 onChange={this.handleAmountFiatChange}
                 disabled={disabled}

--- a/app/components/UI/Input.js
+++ b/app/components/UI/Input.js
@@ -148,7 +148,7 @@ class Input extends React.Component {
 
     return (
       <Flex flexDirection="column" justifyContent={justifyContent} {...spaceProps}>
-        {label && (
+        {typeof label !== 'undefined' && label !== null && (
           <Label htmlFor={field} mb={2}>
             {label}
             {required && (


### PR DESCRIPTION
## Description:

Ensure that the amount fields on pay / request / channel open forms have required asterisk.

## Motivation and Context:

The amount fields are missing the required asterisk, even though they are required fields.

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):

**Before:**
![image](https://user-images.githubusercontent.com/200251/52971261-15d7b280-33b7-11e9-80b9-3aff1ae6a2f8.png)

**After:**
![image](https://user-images.githubusercontent.com/200251/52971271-21c37480-33b7-11e9-946a-b1e7fc20490b.png)

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
