### PR TITLE
style: lint icons after generation

### DIFF
--- a/app/components/Icon/PlusOnboarding.js
+++ b/app/components/Icon/PlusOnboarding.js
@@ -2,14 +2,13 @@ import React from 'react'
 
 const SvgPlusOnboarding = props => (
   <svg height="1em" viewBox="0 0 76 76" width="1em" {...props}>
-    <g fill="none" fillRule="evenodd" transform="translate(1 1)">
+    <g fill="none" fillRule="evenodd" stroke="#FD9800" transform="translate(1 1)">
       <path
         d="M37.408 23.545v26.91M23.545 37.408h26.91"
-        stroke="currentColor"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
-      <circle cx={37} cy={37} r={37} stroke="currentColor" />
+      <circle cx={37} cy={37} r={37} />
     </g>
   </svg>
 )

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "fetch-lnd": "node ./internals/scripts/fetch-lnd-for-packaging.js",
     "flow": "flow",
     "flow-typed": "rimraf flow-typed/npm && flow-typed install --overwrite || true",
-    "generate-icons": "npx @svgr/cli --icon -d app/components/Icon app/icons",
+    "generate-icons": "npx @svgr/cli --icon -d app/components/Icon app/icons && npm run lint-fix -- app/components/Icon",
     "lint-base": "eslint --cache --format=node_modules/eslint-formatter-pretty",
     "lint": "npm run lint-base -- .",
     "lint-fix-base": "npm run lint-base -- --fix",


### PR DESCRIPTION
## Description:

lint icons after generation

## Motivation and Context:

Ensure that newly generated icons do not fail lint checks, and the existing icons are not regenerated with changes that fail our lint rules.

## How Has This Been Tested?

Manually (run `yarn generate-icons` and verify existing icons are not modified.

## Types of changes:

Lint fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
