### PR TITLE
fix(ui): ensure notifications don't cover modal close button

### DIFF
--- a/app/components/GlobalNotification/GlobalNotification.js
+++ b/app/components/GlobalNotification/GlobalNotification.js
@@ -1,9 +1,17 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { animated, Transition } from 'react-spring'
+import styled from 'styled-components'
 import { Box } from 'rebass'
 import errorToUserFriendly from 'lib/utils/userFriendlyErrors'
 import { Notification } from 'components/UI'
+
+const Wrapper = styled(Box)`
+  position: absolute;
+  right: 0;
+  left: 0;
+  z-index: 99999;
+`
 
 class GlobalNotification extends React.Component {
   static propTypes = {
@@ -24,7 +32,7 @@ class GlobalNotification extends React.Component {
     }
 
     return (
-      <Box mt="22px" px={3} width={1} css={{ position: 'absolute', 'z-index': '99999' }}>
+      <Wrapper mt="22px" px={3} width={0.9} mx="auto">
         {notifications.map(item => (
           <Transition
             native
@@ -50,7 +58,7 @@ class GlobalNotification extends React.Component {
             }
           </Transition>
         ))}
-      </Box>
+      </Wrapper>
     )
   }
 }


### PR DESCRIPTION
## Description:

Ensure notifications don't cover modal close button

## Motivation and Context:

Notifications cover the modal close button, forcing users to close notifications before they can close a modal.

## How Has This Been Tested?

Trigger a notification in a modal - eg, try to create an invoice for a large amount.

## Screenshots (if appropriate):

**Before:**

![image](https://user-images.githubusercontent.com/200251/53117797-fe7dfe00-354b-11e9-9a5c-239d6c2dd2e1.png)

**After:**

![image](https://user-images.githubusercontent.com/200251/53117782-f45bff80-354b-11e9-9d45-7a19ef1342ff.png)

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
