### PR TITLE
chore(devops): run deploy jobs on next branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
   include:
     - stage: deploy
       name: Deploy to Github
-      if: (NOT type IN (pull_request)) AND (branch = master)
+      if: (NOT type IN (pull_request)) AND (branch IN (master, next))
       script: skip
       deploy:
         skip_cleanup: true
@@ -68,11 +68,10 @@ jobs:
         script: yarn release --linux
         on:
           repo: LN-Zap/zap-desktop
-          branch: master
 
     - os: osx
       name: Deploy to Github
-      if: (NOT type IN (pull_request)) AND (branch = master)
+      if: (NOT type IN (pull_request)) AND (branch IN (master, next))
       script: skip
       deploy:
         skip_cleanup: true
@@ -80,4 +79,3 @@ jobs:
         script: yarn release --mac
         on:
           repo: LN-Zap/zap-desktop
-          branch: master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,4 +33,4 @@ test_script:
   - yarn test-ci
 
 deploy_script:
-  - cmd: powershell if (($env:appveyor_repo_name -eq 'LN-Zap/zap-desktop') -and ($env:appveyor_repo_branch -eq 'master')) { yarn release --win }
+  - cmd: powershell if (($env:appveyor_repo_name -eq 'LN-Zap/zap-desktop') -and (($env:appveyor_repo_branch -eq 'master') -or ($env:appveyor_repo_branch -eq 'next'))) { yarn release --win }


### PR DESCRIPTION
## Description:

Update CI jobs so that deploy scripts are run on the `next` branch in addition to `master`.

## Motivation and Context:

Give us ability to have concurrent builds against `master` and `next` targeting different release versions.
