### PR TITLE
chore: bump stable version to 0.4.x

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -2,7 +2,7 @@ const { getPackageDetails, isStableVersion } = require('../app/lib/utils')
 
 // The current stable base version.
 // If the current version is in the same range asd this, the default database domain will be used.
-const STABLE_VERSION = '0.3.x'
+const STABLE_VERSION = '0.4.x'
 
 const { version } = getPackageDetails()
 


### PR DESCRIPTION
## Description:

Bump stable version to 0.4.x

## Motivation and Context:

Set `0.4.x` as stable app version. This will cause `0.4.x` code to once again connect to the default database namespace, freeing up the `next` database namespace to be used in conjunction with `0.5.x`.