### PR TITLE
fix(electron): exit fullscreen before closing

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -338,7 +338,14 @@ app.on('ready', async () => {
     mainLog.trace('mainWindow.close')
     if (os.platform() === 'darwin' && !mainWindow.forceClose) {
       event.preventDefault()
-      mainWindow.hide()
+      if (mainWindow.isFullScreen()) {
+        mainWindow.once('leave-full-screen', () => {
+          mainWindow.hide()
+        })
+        mainWindow.setFullScreen(false)
+      } else {
+        mainWindow.hide()
+      }
     }
   })
 


### PR DESCRIPTION
## Description:

On mac, closing the main window when the app is in fullscreen mode results in a black screen (see #1893). To resolve this, ensure that we exit fullscreen mode before hiding the app.

See https://github.com/electron/electron/issues/6033

## Motivation and Context:

Fix #1893

## How Has This Been Tested?

Follow repro steps in #1893

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
