### PR TITLE
perf: do not store network edges in state

### DIFF
--- a/renderer/reducers/network.js
+++ b/renderer/reducers/network.js
@@ -44,8 +44,8 @@ export const fetchDescribeNetwork = () => dispatch => {
 }
 
 // Receive IPC event for describeNetwork
-export const receiveDescribeNetwork = (event, { nodes, edges }) => dispatch =>
-  dispatch({ type: RECEIVE_DESCRIBE_NETWORK, nodes, edges })
+export const receiveDescribeNetwork = (event, { nodes }) => dispatch =>
+  dispatch({ type: RECEIVE_DESCRIBE_NETWORK, nodes })
 
 // ------------------------------------
 // Helpers
@@ -81,11 +81,10 @@ const mergeNodeUpdates = (state, nodeData) => {
 const ACTION_HANDLERS = {
   [UPDATE_NODE_DATA]: (state, { nodeData }) => nodeData.reduce(mergeNodeUpdates, state),
   [GET_DESCRIBE_NETWORK]: state => ({ ...state, networkLoading: true }),
-  [RECEIVE_DESCRIBE_NETWORK]: (state, { nodes, edges }) => ({
+  [RECEIVE_DESCRIBE_NETWORK]: (state, { nodes }) => ({
     ...state,
     networkLoading: false,
     nodes,
-    edges,
   }),
 }
 
@@ -95,7 +94,6 @@ const ACTION_HANDLERS = {
 const initialState = {
   networkLoading: false,
   nodes: [],
-  edges: [],
 }
 
 // ------------------------------------

--- a/renderer/store/configureStore.dev.js
+++ b/renderer/store/configureStore.dev.js
@@ -39,7 +39,6 @@ export const configureStore = initialState => {
           stateSanitizer: state => {
             const { invoice, locale, network } = state
             const MAX_NODES = 10
-            const MAX_EDGES = 10
 
             return state.invoice
               ? {
@@ -65,13 +64,6 @@ export const configureStore = initialState => {
                             `<<${network.nodes.length - MAX_NODES}_MORE_NODES>>`,
                           ]
                         : network.nodes,
-                    edges:
-                      network.edges.length > MAX_EDGES
-                        ? [
-                            ...network.edges.slice(0, MAX_EDGES),
-                            `<<${network.edges.length - MAX_EDGES}_MORE_NODES>>`,
-                          ]
-                        : network.edges,
                   },
 
                   // Strip out translation strings.


### PR DESCRIPTION
## Description:

Do not store network edges in state. We don't use this data anywhere, and it takes up a lot of memory.

## Motivation and Context:

I was doing some debugging and analysing the memory heap. The thing that takes up the bulk of our memory (sometimes over 50%)is the network edge list. It grows considerably over time as the app remains open.

## How Has This Been Tested?

Look at memory snapshot (taken from memory tab of devtools)before and after patch.

## Types of changes:

Performance improvement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
