### PR TITLE
fix(channels): display wallet balance on create form

### DIFF
--- a/app/components/Channels/ChannelCreateForm.js
+++ b/app/components/Channels/ChannelCreateForm.js
@@ -38,7 +38,7 @@ class ChannelCreateForm extends React.Component {
     activeWalletSettings: PropTypes.shape({
       type: PropTypes.string.isRequired
     }).isRequired,
-    channelBalance: PropTypes.number.isRequired,
+    walletBalance: PropTypes.number.isRequired,
     currency: PropTypes.string.isRequired,
     currencyName: PropTypes.string.isRequired,
     isQueryingFees: PropTypes.bool,
@@ -118,7 +118,7 @@ class ChannelCreateForm extends React.Component {
     const {
       intl,
       activeWalletSettings,
-      channelBalance,
+      walletBalance,
       currencyName,
       isQueryingFees,
       onchainFees,
@@ -256,7 +256,7 @@ class ChannelCreateForm extends React.Component {
                 <Text textAlign="center">
                   <FormattedMessage {...messages.open_channel_form_onchain_balance} />
                   {` `}
-                  <CryptoValue value={channelBalance} />
+                  <CryptoValue value={walletBalance} />
                   {` `}
                   {currencyName}
                 </Text>

--- a/app/containers/Channels/ChannelCreateForm.js
+++ b/app/containers/Channels/ChannelCreateForm.js
@@ -11,7 +11,7 @@ const mapStateToProps = state => ({
   activeWalletSettings: walletSelectors.activeWalletSettings(state),
   searchQuery: state.contactsform.searchQuery,
   currency: tickerSelectors.currency(state),
-  channelBalance: state.balance.channelBalance,
+  walletBalance: state.balance.walletBalance,
   currencyName: tickerSelectors.currencyName(state),
   isQueryingFees: state.pay.isQueryingFees,
   onchainFees: state.pay.onchainFees


### PR DESCRIPTION
## Description:

Display the wallet balance rather than the channel balance in the channel create form footer message.

## Motivation and Context:

Fix #1648

## How Has This Been Tested?

Manually

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
