### PR TITLE
chore: bump version to 0.5.0-alpha

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap-desktop",
   "productName": "Zap",
-  "version": "0.4.0-beta",
+  "version": "0.5.0-alpha",
   "description": "desktop application for the lightning network",
   "main": "./dist/main.prod.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zap-desktop",
   "productName": "Zap",
-  "version": "0.4.0-beta",
+  "version": "0.5.0-alpha",
   "description": "desktop application for the lightning network",
   "scripts": {
     "build": "concurrently --raw \"npm:build-main\" \"npm:build-preload\" \"npm:build-renderer\"",


### PR DESCRIPTION
## Description:

Bump version to 0.5.0-alpha

## Motivation and Context:

Bump version in `5.x` branch to `0.5.0-alpha` (`5.x` branch will soon become the new `next`)
