### PR TITLE
fix(home): increase sidebar width

### DIFF
--- a/app/components/Home/Home.js
+++ b/app/components/Home/Home.js
@@ -92,7 +92,7 @@ class Home extends React.Component {
 
     return (
       <>
-        <Sidebar.small pl={4} pt={40}>
+        <Sidebar.medium pl={4} pt={40}>
           <Panel>
             <Panel.Header>
               <ZapLogo width="70px" height="32px" />
@@ -112,7 +112,7 @@ class Home extends React.Component {
               </Box>
             </Panel.Footer>
           </Panel>
-        </Sidebar.small>
+        </Sidebar.medium>
 
         <MainContent css={{ position: 'relative' }}>
           <Switch>

--- a/app/components/UI/Sidebar.js
+++ b/app/components/UI/Sidebar.js
@@ -11,9 +11,9 @@ const Sidebar = ({ ...props }) => (
   <BackgroundTertiary as="aside" width={3 / 12} css={{ overflow: 'hidden' }} {...props} />
 )
 
-Sidebar.small = props => <Sidebar {...props} width={3 / 12} />
-Sidebar.medium = props => <Sidebar {...props} width={4 / 12} />
-Sidebar.large = props => <Sidebar {...props} width={5 / 12} />
+Sidebar.small = props => <Sidebar {...props} width={4 / 16} />
+Sidebar.medium = props => <Sidebar {...props} width={5 / 16} />
+Sidebar.large = props => <Sidebar {...props} width={6 / 16} />
 
 Sidebar.small.displayName = 'Sidebar Small'
 Sidebar.medium.displayName = 'Sidebar Medium'


### PR DESCRIPTION
## Description:

Increase the homepage sidebar width.

## Motivation and Context:

Sidebar looks disproportionately small compared to the main content area and the create new wallet button looks squashed.

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):

**Before:**

![image](https://user-images.githubusercontent.com/200251/53992744-e900fa80-412d-11e9-9662-5a26b79983ef.png)

**After:**

![image](https://user-images.githubusercontent.com/200251/53992844-1f3e7a00-412e-11e9-9a36-26247a14a3e1.png)


## Types of changes:

Style adjustment

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
