### PR TITLE
fix(launchpad): fallback wallet name incase host unknown

### DIFF
--- a/renderer/components/Util/WalletName.js
+++ b/renderer/components/Util/WalletName.js
@@ -4,11 +4,18 @@ const WalletName = ({ wallet }) => {
   if (!wallet) {
     return null
   }
+  const { name, host, type, id } = wallet
 
-  if (wallet.type === 'local') {
-    return wallet.name || `Wallet #${wallet.id}`
+  // For local wallets, display the wallet name if set.
+  // Otherwise fallback to the wallet id.
+  if (type === 'local') {
+    return name || `Wallet #${id}`
   }
-  return wallet.name || wallet.host.split(':')[0]
+
+  // For remote wallets, use the wallet name if set.
+  // Otherwise use the hostname.
+  // If neither are set, provide a fallback value.
+  return name || (host && host.split(':')[0]) || '[unnamed]'
 }
 
 WalletName.propTypes = {


### PR DESCRIPTION
## Description:

Show a fallback value in case we are unable to determine the wallet name, rather than crashing the app.

This PR sets the wallet name as `[unnamed]` in the case that we can't determine the wallet name.

## Motivation and Context:

In some situations (eg #1997) it's possible that a corrupt wallet config gets saved such that we are unable to determine the wallet name correctly. In this case, the app crashes as it assumes that a wallet config has a value for `host`.

## How Has This Been Tested?

Put an invalid wallet config into the db (one without a host prop) and verify that the app doesn't crash when trying to access the wallet's settings form.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/200251/55911074-2a2e7380-5be0-11e9-8df6-116cb15ce458.png)

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
