### PR TITLE
fix(ui): make channel search results header more informative

### DIFF
--- a/app/components/Channels/ChannelNodeSearch.js
+++ b/app/components/Channels/ChannelNodeSearch.js
@@ -113,7 +113,10 @@ class ChannelNodeSearch extends React.PureComponent {
         {searchQuery && (
           <>
             <Heading.h1 mt={4}>
-              <FormattedMessage {...messages.node_search_results_header} />
+              <FormattedMessage
+                {...messages.node_search_results_header}
+                values={{ count: filteredNetworkNodes.length }}
+              />
             </Heading.h1>
             {filteredNetworkNodes.length > 0 ? (
               <SearchResults

--- a/app/components/Channels/messages.js
+++ b/app/components/Channels/messages.js
@@ -79,6 +79,6 @@ export default defineMessages({
     'Make funds available for sending over the Lightning Network by opening channels to other nodes on the network.',
   node_search_placeholder: 'Search the network',
   node_search_description: 'Search for nodes by name, public key, or paste their pubkey@host',
-  node_search_results_header: 'All Nodes',
+  node_search_results_header: '{count, plural, =0 {No results}  other {Search results ({count})}}',
   node_suggestions_title: 'Suggested Nodes'
 })

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -91,7 +91,7 @@
   "components.Channels.node_search_description": "Search for nodes by name, public key, or paste their pubkey@host",
   "components.Channels.node_search_form_description": "Make funds available for sending over the Lightning Network by opening channels to other nodes on the network.",
   "components.Channels.node_search_placeholder": "Search the network",
-  "components.Channels.node_search_results_header": "All Nodes",
+  "components.Channels.node_search_results_header": "{count, plural, =0 {No results} other {Search results ({count})}}",
   "components.Channels.node_suggestions_title": "Suggested Nodes",
   "components.Channels.num_updates_description": "The total number of updates within this channel.",
   "components.Channels.num_updates_label": "Number of Updates",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Make channel search results header more informative
<!--- Describe your changes in detail -->

## Motivation and Context:
Right we have generic `All nodes` header for any search case (including no results) which is not very informatove
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/14069193/53595379-c4dd7080-3ba5-11e9-818f-6bb28be9337c.png)

![image](https://user-images.githubusercontent.com/14069193/53595385-cc047e80-3ba5-11e9-8412-0f6341760a99.png)

## Types of changes:
Enhancement
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
