### PR TITLE
fix(ui): disable pointer events on fade

### DIFF
--- a/app/components/LoadingBolt/LoadingBolt.js
+++ b/app/components/LoadingBolt/LoadingBolt.js
@@ -68,9 +68,9 @@ class LoadingBolt extends React.PureComponent {
       <Transition
         native
         items={isLoading}
-        from={{ opacity: 1 }}
-        enter={{ opacity: 1 }}
-        leave={{ opacity: 0 }}
+        from={{ opacity: 1, pointerEvents: 'auto' }}
+        enter={{ opacity: 1, pointerEvents: 'auto' }}
+        leave={{ opacity: 0, pointerEvents: 'none' }}
       >
         {show =>
           show &&

--- a/app/containers/ModalStack.js
+++ b/app/containers/ModalStack.js
@@ -63,9 +63,9 @@ function ModalStack(props) {
     <Transition
       items={modals}
       keys={item => item.id}
-      from={{ opacity: 0 }}
-      enter={{ opacity: 1 }}
-      leave={{ opacity: 0 }}
+      from={{ opacity: 0, pointerEvents: 'auto' }}
+      enter={{ opacity: 1, pointerEvents: 'auto' }}
+      leave={{ opacity: 0, pointerEvents: 'none' }}
     >
       {modal =>
         modal &&


### PR DESCRIPTION
## Description:

Disable pointer events when fading out overlays

## Motivation and Context:

App is unresponsive during a fade out event (loading screen or modal close) - you can't click on anything until the fade out has fully completed.

## How Has This Been Tested?

Manually

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
