### PR TITLE
fix(ui): change invoice status color scheme

### DIFF
--- a/app/components/Request/RequestSummary.js
+++ b/app/components/Request/RequestSummary.js
@@ -78,6 +78,13 @@ class RequestSummary extends React.Component {
     const descriptionTag = tags.find(tag => tag.tagName === 'description') || {}
     const memo = descriptionTag.data
 
+    const getStatusColor = () => {
+      if (invoice.settled) {
+        return 'superGreen'
+      }
+      return isExpired ? 'superRed' : 'lightningOrange'
+    }
+
     return (
       <Box {...rest}>
         <DataRow
@@ -143,13 +150,13 @@ class RequestSummary extends React.Component {
           left={<FormattedMessage {...messages.status} />}
           right={
             invoice.settled ? (
-              <Text color="superGreen" fontWeight="normal">
+              <Text color={getStatusColor()} fontWeight="normal">
                 <FormattedMessage {...messages.paid} />
                 {` `}
                 <FormattedTime value={invoice.settle_date * 1000} />
               </Text>
             ) : (
-              <Text color="superRed" fontWeight="normal">
+              <Text color={getStatusColor()} fontWeight="normal">
                 {isExpired ? 'Expired ' : 'Expires '}
                 <FormattedRelative
                   updateInterval={1000}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Improve payment request  status color scheme

- Green is paid
- Orange is not paid
- Red is expired

<!--- Describe your changes in detail -->

## Motivation and Context:
Currently it's hard to distinguish between states based on color
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/14069193/54544398-38ee8580-49a8-11e9-9935-13ed06cdd18a.png)

## Types of changes:
Enhancement
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
