### PR TITLE
fix(channels): prevent crash when closing a channel

### DIFF
--- a/renderer/components/App/App.js
+++ b/renderer/components/App/App.js
@@ -52,7 +52,7 @@ function App({
   useEffect(() => {
     if (isAppReady && payReq) {
       if (!modals.find(m => m.type === 'PAY_FORM')) {
-        setModals(['PAY_FORM'])
+        setModals([{ type: 'PAY_FORM' }])
       }
     }
   }, [payReq, isAppReady])

--- a/renderer/components/Channels/ChannelDetail.js
+++ b/renderer/components/Channels/ChannelDetail.js
@@ -14,37 +14,39 @@ const ChannelDetail = ({
   setSelectedChannel,
   networkInfo,
   ...rest
-}) => (
-  <Panel {...rest}>
-    <Panel.Header mx="auto" width={9 / 16}>
-      <ChannelHeader channel={channel} />
-    </Panel.Header>
-    <Panel.Body css={{ 'overflow-y': 'overlay', 'overflow-x': 'hidden' }}>
-      <ChannelCapacity
-        localBalance={channel.local_balance}
-        mx="auto"
-        my={4}
-        remoteBalance={channel.remote_balance}
-        width={9 / 16}
-      />
-      <ChannelData
-        channel={channel}
-        currencyName={currencyName}
-        mx="auto"
-        networkInfo={networkInfo}
-        viewMode={CHANNEL_DATA_VIEW_MODE_FULL}
-        width={9 / 16}
-      />
-    </Panel.Body>
+}) => {
+  return channel ? (
+    <Panel {...rest}>
+      <Panel.Header mx="auto" width={9 / 16}>
+        <ChannelHeader channel={channel} />
+      </Panel.Header>
+      <Panel.Body css={{ 'overflow-y': 'overlay', 'overflow-x': 'hidden' }}>
+        <ChannelCapacity
+          localBalance={channel.local_balance}
+          mx="auto"
+          my={4}
+          remoteBalance={channel.remote_balance}
+          width={9 / 16}
+        />
+        <ChannelData
+          channel={channel}
+          currencyName={currencyName}
+          mx="auto"
+          networkInfo={networkInfo}
+          viewMode={CHANNEL_DATA_VIEW_MODE_FULL}
+          width={9 / 16}
+        />
+      </Panel.Body>
 
-    <Panel.Footer mt={2} px={4}>
-      <ChannelFooter channel={channel} closeChannel={closeChannel} />
-    </Panel.Footer>
-  </Panel>
-)
+      <Panel.Footer mt={2} px={4}>
+        <ChannelFooter channel={channel} closeChannel={closeChannel} />
+      </Panel.Footer>
+    </Panel>
+  ) : null
+}
 
 ChannelDetail.propTypes = {
-  channel: PropTypes.object.isRequired,
+  channel: PropTypes.object,
   closeChannel: PropTypes.func.isRequired,
   currencyName: PropTypes.string.isRequired,
   networkInfo: PropTypes.shape({

--- a/renderer/containers/Channels/ChannelDetailModal.js
+++ b/renderer/containers/Channels/ChannelDetailModal.js
@@ -1,0 +1,44 @@
+import React, { useEffect } from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+import { decoratedSelectedChannel } from 'reducers/utils'
+import { closeAllModals } from 'reducers/modal'
+import ChannelCloseDialog from './ChannelCloseDialog'
+import ChannelDetail from './ChannelDetail'
+
+function ChannelDetailModal({ channel, type, closeAllModals }) {
+  // if selected channel is no longer available, close the modal
+  // this is needed to handle external state changes like channel closing
+  // initiated either by a 3rd party or a user
+  useEffect(() => {
+    if (!channel) {
+      closeAllModals({ type })
+    }
+  }, [channel])
+
+  return (
+    <>
+      <ChannelDetail mx={-4} />
+      <ChannelCloseDialog />
+    </>
+  )
+}
+
+const mapStateToProps = state => ({
+  channel: decoratedSelectedChannel(state),
+})
+
+const mapDispatchToProps = {
+  closeAllModals,
+}
+
+ChannelDetailModal.propTypes = {
+  channel: PropTypes.object,
+  closeAllModals: PropTypes.func.isRequired,
+  type: PropTypes.string.isRequired,
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ChannelDetailModal)

--- a/renderer/containers/ModalStack.js
+++ b/renderer/containers/ModalStack.js
@@ -9,8 +9,7 @@ import { useOnKeydown } from 'hooks'
 import Pay from 'containers/Pay'
 import Request from 'containers/Request'
 import Channels from 'containers/Channels'
-import ChannelCloseDialog from 'containers/Channels/ChannelCloseDialog'
-import ChannelDetail from 'containers/Channels/ChannelDetail'
+import ChannelDetailModal from 'containers/Channels/ChannelDetailModal'
 import ChannelCreate from 'containers/Channels/ChannelCreate'
 import ReceiveModal from 'containers/Wallet/ReceiveModal'
 import ActivityModal from 'containers/Activity/ActivityModal'
@@ -40,12 +39,7 @@ const ModalContent = ({ type, closeModal }) => {
       return <ChannelCreate mx={-4} onSubmit={() => closeModal()} />
 
     case 'CHANNEL_DETAIL':
-      return (
-        <>
-          <ChannelDetail mx={-4} />
-          <ChannelCloseDialog />
-        </>
-      )
+      return <ChannelDetailModal type="CHANNEL_DETAIL" />
   }
 }
 

--- a/renderer/reducers/modal.js
+++ b/renderer/reducers/modal.js
@@ -1,3 +1,5 @@
+import matches from 'lodash.matches'
+
 import genId from '@zap/utils/genId'
 
 // ------------------------------------
@@ -15,17 +17,14 @@ export const CLOSE_MODAL = 'CLOSE_MODAL'
 export const CLOSE_ALL_MODALS = 'CLOSE_ALL_MODALS'
 export const SET_MODALS = 'SET_MODALS'
 
+const createModalData = (type, options) => ({ id: genId(), type, options })
 // ------------------------------------
 // Actions
 // ------------------------------------
-export function openModal(type) {
-  const modal = {
-    id: genId(),
-    type,
-  }
+export function openModal(type, options) {
   return {
     type: OPEN_MODAL,
-    modal,
+    modal: createModalData(type, options),
   }
 }
 
@@ -36,17 +35,37 @@ export function closeModal(id) {
   }
 }
 
-export function closeAllModals() {
-  return {
-    type: CLOSE_ALL_MODALS,
+export function closeAllModals(predicate) {
+  return (dispatch, getState) => {
+    // returns a specific list of modal ids that have to be closed
+    // or undefined if the entire modal stack needs to be cleared
+    const getIdsToClose = () => {
+      if (!predicate) {
+        return undefined
+      }
+      const state = getState().modal
+      // find all modal ids that match predicate
+      const matcher = matches(predicate)
+      return state.modals.filter(matcher).map(m => m.id)
+    }
+
+    // Check if there is a specific list of modals to close
+    const ids = getIdsToClose()
+    if (ids) {
+      ids.map(id => dispatch(closeModal(id)))
+    }
+    // Otherwise close all
+    else {
+      dispatch({
+        type: CLOSE_ALL_MODALS,
+        ids,
+      })
+    }
   }
 }
 
 export function setModals(modalList = []) {
-  const modals = modalList.map(type => ({
-    id: genId(),
-    type,
-  }))
+  const modals = modalList.map(({ type, options }) => createModalData(type, options))
   return {
     type: SET_MODALS,
     modals,

--- a/renderer/reducers/utils.js
+++ b/renderer/reducers/utils.js
@@ -90,7 +90,7 @@ export const decoratedSelectedChannel = createSelector(
   transactionsSelectors.rawTransactionsSelector,
   channelsSelectors.selectedChannel,
   (transactions, channelData) => {
-    if (channelData.channel_point) {
+    if (channelData && channelData.channel_point) {
       const [funding_txid] = channelData.channel_point.split(':')
       // cross reference funding tx
       const fundingTx = funding_txid && transactions.find(tx => tx.tx_hash === funding_txid)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
FIx app crash when closing a channel
<!--- Describe your changes in detail -->

## Motivation and Context:
This PR fixes/changes a couple of things
1. A crash when the channel is closed and removed from the list (resolves #1996)
2. Automatically closes channels details modal after closing is done
3. Add ability to pass additional data when opening a modal and then carpet-closing modals based on predicates
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes:
Bugfix/Refactor
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [ ] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
