### PR TITLE
feat(channels): validate channel amount input

### DIFF
--- a/app/components/Channels/ChannelCreateForm.js
+++ b/app/components/Channels/ChannelCreateForm.js
@@ -257,6 +257,7 @@ class ChannelCreateForm extends React.Component {
           validateOnChange={formState.submits > 0}
           validateOnBlur={formState.submits > 0}
           required
+          css={{ height: '88px' }}
         />
 
         <Bar my={3} opacity={0.3} />

--- a/app/components/Channels/ChannelCreateForm.js
+++ b/app/components/Channels/ChannelCreateForm.js
@@ -264,12 +264,7 @@ class ChannelCreateForm extends React.Component {
 
         <Flex justifyContent="space-between" alignItems="center">
           <Box>
-            <RadioGroup
-              field="speed"
-              label={intl.formatMessage({ ...messages.fee })}
-              description={<FormattedMessage {...messages[speed.toLowerCase() + '_description']} />}
-              required
-            >
+            <RadioGroup field="speed" label={intl.formatMessage({ ...messages.fee })} required>
               <Flex>
                 {speeds.map(speed => (
                   <Radio
@@ -297,11 +292,16 @@ class ChannelCreateForm extends React.Component {
             {!isQueryingFees && !fee && <FormattedMessage {...messages.fee_unknown} />}
 
             {!isQueryingFees && fee && (
-              <>
-                <CryptoValue value={fee} />
-                <CryptoSelector mx={2} />
-                <FormattedMessage {...messages.fee_per_byte} />
-              </>
+              <Flex flexDirection="column" alignItems="flex-end">
+                <Box>
+                  <CryptoValue value={fee} />
+                  <CryptoSelector mx={2} />
+                  <FormattedMessage {...messages.fee_per_byte} />
+                </Box>
+                <Text color="gray">
+                  <FormattedMessage {...messages[speed.toLowerCase() + '_description']} />
+                </Text>
+              </Flex>
             )}
           </Box>
         </Flex>

--- a/app/components/Channels/messages.js
+++ b/app/components/Channels/messages.js
@@ -7,6 +7,7 @@ export default defineMessages({
   calculating: 'calculating',
   channels: 'Channels',
   capacity: 'Capacity',
+  error_not_enough_funds: 'Not enough funds',
   total_capacity: 'Total Capacity',
   more_button_text: 'More',
   create_new_button_text: 'Create New',

--- a/app/components/UI/CurrencyFieldGroup.js
+++ b/app/components/UI/CurrencyFieldGroup.js
@@ -37,6 +37,12 @@ class CurrencyFieldGroup extends React.Component {
     initialAmountFiat: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     /** Boolean indicating if form fields are required */
     required: PropTypes.bool,
+    /** Additional field validation */
+    validate: PropTypes.func.isRequired,
+    /** Boolean indicating if form fields should validate on blur */
+    validateOnBlur: PropTypes.bool,
+    /** Boolean indicating if form fields should validate on change */
+    validateOnChange: PropTypes.bool,
     /** Set the current cryptocurrency. */
     setCryptoCurrency: PropTypes.func.isRequired,
     /** Set the current fiat currency */
@@ -46,7 +52,9 @@ class CurrencyFieldGroup extends React.Component {
   static defaultProps = {
     disabled: false,
     initialAmountCrypto: null,
-    initialAmountFiat: null
+    initialAmountFiat: null,
+    validateOnBlur: true,
+    validateOnChange: true
   }
 
   /**
@@ -96,13 +104,16 @@ class CurrencyFieldGroup extends React.Component {
       initialAmountCrypto,
       initialAmountFiat,
       required,
+      validate,
+      validateOnBlur,
+      validateOnChange,
       ...rest
     } = this.props
 
     return (
       <Box {...rest}>
-        <Flex justifyContent="space-between" alignItems="center">
-          <Flex width={6 / 13} alignItems="center">
+        <Flex justifyContent="space-between">
+          <Flex width={6 / 13}>
             <Box width={150}>
               <CryptoAmountInput
                 field="amountCrypto"
@@ -112,8 +123,9 @@ class CurrencyFieldGroup extends React.Component {
                 required={required}
                 label={<FormattedMessage {...messages.amount} />}
                 width={150}
-                validateOnChange
-                validateOnBlur
+                validate={validate}
+                validateOnBlur={validateOnBlur}
+                validateOnChange={validateOnChange}
                 onChange={this.handleAmountCryptoChange}
                 forwardedRef={this.forwardedRef}
                 disabled={disabled}
@@ -123,14 +135,14 @@ class CurrencyFieldGroup extends React.Component {
               activeKey={cryptoCurrency}
               items={cryptoCurrencies}
               onChange={this.handleCryptoCurrencyChange}
-              mt={3}
+              mt={36}
               ml={2}
             />
           </Flex>
-          <Flex alignItems="center" justifyContent="center" width={1 / 11} mt={3}>
+          <Flex justifyContent="center" width={1 / 11} mt={38}>
             =
           </Flex>
-          <Flex width={6 / 13} alignItems="center">
+          <Flex width={6 / 13}>
             <Box width={150} ml="auto">
               <FiatAmountInput
                 field="amountFiat"
@@ -149,7 +161,7 @@ class CurrencyFieldGroup extends React.Component {
               activeKey={fiatCurrency}
               items={fiatCurrencies}
               onChange={this.handleFiatCurrencyChange}
-              mt={3}
+              mt={36}
               ml={2}
             />
           </Flex>

--- a/app/components/UI/Input.js
+++ b/app/components/UI/Input.js
@@ -208,7 +208,7 @@ class Input extends React.Component {
           <Label htmlFor={field} mb={2}>
             {label}
             {required && (
-              <Span fontSize="s" css={{ 'vertical-align': 'super' }}>
+              <Span fontSize="s" css={{ 'vertical-align': 'top' }}>
                 {' '}
                 *
               </Span>

--- a/app/components/UI/NodePubkeyInput.js
+++ b/app/components/UI/NodePubkeyInput.js
@@ -63,7 +63,7 @@ const NodePubkeyInputAsField = asField(({ fieldState, fieldApi, ...rest }) => {
     <React.Fragment>
       <Input {...rest} />
       {value && !error && (
-        <Message variant="success" mt={1}>
+        <Message variant="success" mt={2}>
           <FormattedMessage {...messages.valid_pubkey} />
         </Message>
       )}

--- a/app/components/UI/RadioGroup.js
+++ b/app/components/UI/RadioGroup.js
@@ -11,7 +11,7 @@ const RadioGroup = ({ label, field, description, required, children, ...rest }) 
       <Label htmlFor={field} mb={2}>
         {label}
         {required && (
-          <Span fontSize="s" css={{ 'vertical-align': 'super' }}>
+          <Span fontSize="s" css={{ 'vertical-align': 'top' }}>
             {' '}
             *
           </Span>

--- a/app/components/UI/TextArea.js
+++ b/app/components/UI/TextArea.js
@@ -177,7 +177,7 @@ class TextArea extends React.PureComponent {
           <Label htmlFor={field} mb={2}>
             {label}
             {required && (
-              <Span fontSize="s" css={{ 'vertical-align': 'super' }}>
+              <Span fontSize="s" css={{ 'vertical-align': 'top' }}>
                 {' '}
                 *
               </Span>

--- a/app/containers/Channels/ChannelCreateForm.js
+++ b/app/containers/Channels/ChannelCreateForm.js
@@ -3,6 +3,7 @@ import ChannelCreateForm from 'components/Channels/ChannelCreateForm'
 import { tickerSelectors } from 'reducers/ticker'
 import { openChannel } from 'reducers/channels'
 import { queryFees } from 'reducers/pay'
+import { balanceSelectors } from 'reducers/balance'
 import { updateContactFormSearchQuery, contactFormSelectors } from 'reducers/contactsform'
 import { walletSelectors } from 'reducers/wallet'
 import { showNotification } from 'reducers/notification'
@@ -12,7 +13,7 @@ const mapStateToProps = state => ({
   searchQuery: state.contactsform.searchQuery,
   selectedNodeDisplayName: contactFormSelectors.selectedNodeDisplayName(state),
   currency: tickerSelectors.currency(state),
-  walletBalance: state.balance.walletBalance,
+  walletBalance: balanceSelectors.walletBalanceConfirmed(state),
   currencyName: tickerSelectors.currencyName(state),
   isQueryingFees: state.pay.isQueryingFees,
   onchainFees: state.pay.onchainFees

--- a/app/lib/lnd/methods/index.js
+++ b/app/lib/lnd/methods/index.js
@@ -139,7 +139,7 @@ export default function(lightning, log, event, msg, data) {
       )
         .then(balance => {
           event.sender.send('receiveBalance', {
-            walletBalance: balance[0].total_balance,
+            walletBalance: balance[0],
             channelBalance: balance[1].balance
           })
           return balance

--- a/app/reducers/balance.js
+++ b/app/reducers/balance.js
@@ -35,20 +35,23 @@ const ACTION_HANDLERS = {
   [RECEIVE_BALANCE]: (state, { walletBalance, channelBalance }) => ({
     ...state,
     balanceLoading: false,
-    walletBalance,
+    walletBalance: walletBalance.total_balance,
+    walletBalanceConfirmed: walletBalance.confirmed_balance,
+    walletBalanceUnconfirmed: walletBalance.unconfirmed_balance,
     channelBalance
   })
 }
 
-const channelBalanceSelector = state => state.balance.channelBalance
-const walletBalanceSelector = state => state.balance.walletBalance
-
 // Selectors
 const balanceSelectors = {}
+balanceSelectors.channelBalance = state => state.balance.channelBalance
+balanceSelectors.walletBalance = state => state.balance.walletBalance
+balanceSelectors.walletBalanceConfirmed = state => state.balance.walletBalanceConfirmed
+balanceSelectors.walletBalanceUnconfirmed = state => state.balance.walletBalanceUnconfirmed
 
 balanceSelectors.totalBalance = createSelector(
-  channelBalanceSelector,
-  walletBalanceSelector,
+  balanceSelectors.channelBalance,
+  balanceSelectors.walletBalance,
   (channelBalance, walletBalance) => (channelBalance || 0) + (walletBalance || 0)
 )
 
@@ -60,6 +63,8 @@ export { balanceSelectors }
 const initialState = {
   balanceLoading: false,
   walletBalance: null,
+  walletBalanceConfirmed: null,
+  walletBalanceUnconfirmed: null,
   channelBalance: null
 }
 

--- a/app/translations/af-ZA.json
+++ b/app/translations/af-ZA.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/ar-SA.json
+++ b/app/translations/ar-SA.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/bg-BG.json
+++ b/app/translations/bg-BG.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/ca-ES.json
+++ b/app/translations/ca-ES.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/cs-CZ.json
+++ b/app/translations/cs-CZ.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/da-DK.json
+++ b/app/translations/da-DK.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/de-DE.json
+++ b/app/translations/de-DE.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/el-GR.json
+++ b/app/translations/el-GR.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "In the event of an uncooperative close (force close) of this channel, the time lock is the number of blocks you will have to wait before you can claim your funds again.",
   "components.Channels.csv_delay_label": "Time Lock",
   "components.Channels.csv_delay_value": "{csvDelay, plural, zero {0 blocks} one {1 block} other {{csvDelay} blocks}}",
+  "components.Channels.error_not_enough_funds": "Not enough funds",
   "components.Channels.fee": "Fee",
   "components.Channels.fee_per_byte": "per byte",
   "components.Channels.fee_unknown": "unknown",

--- a/app/translations/es-ES.json
+++ b/app/translations/es-ES.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/fi-FI.json
+++ b/app/translations/fi-FI.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/fr-FR.json
+++ b/app/translations/fr-FR.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/ga-IE.json
+++ b/app/translations/ga-IE.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/he-IL.json
+++ b/app/translations/he-IL.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/hi-IN.json
+++ b/app/translations/hi-IN.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/hr-HR.json
+++ b/app/translations/hr-HR.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/hu-HU.json
+++ b/app/translations/hu-HU.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/it-IT.json
+++ b/app/translations/it-IT.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/ja-JP.json
+++ b/app/translations/ja-JP.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/ko-KR.json
+++ b/app/translations/ko-KR.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/nl-NL.json
+++ b/app/translations/nl-NL.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/no-NO.json
+++ b/app/translations/no-NO.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/pl-PL.json
+++ b/app/translations/pl-PL.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/pt-BR.json
+++ b/app/translations/pt-BR.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/pt-PT.json
+++ b/app/translations/pt-PT.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/ro-RO.json
+++ b/app/translations/ro-RO.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/ru-RU.json
+++ b/app/translations/ru-RU.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/sr-SP.json
+++ b/app/translations/sr-SP.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/sv-SE.json
+++ b/app/translations/sv-SE.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/tr-TR.json
+++ b/app/translations/tr-TR.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/uk-UA.json
+++ b/app/translations/uk-UA.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/vi-VN.json
+++ b/app/translations/vi-VN.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/zh-CN.json
+++ b/app/translations/zh-CN.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/app/translations/zh-TW.json
+++ b/app/translations/zh-TW.json
@@ -78,6 +78,7 @@
   "components.Channels.csv_delay_description": "",
   "components.Channels.csv_delay_label": "",
   "components.Channels.csv_delay_value": "",
+  "components.Channels.error_not_enough_funds": "",
   "components.Channels.fee": "",
   "components.Channels.fee_per_byte": "",
   "components.Channels.fee_unknown": "",

--- a/stories/Provider.js
+++ b/stories/Provider.js
@@ -81,5 +81,7 @@ store.dispatch({
 store.dispatch({
   type: 'RECEIVE_BALANCE',
   walletBalance: 47238944,
+  walletBalanceConfirmed: 37236599,
+  walletBalanceUnconfirmed: 10002345,
   channelBalance: 256474
 })

--- a/stories/containers/pay.stories.js
+++ b/stories/containers/pay.stories.js
@@ -12,7 +12,9 @@ import { Window, mockCreateInvoice } from '../helpers'
 
 const data = {
   cryptoName: 'Bitcoin',
-  walletBalance: 10000000,
+  walletBalance: 47238944,
+  walletBalanceConfirmed: 37236599,
+  walletBalanceUnconfirmed: 10002345,
   channelBalance: 25000,
   onchainFees: {
     fastestFee: 100,

--- a/test/unit/reducers/__snapshots__/balance.spec.js.snap
+++ b/test/unit/reducers/__snapshots__/balance.spec.js.snap
@@ -1,18 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`reducers balanceReducer should handle DECREMENT_COUNTER 1`] = `
-Object {
-  "balanceLoading": false,
-  "channelBalance": undefined,
-  "walletBalance": undefined,
-}
-`;
-
-exports[`reducers balanceReducer should handle INCREMENT_COUNTER 1`] = `
+exports[`reducers balanceReducer should handle GET_BALANCE 1`] = `
 Object {
   "balanceLoading": true,
   "channelBalance": null,
   "walletBalance": null,
+  "walletBalanceConfirmed": null,
+  "walletBalanceUnconfirmed": null,
+}
+`;
+
+exports[`reducers balanceReducer should handle RECEIVE_BALANCE 1`] = `
+Object {
+  "balanceLoading": false,
+  "channelBalance": 1,
+  "walletBalance": 1,
+  "walletBalanceConfirmed": 1,
+  "walletBalanceUnconfirmed": 1,
 }
 `;
 
@@ -21,6 +25,8 @@ Object {
   "balanceLoading": false,
   "channelBalance": null,
   "walletBalance": null,
+  "walletBalanceConfirmed": null,
+  "walletBalanceUnconfirmed": null,
 }
 `;
 
@@ -29,5 +35,7 @@ Object {
   "balanceLoading": false,
   "channelBalance": null,
   "walletBalance": null,
+  "walletBalanceConfirmed": null,
+  "walletBalanceUnconfirmed": null,
 }
 `;

--- a/test/unit/reducers/balance.spec.js
+++ b/test/unit/reducers/balance.spec.js
@@ -6,12 +6,20 @@ describe('reducers', () => {
       expect(balanceReducer(undefined, {})).toMatchSnapshot()
     })
 
-    it('should handle INCREMENT_COUNTER', () => {
+    it('should handle GET_BALANCE', () => {
       expect(balanceReducer(undefined, { type: GET_BALANCE })).toMatchSnapshot()
     })
 
-    it('should handle DECREMENT_COUNTER', () => {
-      expect(balanceReducer(undefined, { type: RECEIVE_BALANCE })).toMatchSnapshot()
+    it('should handle RECEIVE_BALANCE', () => {
+      const walletBalance = {
+        total_balance: 1,
+        confirmed_balance: 1,
+        unconfirmed_balance: 1
+      }
+      const channelBalance = 1
+      expect(
+        balanceReducer(undefined, { type: RECEIVE_BALANCE, walletBalance, channelBalance })
+      ).toMatchSnapshot()
     })
 
     it('should handle unknown action type', () => {


### PR DESCRIPTION
## Description:

Do not allow submission of the channel create form if the amount is greater than the total confirmed wallet balance.

**NOTE 1:** I have updated the footer text to show the confirmed wallet balance, rather than the total balance, since only confirmed UTXOs are relevant in this context.

**NOTE 2:** We only know the per-byte fee, so can not fully cater for the fee amounts. We need to wait for the new fee estimation api in lnd in order to know the full fee value.

## Motivation and Context:

Resolves #1494

## How Has This Been Tested?

Manually

## Screenshots:

![image](https://user-images.githubusercontent.com/200251/53576339-b9715180-3b73-11e9-96d2-e096a3ecf579.png)

## Types of changes:

Enhancement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
