### PR TITLE
fix(deps): update lnd to v0.5.1-beta-847-gc4a438e

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "config": {
     "style_paths": "app/components/**/*.js",
     "lnd-binary": {
-      "binaryVersion": "0.5.1-beta-795-ga6ba965b",
+      "binaryVersion": "0.5.1-beta-847-gc4a438e1",
       "binarySite": "https://github.com/LN-Zap/lnd/releases/download"
     }
   },
@@ -344,7 +344,7 @@
     "is-electron-renderer": "2.0.1",
     "javascript-state-machine": "3.1.0",
     "jstimezonedetect": "1.0.6",
-    "lnd-grpc": "0.1.7",
+    "lnd-grpc": "0.1.8",
     "lndconnect": "0.2.2",
     "lodash.debounce": "4.0.8",
     "lodash.get": "4.4.2",


### PR DESCRIPTION
## Description:

Updates lnd to latest build from master. This build of lnd has mainnet neutrino support enabled.

## Motivation and Context:

Bring lnd build up to date.
