### PR TITLE
[WIP] fix(channels): notification when channel enters pending state

### DIFF
--- a/app/reducers/channels.js
+++ b/app/reducers/channels.js
@@ -2,7 +2,7 @@ import { createSelector } from 'reselect'
 import throttle from 'lodash.throttle'
 import { send } from 'redux-electron-ipc'
 import { requestSuggestedNodes } from 'lib/utils/api'
-import { showError } from './notification'
+import { showNotification, showError } from './notification'
 import { fetchBalance } from './balance'
 import { walletSelectors } from './wallet'
 import { getNodeDisplayName, truncateNodePubkey, updateNodeData } from './network'
@@ -331,7 +331,12 @@ export const channelSuccessful = () => dispatch => {
 }
 
 // Receive IPC event for updated channel
-export const pushchannelupdated = (event, { pubkey }) => dispatch => {
+export const pushchannelupdated = (event, { pubkey, data }) => dispatch => {
+  // If the channel update is pending then show notification that the channel open was a success
+  if (data.update === 'chan_pending') {
+    dispatch(showNotification('Channel successfully created'))
+  }
+
   dispatch(fetchChannels())
   dispatch(removeLoadingPubkey(pubkey))
 }


### PR DESCRIPTION
## Description:

Give a notification when a freshly submitted channel is successfully broadcasted and enters a pending state

## Motivation and Context:

Right now we only notify when a user simply submits the channel form and have gotten feedback that this isn't too great.

There are a few things wrong with this pull request as it stands:

- [ ] The notification is a hard-coded string and needs to come from the channels `messages` file
- [ ] A user now gets back to back notifications on a successful channel submit.

<img width="903" alt="Screen Shot 2019-03-14 at 9 32 56 PM" src="https://user-images.githubusercontent.com/4040039/54405360-55d34200-46a4-11e9-8e21-85bfe3a0bed4.png">

I think instead the form submit button should enter a `loading` state where the submit button displays our spinner until we get a response. On a success response, we can close the form and show the success notification. On an error, we can leave the loading state but keep the form open, and show an error notification.

@mrfelton @korhaliv feel free to pick this up. Given my schedule I'm not sure I will be able to finish this one