### PR TITLE
fix(ui): improve scrollbar visibility

### DIFF
--- a/renderer/components/UI/GlobalStyle.js
+++ b/renderer/components/UI/GlobalStyle.js
@@ -1,5 +1,7 @@
 import { createGlobalStyle } from 'styled-components'
 import reset from 'styled-reset'
+import { rgba } from 'polished'
+import { themeGet } from 'styled-system'
 
 /* eslint-disable max-len */
 const GlobalStyle = createGlobalStyle`
@@ -41,18 +43,19 @@ const GlobalStyle = createGlobalStyle`
   }
 
   ::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
+    width: 10px;
+    height: 10px;
   }
 
-  ::-webkit-scrollbar-track,
-  ::-webkit-scrollbar-corner {
-    background: rgba(0, 0, 0, 0.1);
+  ::-webkit-scrollbar-track {
+    background: ${props => rgba(themeGet('colors.primaryText')(props), 0.12)};
+    box-shadow: inset 0 0 4px rgba(0, 0, 0, 0.3);
+    border-radius: 4px;
   }
 
   ::-webkit-scrollbar-thumb {
-    background: rgba(0, 0, 0, 0.3);
-    border-radius: 5px;
+    background: ${props => rgba(themeGet('colors.primaryText')(props), 0.4)};
+    border-radius: 4px;
   }
 
   a {


### PR DESCRIPTION
## Description:

Improve scrollbar visibility:

 - Use the primary text colour as the accent colour for the scrollbars.
 - Increase the width by 2px

## Motivation and Context:

fix #2025

## How Has This Been Tested?

Manually (dark and light theme)

## Screenshots:

**Before::**

![image](https://user-images.githubusercontent.com/200251/56233751-13769980-6084-11e9-85d3-477e92510e88.png)

**After:**

![image](https://user-images.githubusercontent.com/200251/56233898-5e90ac80-6084-11e9-9db6-7afb2fcb2e17.png)

## Types of changes:

UI improvement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
