### PR TITLE
fix(ui): standardize hr line weights

### DIFF
--- a/app/components/Activity/Activity.js
+++ b/app/components/Activity/Activity.js
@@ -56,7 +56,7 @@ class Activity extends Component {
                 <Heading.h4 fontWeight="normal">
                   <FormattedDate day="2-digit" month="short" year="numeric" value={item.title} />
                 </Heading.h4>
-                <Bar py={1} />
+                <Bar my={1} />
               </Box>
             ) : (
               <ActivityListItem

--- a/app/components/Activity/InvoiceModal/InvoiceModal.js
+++ b/app/components/Activity/InvoiceModal/InvoiceModal.js
@@ -29,7 +29,7 @@ export default class InvoiceModal extends React.PureComponent {
             subtitle={<FormattedMessage {...messages.subtitle} />}
             logo={<Lightning height="45px" width="45px" />}
           />
-          <Bar pt={2} />
+          <Bar mt={2} />
         </Panel.Header>
 
         <Panel.Body>

--- a/app/components/Activity/PaymentModal/PaymentModal.js
+++ b/app/components/Activity/PaymentModal/PaymentModal.js
@@ -23,7 +23,7 @@ export default class PaymentModal extends React.PureComponent {
             subtitle={<FormattedMessage {...messages.subtitle} />}
             logo={<Lightning height="45px" width="45px" />}
           />
-          <Bar pt={2} />
+          <Bar mt={2} />
         </Panel.Header>
 
         <Panel.Body>
@@ -37,7 +37,7 @@ export default class PaymentModal extends React.PureComponent {
             }
           />
 
-          <Bar />
+          <Bar variant="light" />
 
           <DataRow
             left={<FormattedMessage {...messages.current_value} />}
@@ -49,7 +49,7 @@ export default class PaymentModal extends React.PureComponent {
             }
           />
 
-          <Bar />
+          <Bar variant="light" />
 
           <DataRow
             left={<FormattedMessage {...messages.date_sent} />}
@@ -67,7 +67,7 @@ export default class PaymentModal extends React.PureComponent {
             }
           />
 
-          <Bar />
+          <Bar variant="light" />
 
           <DataRow
             left={<FormattedMessage {...messages.preimage} />}

--- a/app/components/Activity/TransactionModal/TransactionModal.js
+++ b/app/components/Activity/TransactionModal/TransactionModal.js
@@ -49,7 +49,7 @@ export default class TransactionModal extends React.PureComponent {
             subtitle={<FormattedMessage {...messages.subtitle} />}
             logo={<Onchain height="45px" width="45px" />}
           />
-          <Bar pt={2} />
+          <Bar mt={2} />
         </Panel.Header>
 
         <Panel.Body>
@@ -63,7 +63,7 @@ export default class TransactionModal extends React.PureComponent {
             }
           />
 
-          <Bar />
+          <Bar variant="light" />
 
           <DataRow
             left={<FormattedMessage {...messages.current_value} />}
@@ -77,7 +77,7 @@ export default class TransactionModal extends React.PureComponent {
 
           {item.num_confirmations > 0 && (
             <>
-              <Bar />
+              <Bar variant="light" />
 
               <DataRow
                 left={<FormattedMessage {...messages.date_confirmed} />}
@@ -102,14 +102,14 @@ export default class TransactionModal extends React.PureComponent {
                 }
               />
 
-              <Bar />
+              <Bar variant="light" />
 
               <DataRow
                 left={<FormattedMessage {...messages.num_confirmations} />}
                 right={<FormattedNumber value={item.num_confirmations} />}
               />
 
-              <Bar />
+              <Bar variant="light" />
 
               <DataRow
                 left={<FormattedMessage {...messages.address} />}
@@ -126,10 +126,10 @@ export default class TransactionModal extends React.PureComponent {
             </>
           )}
 
-          <Bar />
-
           {!isIncoming && (
             <>
+              <Bar variant="light" />
+
               <DataRow
                 left={<FormattedMessage {...messages.fee} />}
                 right={
@@ -139,11 +139,10 @@ export default class TransactionModal extends React.PureComponent {
                   </Flex>
                 }
               />
-
-              <Bar />
             </>
           )}
 
+          <Bar variant="light" />
           <DataRow
             left={<FormattedMessage {...messages.status} />}
             right={
@@ -180,7 +179,7 @@ export default class TransactionModal extends React.PureComponent {
             }
           />
 
-          <Bar />
+          <Bar variant="light" />
 
           <DataRow
             left={<FormattedMessage {...messages.tx_hash} />}

--- a/app/components/Channels/ChannelCardListItem.js
+++ b/app/components/Channels/ChannelCardListItem.js
@@ -47,7 +47,7 @@ const ChannelCardListItem = React.memo(
               <ClippedText width={2 / 3}>{display_pubkey}</ClippedText>
             </Flex>
             <Box opacity={opacity}>
-              <Bar my={2} opacity={0.3} />
+              <Bar my={2} variant="light" />
             </Box>
           </Panel.Header>
 

--- a/app/components/Channels/ChannelCreate.js
+++ b/app/components/Channels/ChannelCreate.js
@@ -29,7 +29,7 @@ class ChannelCreate extends React.Component {
           <Flex justifyContent="center">
             <Panel.Header width={9 / 16}>
               <ChannelCreateHeader />
-              <Bar pt={2} mb={3} />
+              <Bar mt={2} mb={3} />
             </Panel.Header>
           </Flex>
 

--- a/app/components/Channels/ChannelCreateForm.js
+++ b/app/components/Channels/ChannelCreateForm.js
@@ -249,7 +249,7 @@ class ChannelCreateForm extends React.Component {
           disabled={Boolean(searchQuery)}
         />
 
-        <Bar my={3} opacity={0.3} />
+        <Bar my={3} variant="light" />
 
         <CurrencyFieldGroup
           formApi={this.formApi}
@@ -260,7 +260,7 @@ class ChannelCreateForm extends React.Component {
           css={{ height: '88px' }}
         />
 
-        <Bar my={3} opacity={0.3} />
+        <Bar my={3} variant="light" />
 
         <Flex justifyContent="space-between" alignItems="center">
           <Box>
@@ -308,7 +308,7 @@ class ChannelCreateForm extends React.Component {
 
         {activeWalletSettings.type !== 'local' && (
           <>
-            <Bar my={3} opacity={0.3} />
+            <Bar my={3} variant="light" />
             <Flex justifyContent="space-between" alignItems="center">
               <Flex>
                 <Span color="gray" fontSize="s" mr={2}>

--- a/app/components/Channels/ChannelCreateSummary.js
+++ b/app/components/Channels/ChannelCreateSummary.js
@@ -76,7 +76,7 @@ class ChannelCreateSummary extends React.Component {
 
         {fee > 0 && (
           <>
-            <Bar />
+            <Bar variant="light" />
 
             <DataRow
               left={<FormattedMessage {...messages.fee} />}
@@ -93,7 +93,7 @@ class ChannelCreateSummary extends React.Component {
               }
             />
 
-            <Bar />
+            <Bar variant="light" />
 
             <DataRow
               left={<FormattedMessage {...messages.total} />}

--- a/app/components/Channels/ChannelData.js
+++ b/app/components/Channels/ChannelData.js
@@ -133,7 +133,7 @@ const ChannelData = ({ channel, currencyName, networkInfo, viewMode, ...rest }) 
     <Box {...rest}>
       {rows.map(row => (
         <React.Fragment key={row.id}>
-          <Bar opacity={0.3} />
+          <Bar variant="light" />
           <DataRow
             left={row.label}
             right={row.value}

--- a/app/components/Channels/ChannelHeader.js
+++ b/app/components/Channels/ChannelHeader.js
@@ -23,7 +23,7 @@ const ChannelHeader = ({ intl, channel, ...rest }) => {
       </Flex>
       <ClippedText>{display_pubkey}</ClippedText>
       <Box>
-        <Bar my={3} opacity={0.3} />
+        <Bar my={3} />
       </Box>
     </Box>
   )

--- a/app/components/Channels/ChannelNodeSearch.js
+++ b/app/components/Channels/ChannelNodeSearch.js
@@ -37,7 +37,7 @@ const SearchResults = ({ filteredNetworkNodes, onClickConnect, ...rest }) => (
               <FormattedMessage {...messages.connect} />
             </Button>
           </Flex>
-          <Bar opacity={0.3} />
+          <Bar variant="light" />
         </React.Fragment>
       )
     })}

--- a/app/components/Pay/Pay.js
+++ b/app/components/Pay/Pay.js
@@ -423,7 +423,7 @@ class Pay extends React.Component {
       >
         {styles => (
           <Box style={styles}>
-            <Bar my={3} />
+            <Bar my={3} variant="light" />
 
             <CurrencyFieldGroup
               disabled={currentStep !== 'amount'}
@@ -558,7 +558,7 @@ class Pay extends React.Component {
                   }
                   type={isLn ? 'offchain' : isOnchain ? 'onchain' : null}
                 />
-                <Bar pt={2} />
+                <Bar mt={2} />
               </Panel.Header>
 
               <Panel.Body py={3}>

--- a/app/components/Pay/PaySummaryLightning.js
+++ b/app/components/Pay/PaySummaryLightning.js
@@ -108,7 +108,7 @@ class PaySummaryLightning extends React.Component {
           </Flex>
         </Box>
 
-        <Bar />
+        <Bar variant="light" />
 
         <DataRow
           left={<FormattedMessage {...messages.fee} />}
@@ -127,7 +127,7 @@ class PaySummaryLightning extends React.Component {
           }
         />
 
-        <Bar />
+        <Bar variant="light" />
 
         <DataRow
           left={<FormattedMessage {...messages.total} />}
@@ -138,7 +138,7 @@ class PaySummaryLightning extends React.Component {
           }
         />
 
-        <Bar />
+        <Bar variant="light" />
 
         {memo && <DataRow left={<FormattedMessage {...messages.memo} />} right={memo} />}
       </Box>

--- a/app/components/Pay/PaySummaryOnChain.js
+++ b/app/components/Pay/PaySummaryOnChain.js
@@ -82,7 +82,7 @@ class PaySummaryOnChain extends React.Component {
           </Flex>
         </Box>
 
-        <Bar />
+        <Bar variant="light" />
 
         <DataRow
           left={<FormattedMessage {...messages.fee} />}
@@ -110,7 +110,7 @@ class PaySummaryOnChain extends React.Component {
           }
         />
 
-        <Bar />
+        <Bar variant="light" />
 
         <DataRow
           left={<FormattedMessage {...messages.total} />}

--- a/app/components/Request/Request.js
+++ b/app/components/Request/Request.js
@@ -190,7 +190,7 @@ class Request extends React.Component {
                   subtitle={<FormattedMessage {...messages.subtitle} />}
                   logo={<Lightning height="45px" width="45px" />}
                 />
-                <Bar pt={2} />
+                <Bar mt={2} />
               </Panel.Header>
               <Panel.Body py={3}>
                 {currentStep == 'form' ? (

--- a/app/components/Request/RequestSummary.js
+++ b/app/components/Request/RequestSummary.js
@@ -90,7 +90,7 @@ class RequestSummary extends React.Component {
           }
         />
 
-        <Bar />
+        <Bar variant="light" />
 
         <DataRow
           left={<FormattedMessage {...messages.current_value} />}
@@ -102,14 +102,14 @@ class RequestSummary extends React.Component {
           }
         />
 
-        <Bar />
-
         {memo && (
           <>
+            <Bar variant="light" />
             <DataRow left={<FormattedMessage {...messages.memo} />} right={memo} />
-            <Bar />
           </>
         )}
+
+        <Bar variant="light" />
 
         <DataRow
           left={
@@ -137,7 +137,7 @@ class RequestSummary extends React.Component {
           }
         />
 
-        <Bar />
+        <Bar variant="light" />
 
         <DataRow
           left={<FormattedMessage {...messages.status} />}

--- a/app/components/UI/Bar.js
+++ b/app/components/UI/Bar.js
@@ -1,20 +1,24 @@
-import system from '@rebass/components'
+import styled from 'styled-components'
+import { variant, space, height } from 'styled-system'
 
-const Bar = system(
-  {
-    is: 'hr',
-    m: 0,
-    border: 0,
-    borderBottom: 1,
-    borderColor: 'primaryText',
-    opacity: 0.6
-  },
-  'borders',
-  'borderColor',
-  'space',
-  'opacity',
-  'width'
-)
+const bars = variant({
+  key: 'bars'
+})
+
+const Bar = styled.hr`
+  height: 1px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background-color: ${props => props.theme.colors.primaryText};
+  ${space}
+  ${height}
+  ${bars}
+`
+
+Bar.defaultProps = {
+  variant: 'normal'
+}
 
 Bar.displayName = 'Bar'
 

--- a/app/components/Wallet/ReceiveModal/ReceiveModal.js
+++ b/app/components/Wallet/ReceiveModal/ReceiveModal.js
@@ -124,7 +124,7 @@ class ReceiveModal extends React.PureComponent {
           {networkInfo && networkInfo.id === 'testnet' && networkInfo.name}
         </Heading.h1>
 
-        <Bar pt={2} />
+        <Bar mt={2} />
 
         <Flex justifyContent="center" my={3}>
           <Tabs onClick={this.setQrcode} activeKey={qrCodeType} items={tabs} />

--- a/app/themes/base.js
+++ b/app/themes/base.js
@@ -72,6 +72,15 @@ const statuses = {
   }
 }
 
+const bars = {
+  normal: {
+    opacity: 0.6
+  },
+  light: {
+    opacity: 0.3
+  }
+}
+
 export default {
   space,
   fontSizes,
@@ -79,5 +88,6 @@ export default {
   fonts,
   letterSpacings,
   palette,
-  statuses
+  statuses,
+  bars
 }

--- a/test/unit/components/Pay/__snapshots__/PaySummaryLightning.spec.js.snap
+++ b/test/unit/components/Pay/__snapshots__/PaySummaryLightning.spec.js.snap
@@ -96,12 +96,7 @@ exports[`component.Form.PaySummaryLightning should render correctly 1`] = `
     </Styled(styled.div)>
   </styled.div>
   <Bar
-    border={0}
-    borderBottom={1}
-    borderColor="primaryText"
-    is="hr"
-    m={0}
-    opacity={0.6}
+    variant="light"
   />
   <DataRow
     left={
@@ -125,12 +120,7 @@ exports[`component.Form.PaySummaryLightning should render correctly 1`] = `
     }
   />
   <Bar
-    border={0}
-    borderBottom={1}
-    borderColor="primaryText"
-    is="hr"
-    m={0}
-    opacity={0.6}
+    variant="light"
   />
   <DataRow
     left={
@@ -151,12 +141,7 @@ exports[`component.Form.PaySummaryLightning should render correctly 1`] = `
     }
   />
   <Bar
-    border={0}
-    borderBottom={1}
-    borderColor="primaryText"
-    is="hr"
-    m={0}
-    opacity={0.6}
+    variant="light"
   />
 </styled.div>
 `;

--- a/test/unit/components/Pay/__snapshots__/PaySummaryOnchain.spec.js.snap
+++ b/test/unit/components/Pay/__snapshots__/PaySummaryOnchain.spec.js.snap
@@ -108,12 +108,7 @@ exports[`component.Form.PaySummaryOnchain should render correctly 1`] = `
     </Styled(styled.div)>
   </styled.div>
   <Bar
-    border={0}
-    borderBottom={1}
-    borderColor="primaryText"
-    is="hr"
-    m={0}
-    opacity={0.6}
+    variant="light"
   />
   <DataRow
     left={
@@ -132,12 +127,7 @@ exports[`component.Form.PaySummaryOnchain should render correctly 1`] = `
     }
   />
   <Bar
-    border={0}
-    borderBottom={1}
-    borderColor="primaryText"
-    is="hr"
-    m={0}
-    opacity={0.6}
+    variant="light"
   />
   <DataRow
     left={

--- a/test/unit/components/UI/Bar.spec.js
+++ b/test/unit/components/UI/Bar.spec.js
@@ -1,10 +1,18 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
+import { ThemeProvider } from 'styled-components'
+import { dark } from 'themes'
 import { Bar } from 'components/UI'
 
 describe('component.UI.Bar', () => {
   it('should render correctly', () => {
-    const tree = renderer.create(<Bar />).toJSON()
+    const tree = renderer
+      .create(
+        <ThemeProvider theme={dark}>
+          <Bar />
+        </ThemeProvider>
+      )
+      .toJSON()
     expect(tree).toMatchSnapshot()
   })
 })

--- a/test/unit/components/UI/__snapshots__/Bar.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Bar.spec.js.snap
@@ -2,10 +2,11 @@
 
 exports[`component.UI.Bar should render correctly 1`] = `
 .c0 {
+  height: 1px;
+  margin: 0;
+  padding: 0;
   border: 0;
-  border-bottom: 1px solid;
-  border-color: primaryText;
-  margin: 0px;
+  background-color: #ffffff;
   opacity: 0.6;
 }
 


### PR DESCRIPTION
## Description:

Standardize hr line weights used throughout the app.

- Create `normal` and `light` theme variants for Bar element
- Use normal (0.6 opacity) for hr's under headings
- Use light (0.3 opacity) elsewhere

## Motivation and Context:

Some pages have heavy hr's (eg the transaction detail page), others have light ones (eg channel details) and we are not consistent in our approach.

## How Has This Been Tested?

Manually - view all pages of the app and verify hr weights look consistent.

## Types of changes:

Style fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
