### PR TITLE
feat(wallet): set defatult currency to sats

### DIFF
--- a/app/reducers/settings.js
+++ b/app/reducers/settings.js
@@ -59,8 +59,7 @@ const ACTION_HANDLERS = {
 // Reducer
 // ------------------------------------
 const initialState = {
-  isSettingsOpen: false,
-  activeSubMenu: null,
+  settings: {},
 }
 
 export default function settingsReducer(state = initialState, action) {

--- a/app/reducers/ticker.js
+++ b/app/reducers/ticker.js
@@ -16,8 +16,8 @@ export const RECIEVE_TICKERS = 'RECIEVE_TICKERS'
 
 // Map for crypto codes to crypto tickers
 const DEFAULT_CRYPTO_UNITS = {
-  bitcoin: 'btc',
-  litecoin: 'ltc',
+  bitcoin: window.CONFIG.bitcoin.currency,
+  litecoin: window.CONFIG.litecoin.currency,
 }
 
 // Map for crypto names to crypto tickers
@@ -105,10 +105,10 @@ export const receiveCryptocurrency = (event, chain) => async (dispatch, getState
 
   // Load saved settings for the chain.
   const state = getState()
-  const chainSettings = state.settings[`chain.${chain}`]
+  const chainSettings = state.settings[`chain.${chain}`] || {}
 
   // Set currency unit based on saved setting, or fallback to default value.
-  const unit = get(chainSettings, 'value.unit', DEFAULT_CRYPTO_UNITS[chain])
+  const unit = get(chainSettings, 'unit', DEFAULT_CRYPTO_UNITS[chain])
   dispatch(setCurrency(unit))
 }
 

--- a/config/default.js
+++ b/config/default.js
@@ -24,4 +24,12 @@ module.exports = {
   chains: ['bitcoin'],
 
   networks: ['testnet', 'mainnet'],
+
+  bitcoin: {
+    currency: 'sats',
+  },
+
+  litecoin: {
+    currency: 'lits',
+  },
 }


### PR DESCRIPTION
## Description:

Set default currency to sats. This affects new users only, or users that have not already manually set the currency within the app.

## Motivation and Context:

Better UX for new users with small balances.

## How Has This Been Tested?

Delete the `chain.bitcoin` entry  from the `settings` database table, and then restart the app. Should be reset to `sats`.

## Types of changes:

Enhancement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
