### PR TITLE
fix(lndconnect): support old style lndconnect links

### DIFF
--- a/package.json
+++ b/package.json
@@ -344,7 +344,7 @@
     "javascript-state-machine": "3.1.0",
     "jstimezonedetect": "1.0.6",
     "lnd-grpc": "0.1.21",
-    "lndconnect": "0.2.3",
+    "lndconnect": "0.2.4",
     "lodash.debounce": "4.0.8",
     "lodash.get": "4.4.2",
     "lodash.matches": "4.6.0",

--- a/renderer/components/Onboarding/Steps/ConnectionConfirm.js
+++ b/renderer/components/Onboarding/Steps/ConnectionConfirm.js
@@ -61,10 +61,22 @@ class ConnectionConfirm extends React.Component {
 
     // If its already an lndconnect uri, use it as is.
     if (connectionString.startsWith('lndconnect:')) {
+      // In order to support legacy style lndconnect links we first pass the connection string through
+      // lndconnect.decode (which supports legacy style links where the host is provided as a querystring). Then encode
+      // the result. This ensures that we always store the link the current lndconnect format (with the host part in the
+      // origin position).
+      //
+      // eg. legacy lndconnect format:
+      // lndconnect:?cert=~/.lnd/tls.cert&macaroon=~/.lnd/admin.macaroon&host=example.com:10009
+      //
+      // eg. current lndconnect format:
+      // lndconnect://example.com:10009?cert=~/.lnd/tls.cert&macaroon=~/.lnd/admin.macaroon
+      const lndconnectUri = encode(decode(connectionString))
+
       return startLnd({
         type: 'custom',
         decoder: 'lnd.lndconnect.v1',
-        lndconnectUri: connectionString,
+        lndconnectUri,
       })
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10949,10 +10949,10 @@ lnd-grpc@0.1.21:
     debug "^4.1.1"
     semver "^5.7.0"
 
-lndconnect@0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/lndconnect/-/lndconnect-0.2.3.tgz#73cdaa0533aebccce72a64830867b047f4a9523c"
-  integrity sha512-hpct0HRTfAxbmUUfYQoHTiIsIbARs2NxGP19iFfxqzU/DoDuyX+tpnAOxfSA1sD0TGITXl3aNXYJD9Mp1xIqvw==
+lndconnect@0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/lndconnect/-/lndconnect-0.2.4.tgz#26be0bbc5c13f730ac377bb768708356fa72c4d2"
+  integrity sha512-TrDSPJysUhfZ+Zjh3K8Prs3ARhUO+jdaxFdRNpZQQowyU3fty0L5fgU1flBb6WseICmQZoWel9ORBLrkFwzKwQ==
   dependencies:
     base64url "^3.0.1"
     decode-uri-component "^0.2.0"


### PR DESCRIPTION
## Description:

Convert old style lndconnect links to the new format before storing as part of a wallet config.

## Motivation and Context:

fix #1997

## How Has This Been Tested?

Try an old style lndconnect link, like the ones used by Node Launcher:

edit to work with your own node:
```
lndconnect:?cert=~/.lnd/tls.cert&macaroon=~/.lnd/admin.macaroon&host=example.com:10009
```

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
