### PR TITLE
fix(ui): only show on-chain transaction fee widget for onchain transactions

### DIFF
--- a/app/components/Pay/Pay.js
+++ b/app/components/Pay/Pay.js
@@ -467,7 +467,7 @@ class Pay extends React.Component {
   }
 
   renderAmountFields = () => {
-    const { currentStep } = this.state
+    const { currentStep, isOnchain } = this.state
     const { intl, initialAmountCrypto, initialAmountFiat, isQueryingFees } = this.props
     const fee = this.getFee()
 
@@ -489,15 +489,19 @@ class Pay extends React.Component {
               isRequired
             />
 
-            <Bar my={3} variant="light" />
+            {isOnchain && (
+              <>
+                <Bar my={3} variant="light" />
 
-            <TransactionFeeInput
-              fee={fee}
-              field="speed"
-              isQueryingFees={isQueryingFees}
-              label={intl.formatMessage({ ...messages.fee })}
-              required
-            />
+                <TransactionFeeInput
+                  fee={fee}
+                  field="speed"
+                  isQueryingFees={isQueryingFees}
+                  label={intl.formatMessage({ ...messages.fee })}
+                  required
+                />
+              </>
+            )}
           </Box>
         )}
       </ShowHideAmount>


### PR DESCRIPTION
## Description:

Only show fee widget for onchain transactions

## Motivation and Context:

Transaction fee widget was recently added to the pay form, but it's currently showing up if you try to pay a lightning invoice with a `zero` amount. It should only show for onchain transactions.

This PR ensures that it only shows for onChain transactions.

## How Has This Been Tested?

Try to pay a LN invoice with a 0 amount, eg https://tippin.me/@mrfelton and verify that the onchain transaction fee widget does not show.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
