### PR TITLE
fix(ui): disable launch button when opening wallet

### DIFF
--- a/app/components/Home/WalletLauncher.js
+++ b/app/components/Home/WalletLauncher.js
@@ -98,6 +98,7 @@ class WalletLauncher extends React.Component {
     lightningGrpcActive: PropTypes.bool.isRequired,
     walletUnlockerGrpcActive: PropTypes.bool.isRequired,
     startLndError: PropTypes.object,
+    startingLnd: PropTypes.bool.isRequired,
     clearStartLndError: PropTypes.func.isRequired,
     putWallet: PropTypes.func.isRequired,
     showNotification: PropTypes.func.isRequired,
@@ -289,7 +290,7 @@ class WalletLauncher extends React.Component {
   }
 
   render() {
-    const { wallet } = this.props
+    const { wallet, startingLnd } = this.props
     const actionBarButtons = (
       <>
         <Button type="button" key="cancel" variant="secondary" mr={6} onClick={this.resetForm}>
@@ -314,7 +315,13 @@ class WalletLauncher extends React.Component {
                   <WalletHeader wallet={wallet} />
                 </Box>
                 <Flex ml="auto" justifyContent="flex-end" flexDirection="column">
-                  <Button type="submit" size="small" ml={2}>
+                  <Button
+                    type="submit"
+                    size="small"
+                    ml={2}
+                    disabled={startingLnd}
+                    processing={startingLnd}
+                  >
                     <FormattedMessage {...messages.launch_wallet_button_text} />
                   </Button>
                 </Flex>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Disable wallet launch button while starting LND
<!--- Describe your changes in detail -->

## Motivation and Context:
Currently there is no response from UI when launching wallet. User can click `launch` button multiple times while wallet is starting.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes:
Bugfix
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
