### PR TITLE
 perf(ui): use persistent tabs in channel management

### DIFF
--- a/app/components/Channels/Channels.js
+++ b/app/components/Channels/Channels.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import debounce from 'lodash.debounce'
 import { Panel } from 'components/UI'
+import PersistentTabControl from 'components/TabControl/PersistentTabControl'
 import { ChannelsHeader, ChannelCardList, ChannelSummaryList } from 'components/Channels'
 
 export const VIEW_MODE_SUMMARY = 'VIEW_MODE_SUMMARY'
@@ -55,13 +56,6 @@ class Channels extends React.Component {
       ...rest
     } = this.props
 
-    const VIEW_MODES = {
-      [VIEW_MODE_SUMMARY]: ChannelSummaryList,
-      [VIEW_MODE_CARD]: ChannelCardList
-    }
-
-    const ChannelsView = VIEW_MODES[channelViewMode]
-
     return (
       <Panel {...rest}>
         <Panel.Header mx={4}>
@@ -79,13 +73,22 @@ class Channels extends React.Component {
           />
         </Panel.Header>
         <Panel.Body px={4} pt={2} css={{ 'overflow-y': 'overlay', 'overflow-x': 'hidden' }}>
-          <ChannelsView
-            channels={channels}
-            currencyName={currencyName}
-            openModal={openModal}
-            setSelectedChannel={setSelectedChannel}
-            networkInfo={networkInfo}
-          />
+          <PersistentTabControl activeTab={channelViewMode === VIEW_MODE_CARD ? 0 : 1}>
+            <ChannelCardList
+              channels={channels}
+              currencyName={currencyName}
+              openModal={openModal}
+              setSelectedChannel={setSelectedChannel}
+              networkInfo={networkInfo}
+            />
+            <ChannelSummaryList
+              channels={channels}
+              currencyName={currencyName}
+              openModal={openModal}
+              setSelectedChannel={setSelectedChannel}
+              networkInfo={networkInfo}
+            />
+          </PersistentTabControl>
         </Panel.Body>
       </Panel>
     )

--- a/app/components/TabControl/PersistentTabControl.js
+++ b/app/components/TabControl/PersistentTabControl.js
@@ -1,0 +1,30 @@
+'use strict'
+
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+
+import Tab from './Tab'
+
+const Container = styled.div`
+  display: ${props => (props.isActive ? 'display' : 'none')};
+`
+
+const PersistentTabControl = ({ activeTab, children }) => (
+  <>
+    {React.Children.map(children, (tab, index) => {
+      const isActive = index === activeTab
+      return (
+        <Container key={index} isActive={isActive}>
+          <Tab isActive={isActive}>{tab}</Tab>
+        </Container>
+      )
+    })}
+  </>
+)
+
+PersistentTabControl.propTypes = {
+  activeTab: PropTypes.number.isRequired,
+  children: PropTypes.node.isRequired
+}
+export default PersistentTabControl

--- a/app/components/TabControl/Tab.js
+++ b/app/components/TabControl/Tab.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+// don't update a tab if it's currently hidden
+const shouldUpdate = (prevProps, nextProps) => !nextProps.isActive
+
+const Tab = React.memo(({ children }) => <>{children}</>, shouldUpdate)
+Tab.displayName = 'Tab'
+
+Tab.propTypes = {
+  children: PropTypes.node.isRequired
+}
+
+export default Tab


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Improve performance of channel management tab view
<!--- Describe your changes in detail -->

## Motivation and Context:
Currently we unmount current tab when switching between card and list view, which results in some significant delay upon that action. This PR introduces persistent tab control component which hides inactive tabs without unmounting them.

One side effect of this change is that switching between tabs retains their respective scroll positions. If  this is totally undesired, this can be mitigated probably. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes:
Perf improvement
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
