### PR TITLE
fix(lnd): enable assumechanvalid on mainnet

### DIFF
--- a/app/lib/lnd/neutrino.js
+++ b/app/lib/lnd/neutrino.js
@@ -134,6 +134,7 @@ class Neutrino extends EventEmitter {
 
     // Configure lnd.
     const neutrinoArgs = [
+      `--routing.assumechanvalid`,
       `--configfile=${this.lndConfig.configPath}`,
       `--lnddir=${this.lndConfig.lndDir}`,
       `--listen=0.0.0.0:${p2pListen}`,
@@ -150,11 +151,6 @@ class Neutrino extends EventEmitter {
     global.CONFIG.neutrino.connect[this.lndConfig.network].forEach(node =>
       neutrinoArgs.push(`--neutrino.connect=${node}`)
     )
-
-    // When not on mainnet, enable the experimental assumechanvalid flag.
-    if (this.lndConfig.network !== 'mainnet') {
-      neutrinoArgs.push(`--routing.assumechanvalid`)
-    }
 
     // Log the final config.
     mainLog.info(


### PR DESCRIPTION
## Description:

Neutrino seems to struggle with channel validation, resulting in Zap users not being able to open channels. To resolve this, for the time being, we enable `assumechanvalid` on mainnet, so that users can test neutrino on mainnet.

## Motivation and Context:

Make sure mainnet neutrino is functional

## How Has This Been Tested?

Enable mainnet on a local wallet and open a channel

## Types of changes:

Fix

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
