### PR TITLE
build(electron): exclude node modules from production app

### DIFF
--- a/electron/about/index.js
+++ b/electron/about/index.js
@@ -2,6 +2,7 @@
 'use strict'
 
 import electron, { BrowserWindow } from 'electron'
+import isDev from 'electron-is-dev'
 
 const path = require('path')
 
@@ -22,9 +23,9 @@ function openAboutWindow(info, htmlPath) {
     icon: info.icon_path,
     webPreferences: {
       nodeIntegration: false,
-      preload: process.env.HOT
-        ? path.resolve(__dirname, 'preload.js')
-        : path.resolve(__dirname, 'about_preload.prod.js'),
+      preload: isDev
+        ? path.resolve('electron/about', 'preload.js')
+        : path.resolve(__dirname, 'about', 'preload.js'),
     },
   }
   window = new BrowserWindow(options)

--- a/electron/menuBuilder.js
+++ b/electron/menuBuilder.js
@@ -1,6 +1,7 @@
 // @flow
 import os from 'os'
 import { app, Menu, shell, BrowserWindow, ipcMain } from 'electron'
+import isDev from 'electron-is-dev'
 import { appRootPath } from '@zap/lnd/util'
 import { getLanguageName, locales } from '@zap/i18n'
 import { getPackageDetails } from '@zap/utils'
@@ -15,15 +16,17 @@ const buildAboutMenu = () => {
       const { productName, version } = getPackageDetails()
       openAboutWindow(
         {
-          icon_path: path.resolve(appRootPath(), 'resources', 'icon.png'),
+          icon_path: isDev
+            ? path.resolve('resources', 'icon.png')
+            : path.resolve(appRootPath(), 'resources', 'icon.png'),
           open_devtools: process.env.NODE_ENV === 'development' || process.env.DEBUG_PROD,
           product_name: `${productName} ${version}`,
         },
-        `file://${path.resolve(
-          process.env.HOT ? '' : app.getAppPath(),
-          'electron/about/public/',
-          'about.html'
-        )}`
+        // When running in dev mode, load the about code from source directly.
+        // When the app is packaged for production, the about src code is copeid into the dist dir with WebpackCopy.
+        isDev
+          ? `file://${path.resolve('electron/about/public/', 'about.html')}`
+          : `file://${path.resolve(app.getAppPath(), 'dist/about/public/', 'about.html')}`
       )
     },
   }

--- a/webpack/webpack.config.renderer.prod.js
+++ b/webpack/webpack.config.renderer.prod.js
@@ -60,7 +60,7 @@ export default merge.smart(baseConfig, {
 
     new CopyWebpackPlugin([
       path.join('renderer', 'empty.html'),
-      { from: path.join('electron/about', 'preload.js'), to: 'about_preload.prod.js' },
+      { from: path.join('electron', 'about'), to: 'about' },
     ]),
 
     new CspHtmlWebpackPlugin({


### PR DESCRIPTION
## Description:

Since flattening the repo in #1895 the linux builds have been broken. On investigation I've discovered that it's attempting to package a bunch of node_modules that it should not be.

By default, electron-builder packages app production dependencies and ignores devDependencies. Since we bundle all of our code with webpack, technically everything is a development dependency so one solution would be to move all dependencies to `devDependencies`. However, I think it's cleaner for us to just exclude `node_modules` and to keep the `dependencies` section referencing only the dependencies that we actually use in the app.

Additionally, this adjusts how we package the `about` window code and resolves an issue where it was not correctly displaying the logo when running `yarn start`
 
## Motivation and Context:

Fix build issues.

## How Has This Been Tested?

`yarn dev`, `yarn start`, `yarn package`

## Types of changes:

Build gfixes

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
