### PR TITLE
fix(i18n): select current locale in language menu

### DIFF
--- a/electron/menuBuilder.js
+++ b/electron/menuBuilder.js
@@ -312,7 +312,7 @@ export default class ZapMenuBuilder {
         return {
           label: getLanguageName(locale),
           type: 'radio',
-          isChecked: this.locale === locale,
+          checked: this.locale === locale,
           click: () => this.mainWindow.webContents.send('receiveLocale', locale),
         }
       }),


### PR DESCRIPTION
## Description:

Ensure that currently selected language is selected in the language menu.

## Motivation and Context:

Fixes a bug where the selected language did not change in the language menu after changing the app language.

## How Has This Been Tested?

Change the language and ensure that the selected language in the system language menu updates correctly.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
