### PR TITLE
fix(lnd): show sync screen as early as possible

### DIFF
--- a/app/reducers/utils.js
+++ b/app/reducers/utils.js
@@ -32,8 +32,8 @@ export const isLoadingPerPath = state => {
   }
 
   if (pathname === '/syncing') {
-    const { syncStatus, lightningGrpcActive, blockHeight, lndBlockHeight } = state.lnd
-    return syncStatus === 'pending' || !lightningGrpcActive || !blockHeight || !lndBlockHeight
+    const { syncStatus, lightningGrpcActive } = state.lnd
+    return syncStatus === 'pending' || !lightningGrpcActive
   }
 
   return false

--- a/test/e2e/utils/helpers.js
+++ b/test/e2e/utils/helpers.js
@@ -30,6 +30,7 @@ export const delay = time => new Promise(resolve => setTimeout(() => resolve(), 
 export const cleanTestEnvironment = async () => {
   await killLnd()
   await delay(3000)
+  await killLnd()
   await deleteDatabase()
   await delay(3000)
 }
@@ -37,6 +38,6 @@ export const cleanTestEnvironment = async () => {
 // Clean out test environment.
 export const cleanElectronEnvironment = async ctx => {
   if (ctx.userDataDir) {
-    rimraf.sync(path.join(ctx.userDataDir, 'lnd'), { disableGlob: false })
+    rimraf.sync(path.join(ctx.userDataDir, 'lnd'), { disableGlob: false, maxBusyTries: 10 })
   }
 }


### PR DESCRIPTION
## Description:

Show the sync screen as early as possible.

## Motivation and Context:

If you connect to a local lnd node that is connected to a btcd node that it is not fully synced, the app will be stuck on the loading screen until btcd has completed it's sync and the lnd node starts syncing.

Rather than showing the loading screen, we should show the sync screen as it has additional context about the current sync progress for the user.

The reason it was stuck on the loading screen is because we didn't fetch the current block height from block explorers until lnd had started syncing, and knowledge of the current block height as well as the lnd current sync height was a pre-requisite for hiding the loading screen.

This change updates so that we fetch the current block height from block explorers as soon as the attempt to start lnd is initiated, and removes the requirement to know the lnd current sync height before showing the loading screen.



## How Has This Been Tested?

Manually

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
