### PR TITLE
fix(lnd): defer fetching data until sync complete

### DIFF
--- a/app/components/App/App.js
+++ b/app/components/App/App.js
@@ -34,17 +34,17 @@ class App extends React.Component {
     channelFormProps: PropTypes.object,
     setIsWalletOpen: PropTypes.func.isRequired,
     fetchPeers: PropTypes.func.isRequired,
-    fetchDescribeNetwork: PropTypes.func.isRequired
+    fetchActivityHistory: PropTypes.func.isRequired
   }
 
   componentDidMount() {
-    const { fetchDescribeNetwork, setIsWalletOpen } = this.props
+    const { fetchActivityHistory, setIsWalletOpen } = this.props
 
     // Set wallet open state.
     setIsWalletOpen(true)
 
-    // fetch LN network from nodes POV.
-    fetchDescribeNetwork()
+    // fetch data from lnd.
+    fetchActivityHistory()
 
     // fetch node info.
     this.fetchData()

--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -30,9 +30,9 @@ import {
 } from 'reducers/contactsform'
 import { fetchBalance } from 'reducers/balance'
 import { fetchPeers } from 'reducers/peers'
-import { fetchDescribeNetwork } from 'reducers/network'
 import { showNotification, removeNotification } from 'reducers/notification'
 import { setIsWalletOpen } from 'reducers/wallet'
+import { fetchActivityHistory } from 'reducers/activity'
 import App from 'components/App'
 
 const mapDispatchToProps = {
@@ -44,6 +44,7 @@ const mapDispatchToProps = {
   removeNotification,
   fetchBalance,
   fetchPeers,
+  fetchActivityHistory,
   fetchChannels,
   fetchSuggestedNodes,
   openChannel,
@@ -60,7 +61,6 @@ const mapDispatchToProps = {
   updateContactFormSearchQuery,
   setNode,
   contactFormSelectors,
-  fetchDescribeNetwork,
   setIsWalletOpen,
   showNotification
 }

--- a/app/reducers/activity.js
+++ b/app/reducers/activity.js
@@ -1,10 +1,12 @@
 import { createSelector } from 'reselect'
 import { decodePayReq } from 'lib/utils/crypto'
 
+import { fetchDescribeNetwork } from 'reducers/network'
 import { fetchTransactions } from './transaction'
 import { fetchPayments } from './payment'
 import { fetchInvoices } from './invoice'
 import { fetchBalance } from './balance'
+import { fetchChannels } from './channels'
 
 // ------------------------------------
 // Initial State
@@ -88,6 +90,8 @@ export function toggleExpiredRequests() {
  * Transactions
  */
 export const fetchActivityHistory = () => dispatch => {
+  dispatch(fetchDescribeNetwork())
+  dispatch(fetchChannels())
   dispatch(fetchBalance())
   dispatch(fetchPayments())
   dispatch(fetchInvoices())

--- a/app/reducers/lnd.js
+++ b/app/reducers/lnd.js
@@ -6,8 +6,6 @@ import { fetchBalance } from './balance'
 import { fetchInfo, setHasSynced, infoSelectors } from './info'
 import { putWallet, setActiveWallet, walletSelectors } from './wallet'
 import { onboardingFinished, setSeed } from './onboarding'
-import { fetchChannels } from './channels'
-import { fetchActivityHistory } from './activity'
 
 // ------------------------------------
 // Constants
@@ -103,9 +101,6 @@ export const lightningGrpcActive = (event, lndConfig) => async dispatch => {
 
   // Let the onboarding process know that the wallet has started.
   dispatch(onboardingFinished())
-  //fetch user data. channels, balances, payments, invoices and transactions
-  dispatch(fetchChannels())
-  dispatch(fetchActivityHistory())
 }
 
 // Connected to WalletUnlocker gRPC interface (lnd is ready to unlock or create wallet)


### PR DESCRIPTION
## Description:

Defer fetching activity/channel data from lnd until sync is complete.

## Motivation and Context:

Attempting to fetch channel data can cause neutrino to crash with an error like `unable to find arbitrator`.

There is no need for us to attempt to fetch this data until we mount the App, (after syncing has completed in the case of local neutrino wallets).

## How Has This Been Tested?

Manually

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
