### PR TITLE
fix(ui): incorrect fiat to satoshi conversion

### DIFF
--- a/app/components/UI/CryptoAmountInput.js
+++ b/app/components/UI/CryptoAmountInput.js
@@ -42,7 +42,10 @@ class CryptoAmountInput extends React.Component {
     const valueAfter = fieldApi.getValue()
     if (valueAfter !== valueBefore) {
       const [integer, fractional] = parseNumber(valueAfter, this.getRules().precision)
-      const formattedValue = formatValue(integer, fractional)
+      // Handle a corner case for the satoshis. sat number must be integer so
+      // explicitly getting rid of fractional part (to avoid things like "1000." )
+      const isSats = ['sats', 'lits'].includes(currency)
+      const formattedValue = formatValue(integer, isSats ? null : fractional)
       if (formattedValue !== valueAfter) {
         fieldApi.setValue(formattedValue)
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Fix incorrect fiat -> satoshi conversion in Request modal
<!--- Describe your changes in detail -->

## Motivation and Context:
Steps to reproduce

1. Press Request button
2. Switch denomination unit to satoshis
3. Start filling fiat field
4. Satoshi value will have a dot in the end, making it an invalid request amount

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/14069193/53001694-f16deb80-3433-11e9-97b3-663adee15260.png)

## Types of changes:
Bugfix
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
