### PR TITLE
fix(wallet): include pending channel balance in wallet balance

### DIFF
--- a/app/lib/lnd/methods/index.js
+++ b/app/lib/lnd/methods/index.js
@@ -145,7 +145,7 @@ export default function(lightning, log, event, msg, data) {
         .then(balance => {
           event.sender.send('receiveBalance', {
             walletBalance: balance[0],
-            channelBalance: balance[1].balance,
+            channelBalance: balance[1],
           })
           return balance
         })

--- a/app/reducers/balance.js
+++ b/app/reducers/balance.js
@@ -38,7 +38,7 @@ const ACTION_HANDLERS = {
     walletBalance: walletBalance.total_balance,
     walletBalanceConfirmed: walletBalance.confirmed_balance,
     walletBalanceUnconfirmed: walletBalance.unconfirmed_balance,
-    channelBalance,
+    channelBalance: channelBalance.balance + channelBalance.pending_open_balance,
   }),
 }
 

--- a/test/unit/reducers/__snapshots__/balance.spec.js.snap
+++ b/test/unit/reducers/__snapshots__/balance.spec.js.snap
@@ -13,7 +13,7 @@ Object {
 exports[`reducers balanceReducer should handle RECEIVE_BALANCE 1`] = `
 Object {
   "balanceLoading": false,
-  "channelBalance": 1,
+  "channelBalance": 2,
   "walletBalance": 1,
   "walletBalanceConfirmed": 1,
   "walletBalanceUnconfirmed": 1,

--- a/test/unit/reducers/balance.spec.js
+++ b/test/unit/reducers/balance.spec.js
@@ -16,7 +16,10 @@ describe('reducers', () => {
         confirmed_balance: 1,
         unconfirmed_balance: 1,
       }
-      const channelBalance = 1
+      const channelBalance = {
+        balance: 1,
+        pending_open_balance: 1,
+      }
       expect(
         balanceReducer(undefined, { type: RECEIVE_BALANCE, walletBalance, channelBalance })
       ).toMatchSnapshot()


### PR DESCRIPTION
## Description:

Include pending channel balances in the wallet total balance.

## Motivation and Context:

Right now the pending open channel balance is not factored into a users balance, resulting in money seemingly disappearing when a channel is opened.

Fix #1770

## How Has This Been Tested?

Manually

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
