### PR TITLE
refactor: add ArrowDown and ArrowUp icon

### DIFF
--- a/app/components/Icon/ArrowDown.js
+++ b/app/components/Icon/ArrowDown.js
@@ -1,0 +1,16 @@
+import React from 'react'
+
+const SvgArrowDown = props => (
+  <svg height="1em" viewBox="0 0 12 16" width="1em" {...props}>
+    <path
+      d="M6 15V1m5 8.474L6 15 1 9.474"
+      fill="none"
+      fillRule="evenodd"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+)
+
+export default SvgArrowDown

--- a/app/components/Icon/ArrowUp.js
+++ b/app/components/Icon/ArrowUp.js
@@ -1,0 +1,16 @@
+import React from 'react'
+
+const SvgArrowUp = props => (
+  <svg height="1em" viewBox="0 0 12 16" width="1em" {...props}>
+    <path
+      d="M6 1v14M1 6.526L6 1l5 5.526"
+      fill="none"
+      fillRule="evenodd"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+)
+
+export default SvgArrowUp

--- a/app/icons/arrow-down.svg
+++ b/app/icons/arrow-down.svg
@@ -1,0 +1,6 @@
+<svg width="12" height="16" viewBox="0 0 12 16" xmlns="http://www.w3.org/2000/svg">
+  <defs></defs>
+  <g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" transform="matrix(0, -1, 1, 0, 0, 16)">
+    <path d="M1 6h14M6.526 11L1 6l5.526-5"></path>
+  </g>
+</svg>

--- a/app/icons/arrow-up.svg
+++ b/app/icons/arrow-up.svg
@@ -1,0 +1,6 @@
+<svg width="12" height="16" viewBox="0 0 12 16" xmlns="http://www.w3.org/2000/svg">
+  <defs></defs>
+  <g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" transform="matrix(0, 1, -1, 0, 12, 0)">
+    <path d="M1 6h14M6.526 11L1 6l5.526-5"></path>
+  </g>
+</svg>

--- a/stories/icons/icon.stories.js
+++ b/stories/icons/icon.stories.js
@@ -2,12 +2,14 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Box, Flex } from 'rebass'
 
-import AngleRight from 'components/Icon/AngleRight'
-import AngleLeft from 'components/Icon/AngleLeft'
-import AngleUp from 'components/Icon/AngleUp'
 import AngleDown from 'components/Icon/AngleDown'
+import AngleLeft from 'components/Icon/AngleLeft'
+import AngleRight from 'components/Icon/AngleRight'
+import AngleUp from 'components/Icon/AngleUp'
+import ArrowDown from 'components/Icon/ArrowDown'
 import ArrowLeft from 'components/Icon/ArrowLeft'
 import ArrowRight from 'components/Icon/ArrowRight'
+import ArrowUp from 'components/Icon/ArrowUp'
 import BigArrowRight from 'components/Icon/BigArrowRight'
 import Bitcoin from 'components/Icon/Bitcoin'
 import Btcpay from 'components/Icon/Btcpay'
@@ -58,12 +60,14 @@ import ZapLogo from 'components/Icon/ZapLogo'
 const iconSizes = [16, 32, 64, 128]
 
 const zapIconsList = {
+  AngleDown,
   AngleLeft,
   AngleRight,
   AngleUp,
-  AngleDown,
+  ArrowDown,
   ArrowLeft,
   ArrowRight,
+  ArrowUp,
   BigArrowRight,
   Bitcoin,
   Btcpay,


### PR DESCRIPTION
## Description:

Add new `ArrowDown` and `ArrowUp` icons so that we have all 4 directional variations of our arrow icon.

## Motivation and Context:

Needed for new zap website, but figured it would make sense to add them to the repo here so that we have all of our icons in a single location.

Ultimately, we should probably look to extract these icons to a standalone repo but that's not something that I want to address at this point.

## How Has This Been Tested?

Storybook

## Types of changes:

Refactor

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
