### PR TITLE
fix(wallet): ensure tickers are ready before displaying app

### DIFF
--- a/app/reducers/app.js
+++ b/app/reducers/app.js
@@ -1,4 +1,5 @@
 import { createSelector } from 'reselect'
+import { tickerSelectors } from './ticker'
 
 // ------------------------------------
 // Initial State
@@ -70,11 +71,14 @@ appSelectors.isRootReady = createSelector(
 
 appSelectors.isAppReady = createSelector(
   appSelectors.infoLoaded,
-  appSelectors.currency,
+  tickerSelectors.currency,
+  tickerSelectors.currentTicker,
   appSelectors.walletBalance,
   appSelectors.channelBalance,
-  (infoLoaded, currency, walletBalance, channelBalance) => {
-    return Boolean(infoLoaded && currency && channelBalance !== null && walletBalance !== null)
+  (infoLoaded, currency, currentTicker, walletBalance, channelBalance) => {
+    return Boolean(
+      infoLoaded && currency && currentTicker && channelBalance !== null && walletBalance !== null
+    )
   }
 )
 


### PR DESCRIPTION
## Description:

Ensure tickers are ready before displaying app by adding an additional condition the `isAppReady` selector. 

## Motivation and Context:

There is a race condition in which it's possible for the app to try to render before the currency tickers have loaded. This causes the app to crash because the `Value` component doesn't have everything that it expects in order to render currency amounts.

## How Has This Been Tested?

Manually

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
