### PR TITLE
fix(ui): make incoming/outgoing transaction more obvious

### DIFF
--- a/app/components/Activity/Invoice/Invoice.js
+++ b/app/components/Activity/Invoice/Invoice.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { FormattedNumber, FormattedTime, FormattedMessage, injectIntl } from 'react-intl'
 import { Box, Flex } from 'rebass'
 import { btc } from 'lib/utils'
-import { Span, Text, Value } from 'components/UI'
+import { Text, Value } from 'components/UI'
 import messages from './messages'
 
 const Invoice = ({ invoice, ticker, currentTicker, showActivityModal, currencyName, intl }) => (
@@ -33,10 +33,8 @@ const Invoice = ({ invoice, ticker, currentTicker, showActivityModal, currencyNa
       className="hint--top-left"
       data-hint={intl.formatMessage({ ...messages.amount })}
     >
-      <Text mb={1} textAlign="right">
-        <Span color="superGreen" fontWeight="normal" mr={1}>
-          +
-        </Span>
+      <Text mb={1} textAlign="right" color="superGreen">
+        {'+ '}
         <Value
           value={invoice.value}
           currency={ticker.currency}

--- a/app/components/Activity/Payment/Payment.js
+++ b/app/components/Activity/Payment/Payment.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Box, Flex } from 'rebass'
 import { btc } from 'lib/utils'
-import { Message, Span, Text, Value } from 'components/UI'
+import { Message, Text, Value } from 'components/UI'
 import { FormattedMessage, FormattedNumber, FormattedTime, injectIntl } from 'react-intl'
 import messages from './messages'
 
@@ -68,13 +68,9 @@ const Payment = ({
         className="hint--top-left"
         data-hint={intl.formatMessage({ ...messages.amount })}
       >
-        <Box css={payment.status == 'failed' ? { opacity: 0.5 } : null}>
+        <Box css={payment.status == 'failed' ? { opacity: 0.3 } : null}>
           <Text mb={1} textAlign="right">
-            {payment.status !== 'failed' && (
-              <Span color="superRed" fontWeight="normal" mr={1}>
-                -
-              </Span>
-            )}
+            {'- '}
             <Value
               value={payment.value}
               currency={ticker.currency}

--- a/app/components/Activity/Transaction/Transaction.js
+++ b/app/components/Activity/Transaction/Transaction.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { FormattedNumber, FormattedTime, FormattedMessage, injectIntl } from 'react-intl'
 import { Box, Flex } from 'rebass'
 import { btc } from 'lib/utils'
-import { Message, Span, Text, Value } from 'components/UI'
+import { Message, Text, Value } from 'components/UI'
 import messages from './messages'
 
 const Transaction = ({
@@ -61,18 +61,9 @@ const Transaction = ({
       className="hint--top-left"
       data-hint={intl.formatMessage({ ...messages.amount })}
     >
-      <Box css={transaction.status == 'failed' ? { opacity: 0.5 } : null}>
-        <Text mb={1} textAlign="right">
-          {transaction.received && (
-            <Span color="superGreen" fontWeight="normal" mr={1}>
-              +
-            </Span>
-          )}
-          {!transaction.received && transaction.status !== 'failed' && (
-            <Span color="superRed" fontWeight="normal" mr={1}>
-              -
-            </Span>
-          )}
+      <Box css={transaction.status == 'failed' ? { opacity: 0.2 } : null}>
+        <Text mb={1} textAlign="right" color={transaction.received ? 'superGreen' : null}>
+          {transaction.received ? `+ ` : `- `}
           <Value
             value={transaction.amount}
             currency={ticker.currency}


### PR DESCRIPTION
## Description:

Make incoming/outgoing transactions more obvious by applying the green colour to the full amount rather than only the very small `+` symbol.

This change is based on designs supplied in Zeplin.

## Motivation and Context:

Fix #1538

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):

**Before:**

![image](https://user-images.githubusercontent.com/200251/53191146-5def1300-360b-11e9-9f46-11a684d3466a.png)

**After:**

![image](https://user-images.githubusercontent.com/200251/53191016-136d9680-360b-11e9-91bd-2e5a9fbfc7ea.png)

## Types of changes:

UI improvement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
