### PR TITLE
refactor: mark non-required props as such

### DIFF
--- a/app/components/UI/CurrencyFieldGroup.js
+++ b/app/components/UI/CurrencyFieldGroup.js
@@ -38,7 +38,7 @@ class CurrencyFieldGroup extends React.Component {
     /** Boolean indicating if form fields are required */
     required: PropTypes.bool,
     /** Additional field validation */
-    validate: PropTypes.func.isRequired,
+    validate: PropTypes.func,
     /** Boolean indicating if form fields should validate on blur */
     validateOnBlur: PropTypes.bool,
     /** Boolean indicating if form fields should validate on change */

--- a/app/containers/Channels/ChannelCloseDialog.js
+++ b/app/containers/Channels/ChannelCloseDialog.js
@@ -11,7 +11,7 @@ const isForceCloseDialog = state => {
 
 const csvDelay = state => {
   const selectedChannel = channelsSelectors.selectedChannel(state)
-  return selectedChannel && selectedChannel.csv_delay
+  return selectedChannel ? selectedChannel.csv_delay : 0
 }
 
 const mapStateToProps = state => {


### PR DESCRIPTION
## Description:

Mark non-required props as such

## Motivation and Context:

There are a couple of places where there are warnings in the log about required props not being set.

## How Has This Been Tested?

1. View channel details for a channel that is in the process of force closing and verify that no error shows in the console.
2. Open the Pay form and verify that there are no errors in the console about a missing required `validate` prop.

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
