### PR TITLE
 fix(activity): show limbo amount for force close transactions

### DIFF
--- a/app/components/Activity/Transaction/Transaction.js
+++ b/app/components/Activity/Transaction/Transaction.js
@@ -7,7 +7,9 @@ import { CryptoValue, FiatValue } from 'containers/UI'
 import messages from './messages'
 
 const Transaction = ({ transaction, showActivityModal, currencyName, intl }) => {
-  let type = transaction.received ? 'received' : 'sent'
+  const amount = transaction.amount || transaction.limboAmount || 0
+  const isIncoming = transaction.received || transaction.limboAmount > 0
+  let type = isIncoming ? 'received' : 'sent'
   if (transaction.isFunding) {
     type = 'funding'
   } else if (transaction.isClosing) {
@@ -67,13 +69,13 @@ const Transaction = ({ transaction, showActivityModal, currencyName, intl }) => 
         data-hint={intl.formatMessage({ ...messages.amount })}
       >
         <Box css={transaction.status == 'failed' ? { opacity: 0.2 } : null}>
-          <Text mb={1} textAlign="right" color={transaction.received ? 'superGreen' : null}>
-            {transaction.received ? `+ ` : `- `}
-            <CryptoValue value={transaction.amount} />
+          <Text mb={1} textAlign="right" color={isIncoming ? 'superGreen' : null}>
+            {isIncoming ? `+ ` : `- `}
+            <CryptoValue value={amount} />
             <i> {currencyName}</i>
           </Text>
           <Text textAlign="right" color="gray" fontSize="xs" fontWeight="normal">
-            <FiatValue value={transaction.amount} style="currency" />
+            <FiatValue value={amount} style="currency" />
           </Text>
         </Box>
       </Box>

--- a/app/components/Activity/TransactionModal/TransactionModal.js
+++ b/app/components/Activity/TransactionModal/TransactionModal.js
@@ -4,10 +4,11 @@ import get from 'lodash.get'
 import { FormattedDate, FormattedTime, FormattedMessage, FormattedNumber } from 'react-intl'
 import { Flex } from 'rebass'
 import { blockExplorer } from 'lib/utils'
-import { Bar, DataRow, Header, Link, Panel, Text } from 'components/UI'
+import { Bar, DataRow, Header, Link, Panel, Span, Text } from 'components/UI'
 import { CryptoSelector, CryptoValue, FiatSelector, FiatValue } from 'containers/UI'
 import { Truncate } from 'components/Util'
 import Onchain from 'components/Icon/Onchain'
+import Padlock from 'components/Icon/Padlock'
 import messages from './messages'
 
 export default class TransactionModal extends React.PureComponent {
@@ -37,14 +38,14 @@ export default class TransactionModal extends React.PureComponent {
   render() {
     const { item, ...rest } = this.props
     const destAddress = get(item, 'dest_addresses[0]')
+    const amount = item.amount || item.limboAmount || 0
+    const isIncoming = item.received || item.limboAmount > 0
 
     return (
       <Panel {...rest}>
         <Panel.Header>
           <Header
-            title={
-              <FormattedMessage {...messages[item.received ? 'title_received' : 'title_sent']} />
-            }
+            title={<FormattedMessage {...messages[isIncoming ? 'title_received' : 'title_sent']} />}
             subtitle={<FormattedMessage {...messages.subtitle} />}
             logo={<Onchain height="45px" width="45px" />}
           />
@@ -57,7 +58,7 @@ export default class TransactionModal extends React.PureComponent {
             right={
               <Flex alignItems="center">
                 <CryptoSelector mr={2} />
-                <CryptoValue value={item.amount} fontSize="xxl" />
+                <CryptoValue value={amount} fontSize="xxl" />
               </Flex>
             }
           />
@@ -69,7 +70,7 @@ export default class TransactionModal extends React.PureComponent {
             right={
               <Flex alignItems="center">
                 <FiatSelector mr={2} />
-                <FiatValue value={item.amount} />
+                <FiatValue value={amount} />
               </Flex>
             }
           />
@@ -127,7 +128,7 @@ export default class TransactionModal extends React.PureComponent {
 
           <Bar />
 
-          {!item.received && (
+          {!isIncoming && (
             <>
               <DataRow
                 left={<FormattedMessage {...messages.fee} />}
@@ -147,16 +148,32 @@ export default class TransactionModal extends React.PureComponent {
             left={<FormattedMessage {...messages.status} />}
             right={
               item.block_height ? (
-                <Link
-                  className="hint--bottom-left"
-                  data-hint={item.block_hash}
-                  onClick={() => this.showBlock(item.block_hash)}
-                >
-                  <FormattedMessage
-                    {...messages.block_height}
-                    values={{ height: item.block_height }}
-                  />
-                </Link>
+                <>
+                  <Link
+                    className="hint--bottom-left"
+                    data-hint={item.block_hash}
+                    onClick={() => this.showBlock(item.block_hash)}
+                  >
+                    <FormattedMessage
+                      {...messages.block_height}
+                      values={{ height: item.block_height }}
+                    />
+                  </Link>
+
+                  {item.maturityHeight && (
+                    <Flex mt={1} alignItems="center">
+                      <Span color="gray" fontSize="s" mr={1}>
+                        <Padlock />
+                      </Span>
+                      <Text>
+                        <FormattedMessage
+                          {...messages.maturity_height}
+                          values={{ height: item.maturityHeight }}
+                        />
+                      </Text>
+                    </Flex>
+                  )}
+                </>
               ) : (
                 <FormattedMessage {...messages.unconfirmed} />
               )

--- a/app/components/Activity/TransactionModal/messages.js
+++ b/app/components/Activity/TransactionModal/messages.js
@@ -12,6 +12,7 @@ export default defineMessages({
   current_value: 'Current value',
   address: 'Address',
   block_height: 'Confirmed in block {height}',
+  maturity_height: 'Locked until block {height} ',
   tx_hash: 'Transaction ID',
   unconfirmed: 'Unconfirmed'
 })

--- a/app/reducers/activity.js
+++ b/app/reducers/activity.js
@@ -282,7 +282,9 @@ const allActivity = createSelector(
       ...paymentsSending,
       ...transactionsSending,
       ...payments,
-      ...transactions.filter(transaction => !transaction.isFunding && !transaction.isClosing),
+      ...transactions.filter(
+        transaction => !transaction.isFunding && !transaction.isClosing && !transaction.isPending
+      ),
       ...invoices.filter(invoice => invoice.settled || !invoiceExpired(invoice))
     ]
     return prepareData(allData, searchText)
@@ -301,7 +303,11 @@ const sentActivity = createSelector(
       ...transactionsSending,
       ...payments,
       ...transactions.filter(
-        transaction => !transaction.received && !transaction.isFunding && !transaction.isClosing
+        transaction =>
+          !transaction.received &&
+          !transaction.isFunding &&
+          !transaction.isClosing &&
+          !transaction.isPending
       )
     ]
     return prepareData(allData, searchText)
@@ -316,7 +322,11 @@ const receivedActivity = createSelector(
     const allData = [
       ...invoices.filter(invoice => invoice.settled),
       ...transactions.filter(
-        transaction => transaction.received && !transaction.isFunding && !transaction.isClosing
+        transaction =>
+          transaction.received &&
+          !transaction.isFunding &&
+          !transaction.isClosing &&
+          !transaction.isPending
       )
     ]
     return prepareData(allData, searchText)
@@ -354,7 +364,7 @@ const internalActivity = createSelector(
   transactionsSelector,
   (searchText, transactions) => {
     const allData = transactions.filter(
-      transaction => transaction.isFunding || transaction.isClosing
+      transaction => transaction.isFunding || (transaction.isClosing && !transaction.isPending)
     )
     return prepareData(allData, searchText)
   }

--- a/app/reducers/transaction.js
+++ b/app/reducers/transaction.js
@@ -242,7 +242,9 @@ transactionsSelectors.transactionsSelector = createSelector(
         closeType: closedChannel ? closedChannel.close_type : null,
         isFunding: Boolean(fundedChannel),
         isClosing: Boolean(closedChannel),
-        isPending: Boolean(pendingChannel)
+        isPending: Boolean(pendingChannel),
+        limboAmount: pendingChannel && pendingChannel.limbo_balance,
+        maturityHeight: pendingChannel && pendingChannel.maturity_height
       }
     })
 )


### PR DESCRIPTION
## Description:

Show channel limbo amount and block maturity height for transactions that relate to channels that are in the process of a force close.

**NOTE:** This PR builds on the work in #1677 which should be merged first.

## Motivation and Context:

Fix #1176

## How Has This Been Tested?

Force close a channel, when the remote party is offline. This should put the channel in a pending force close status. Then, view the `Pending` tab in the activity list and verify that the amount is what you expect. Then, click the transaction to the see the details and verify that the amount is correct and that the block maturity is displayed.

Previously, the amount would show as 0

## Screenshots:

![image](https://user-images.githubusercontent.com/200251/53653451-9ca84d00-3c4b-11e9-8784-fd1ea584adf8.png)

![image](https://user-images.githubusercontent.com/200251/53653435-92864e80-3c4b-11e9-9f31-d59fb76428c5.png)

## Types of changes:

Enhancement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
