### PR TITLE
fix(lnd): don't reset lnd state on hot-reload

### DIFF
--- a/app/components/Dialog/DialogLndCrashed.js
+++ b/app/components/Dialog/DialogLndCrashed.js
@@ -5,7 +5,6 @@ import { FormattedMessage, injectIntl } from 'react-intl'
 import { withRouter } from 'react-router-dom'
 import Delete from 'components/Icon/Delete'
 import { Dialog, Heading, DialogOverlay, Text } from 'components/UI'
-import { useCloseOnUnmount } from 'hooks'
 import messages from './messages'
 
 const ErrorRow = ({ messageKey, value }) => (
@@ -29,8 +28,6 @@ const DialogLndCrashed = ({ onCancel, lndCrashReason, history, isOpen }) => {
     onCancel()
     history.push('/logout')
   }
-
-  useCloseOnUnmount(isOpen, handleClose)
 
   if (!isOpen) {
     return null


### PR DESCRIPTION
## Description:

Do not reset the lnd state when DialogLndCrashed unmounts (this only happens during hot reload).

## Motivation and Context:

When the app hot reloads (in development mode), the lnd state is currently being reset and the user is sent back to the launchpad. This causes a broken app state since lnd is actually still running but the app thinks that it isn't.

## How Has This Been Tested?

Trigger app hot reload and verify that user is not thrown back to the launchpad.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
