### PR TITLE
refactor: mark non-required properties as such

### DIFF
--- a/app/containers/Initializer.js
+++ b/app/containers/Initializer.js
@@ -16,8 +16,8 @@ class Initializer extends React.Component {
   static propTypes = {
     activeWallet: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     activeWalletSettings: PropTypes.object,
-    hasWallets: PropTypes.bool.isRequired,
-    isWalletOpen: PropTypes.bool.isRequired,
+    hasWallets: PropTypes.bool,
+    isWalletOpen: PropTypes.bool,
     isReady: PropTypes.bool.isRequired,
     lndConnect: PropTypes.string,
     fetchSuggestedNodes: PropTypes.func.isRequired,


### PR DESCRIPTION
## Description:

Mark non-required properties as such

## Motivation and Context:

Console warning about required `isWalletOpen` in the `Initialiser` component. This boolean prop now only gets set to true if there is an an open wallet and can be undefined as well as false if not. Same for `hasWallets`

Previously these props were copied from the settings to the wallet reducer and explicitly initialised as false if not true. Now, we read the settings directly from the settings selector in which the values may or may not be set.

## How Has This Been Tested?

Start app without open wallet and verify no warning in the log about this missing prop

## Types of changes:

Fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
