### PR TITLE
feat(wallet): show confirmations in transaction detail

### DIFF
--- a/app/components/Activity/TransactionModal/TransactionModal.js
+++ b/app/components/Activity/TransactionModal/TransactionModal.js
@@ -1,9 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { FormattedDate, FormattedTime, FormattedMessage } from 'react-intl'
+import get from 'lodash.get'
+import { FormattedDate, FormattedTime, FormattedMessage, FormattedNumber } from 'react-intl'
 import { Flex } from 'rebass'
 import { blockExplorer } from 'lib/utils'
-import { Bar, DataRow, Header, Link, Panel } from 'components/UI'
+import { Bar, DataRow, Header, Link, Panel, Text } from 'components/UI'
 import { CryptoSelector, CryptoValue, FiatSelector, FiatValue } from 'containers/UI'
 import { Truncate } from 'components/Util'
 import Onchain from 'components/Icon/Onchain'
@@ -35,6 +36,7 @@ export default class TransactionModal extends React.PureComponent {
 
   render() {
     const { item, ...rest } = this.props
+    const destAddress = get(item, 'dest_addresses[0]')
 
     return (
       <Panel {...rest}>
@@ -72,38 +74,56 @@ export default class TransactionModal extends React.PureComponent {
             }
           />
 
-          <Bar />
+          {item.num_confirmations > 0 && (
+            <>
+              <Bar />
 
-          <DataRow
-            left={<FormattedMessage {...messages.date_confirmed} />}
-            right={
-              <>
-                <FormattedDate
-                  value={item.time_stamp * 1000}
-                  year="numeric"
-                  month="long"
-                  day="2-digit"
-                />
-                <br />
-                <FormattedTime value={item.time_stamp * 1000} />
-              </>
-            }
-          />
+              <DataRow
+                left={<FormattedMessage {...messages.date_confirmed} />}
+                right={
+                  item.num_confirmations ? (
+                    <>
+                      <Text>
+                        <FormattedDate
+                          value={item.time_stamp * 1000}
+                          year="numeric"
+                          month="long"
+                          day="2-digit"
+                        />
+                      </Text>
+                      <Text>
+                        <FormattedTime value={item.time_stamp * 1000} />
+                      </Text>
+                    </>
+                  ) : (
+                    <FormattedMessage {...messages.unconfirmed} />
+                  )
+                }
+              />
 
-          <Bar />
+              <Bar />
 
-          <DataRow
-            left={<FormattedMessage {...messages.address} />}
-            right={
-              <Link
-                className="hint--bottom-left"
-                data-hint={item.dest_addresses[0]}
-                onClick={() => this.showAddress(item.dest_addresses[0])}
-              >
-                <Truncate text={item.dest_addresses[0]} />
-              </Link>
-            }
-          />
+              <DataRow
+                left={<FormattedMessage {...messages.num_confirmations} />}
+                right={<FormattedNumber value={item.num_confirmations} />}
+              />
+
+              <Bar />
+
+              <DataRow
+                left={<FormattedMessage {...messages.address} />}
+                right={
+                  <Link
+                    className="hint--bottom-left"
+                    data-hint={destAddress}
+                    onClick={() => this.showAddress(destAddress)}
+                  >
+                    <Truncate text={destAddress} />
+                  </Link>
+                }
+              />
+            </>
+          )}
 
           <Bar />
 

--- a/app/components/Activity/TransactionModal/messages.js
+++ b/app/components/Activity/TransactionModal/messages.js
@@ -6,6 +6,7 @@ export default defineMessages({
   subtitle: 'On-Chain Payment',
   amount: 'Amount',
   date_confirmed: 'Date of confirmation',
+  num_confirmations: 'Confirmations',
   fee: 'Total fee',
   status: 'Status',
   current_value: 'Current value',

--- a/app/translations/af-ZA.json
+++ b/app/translations/af-ZA.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/ar-SA.json
+++ b/app/translations/ar-SA.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/bg-BG.json
+++ b/app/translations/bg-BG.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "Такса",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/ca-ES.json
+++ b/app/translations/ca-ES.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/cs-CZ.json
+++ b/app/translations/cs-CZ.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/da-DK.json
+++ b/app/translations/da-DK.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/de-DE.json
+++ b/app/translations/de-DE.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "Gebühr",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/el-GR.json
+++ b/app/translations/el-GR.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "Current value",
   "components.Activity.TransactionModal.date_confirmed": "Date of confirmation",
   "components.Activity.TransactionModal.fee": "Total fee",
+  "components.Activity.TransactionModal.num_confirmations": "Confirmations",
   "components.Activity.TransactionModal.status": "Status",
   "components.Activity.TransactionModal.subtitle": "On-Chain Payment",
   "components.Activity.TransactionModal.title_received": "Received",

--- a/app/translations/es-ES.json
+++ b/app/translations/es-ES.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/fi-FI.json
+++ b/app/translations/fi-FI.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/fr-FR.json
+++ b/app/translations/fr-FR.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/ga-IE.json
+++ b/app/translations/ga-IE.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/he-IL.json
+++ b/app/translations/he-IL.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/hi-IN.json
+++ b/app/translations/hi-IN.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/hr-HR.json
+++ b/app/translations/hr-HR.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "Naknada",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/hu-HU.json
+++ b/app/translations/hu-HU.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/it-IT.json
+++ b/app/translations/it-IT.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/ja-JP.json
+++ b/app/translations/ja-JP.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/ko-KR.json
+++ b/app/translations/ko-KR.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/nl-NL.json
+++ b/app/translations/nl-NL.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/no-NO.json
+++ b/app/translations/no-NO.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/pl-PL.json
+++ b/app/translations/pl-PL.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/pt-BR.json
+++ b/app/translations/pt-BR.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/pt-PT.json
+++ b/app/translations/pt-PT.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/ro-RO.json
+++ b/app/translations/ro-RO.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/ru-RU.json
+++ b/app/translations/ru-RU.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/sr-SP.json
+++ b/app/translations/sr-SP.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/sv-SE.json
+++ b/app/translations/sv-SE.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/tr-TR.json
+++ b/app/translations/tr-TR.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/uk-UA.json
+++ b/app/translations/uk-UA.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/vi-VN.json
+++ b/app/translations/vi-VN.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/zh-CN.json
+++ b/app/translations/zh-CN.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",

--- a/app/translations/zh-TW.json
+++ b/app/translations/zh-TW.json
@@ -52,6 +52,7 @@
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
+  "components.Activity.TransactionModal.num_confirmations": "",
   "components.Activity.TransactionModal.status": "",
   "components.Activity.TransactionModal.subtitle": "",
   "components.Activity.TransactionModal.title_received": "",


### PR DESCRIPTION
## Description:

Show the number of blockchain confirmations in the transaction detail view so that users have this information at their fingertips rather than needing visit a block explorer in order to find it out.

## Motivation and Context:

Fix #1686

## How Has This Been Tested?

Manually - view transaction detail for unconfirmed transaction.

## Screenshots:

**Unconfirmed transaction**:

![image](https://user-images.githubusercontent.com/200251/53724073-5cbeb100-3e69-11e9-8c2e-f9c347cb1c64.png)

**Confirmed transaction:**

![image](https://user-images.githubusercontent.com/200251/53724203-b030ff00-3e69-11e9-978a-360ba7d43919.png)

## Types of changes:

Enhancement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
