### PR TITLE
fix(sync): ensure QR code shown when syncing

### DIFF
--- a/app/components/Syncing/Syncing.js
+++ b/app/components/Syncing/Syncing.js
@@ -145,7 +145,7 @@ class Syncing extends Component {
         </Panel.Header>
 
         <Panel.Body width={9 / 16} mx="auto" mb={3}>
-          {hasSynced === false && address && address.length && (
+          {!hasSynced && address && address.length && (
             <Flex
               alignItems="center"
               flexDirection="column"

--- a/app/reducers/lnd.js
+++ b/app/reducers/lnd.js
@@ -1,9 +1,8 @@
 import { send } from 'redux-electron-ipc'
 import { createSelector } from 'reselect'
 import { showSystemNotification } from 'lib/utils/notifications'
-import db from 'store/db'
 import { fetchBalance } from './balance'
-import { fetchInfo, setHasSynced, infoSelectors } from './info'
+import { fetchInfo, setHasSynced } from './info'
 import { putWallet, setActiveWallet, walletSelectors } from './wallet'
 import { onboardingFinished, setSeed } from './onboarding'
 
@@ -45,21 +44,9 @@ export const FETCH_SEED_SUCCESS = 'FETCH_SEED_SUCCESS'
 // ------------------------------------
 
 // Receive IPC event for LND sync status change.
-export const lndSyncStatus = (event, status) => async (dispatch, getState) => {
+export const lndSyncStatus = (event, status) => async dispatch => {
   const notifTitle = 'Lightning Node Synced'
   const notifBody = "Visa who? You're your own payment processor now!"
-
-  // Persist the fact that the wallet has been synced at least once.
-  const state = getState()
-  const pubKey = state.info.data.identity_pubkey
-  const hasSynced = infoSelectors.hasSynced(state)
-
-  if (pubKey && !hasSynced) {
-    const updated = await db.nodes.update(pubKey, { hasSynced: true })
-    if (!updated) {
-      await db.nodes.add({ id: pubKey, hasSynced: true })
-    }
-  }
 
   switch (status) {
     case 'waiting':
@@ -71,11 +58,12 @@ export const lndSyncStatus = (event, status) => async (dispatch, getState) => {
     case 'complete':
       dispatch({ type: SET_SYNC_STATUS_COMPLETE })
 
-      dispatch(setHasSynced(true))
-
       // Fetch data now that we know LND is synced
       dispatch(fetchBalance())
       dispatch(fetchInfo())
+
+      // Persist the fact that the wallet has been synced at least once.
+      dispatch(setHasSynced(true))
 
       // HTML 5 desktop notification for the new transaction
       showSystemNotification(notifTitle, notifBody)


### PR DESCRIPTION
## Description:

Ensure that we only set the `hasSynced` property when a sync completes, and always show the QR code in the sync process unless this has been set.

## Motivation and Context:

Fix #1367

## How Has This Been Tested?

Manually:

1. Create a new wallet - verify that QR code shows when syncing
2. Exit sync process early, and reload the wallet - verify that QR code shows when syncing
3. Wait for sync process to complete, exit the wallet, reload the wallet - verify that QR code does not show

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
