### PR TITLE
fix(onboarding): don't allow autopilot on mainnet

### DIFF
--- a/app/components/Onboarding/Onboarding.js
+++ b/app/components/Onboarding/Onboarding.js
@@ -75,6 +75,23 @@ class Onboarding extends React.Component {
   }
 
   /**
+   * Remove Autopilot form step if the currently selected network is mainnet.
+   * @param  {{key: string}[]} formSteps List of form steps.
+   * @return {{key: string}[]} Modified list of form steps.
+   */
+  removeAutopilotStepIfMainnet = formSteps => {
+    const { network, setAutopilot } = this.props
+    if (network === 'mainnet') {
+      const index = formSteps.findIndex(s => s.key === 'Autopilot')
+      if (index >= 0) {
+        formSteps.splice(index, 1)
+      }
+      setAutopilot(false)
+    }
+    return formSteps
+  }
+
+  /**
    * Dynamically generte form steps to use in the onboarding Wizzard.
    * @return {[Wizzard.Step]} A list of WizardSteps.
    */
@@ -225,6 +242,11 @@ class Onboarding extends React.Component {
       />,
       ...formSteps,
     ]
+
+    // It is currently not recommended to use autopilot on mainnet.
+    // If user has selected mainnet, remove the autopilot form step.
+    this.removeAutopilotStepIfMainnet(steps)
+
     return steps
   }
 


### PR DESCRIPTION


## Description:

Remove the Autopilot form step from the onboarding flow if the user has selected mainnet.

## Motivation and Context:

Autopilot is currently not recommended to use on mainnet.

## How Has This Been Tested?

Manually

## Types of changes:

Enhancement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
