### PR TITLE
perf(channels): optimize list rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -348,6 +348,7 @@
     "lndconnect": "0.2.4",
     "lodash.debounce": "4.0.8",
     "lodash.get": "4.4.2",
+    "lodash.isequal": "4.5.0",
     "lodash.matches": "4.6.0",
     "lodash.partition": "4.6.0",
     "lodash.pick": "4.4.0",

--- a/renderer/components/Channels/ChannelCardList.js
+++ b/renderer/components/Channels/ChannelCardList.js
@@ -11,7 +11,6 @@ const StyledList = styled(Grid)`
   overflow-y: overlay !important;
   overflow-x: hidden !important;
 `
-
 const ChannelCardList = ({
   channels,
   currencyName,
@@ -43,7 +42,6 @@ const ChannelCardList = ({
       >
         <ChannelCardListItem
           channel={channel}
-          css={{ height: '100%' }}
           currencyName={currencyName}
           networkInfo={networkInfo}
           openModal={openModal}
@@ -62,6 +60,7 @@ const ChannelCardList = ({
             columnCount={2}
             columnWidth={width / 2}
             height={height}
+            overscanRowCount={5}
             rowCount={Math.ceil(channels.length / 2)}
             rowHeight={ROW_HEIGHT}
             width={width}

--- a/renderer/components/Channels/ChannelCardListItem.js
+++ b/renderer/components/Channels/ChannelCardListItem.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import isEqual from 'lodash.isequal'
 import { FormattedMessage, injectIntl, intlShape } from 'react-intl'
 import styled from 'styled-components'
 import { opacity } from 'styled-system'
@@ -17,8 +18,10 @@ const ClippedText = withEllipsis(Text)
 const Box = styled(BaseBox)(opacity)
 const Flex = styled(BaseFlex)(opacity)
 
+const areEqual = (prevProps, nextProps) => isEqual(prevProps, nextProps)
+
 const ChannelCardListItem = React.memo(
-  ({ intl, channel, currencyName, openModal, setSelectedChannel, networkInfo, ...rest }) => {
+  ({ channel, currencyName, openModal, setSelectedChannel, networkInfo }) => {
     const {
       channel_point,
       display_name,
@@ -29,8 +32,9 @@ const ChannelCardListItem = React.memo(
       active,
     } = channel
     const opacity = active ? 1 : 0.3
+
     return (
-      <Card {...rest}>
+      <Card>
         <Panel>
           <Panel.Header>
             <Flex justifyContent="space-between">
@@ -82,7 +86,8 @@ const ChannelCardListItem = React.memo(
         </Panel>
       </Card>
     )
-  }
+  },
+  areEqual
 )
 
 ChannelCardListItem.displayName = 'ChannelCardListItem'

--- a/renderer/components/Channels/ChannelSummaryListItem.js
+++ b/renderer/components/Channels/ChannelSummaryListItem.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import isEqual from 'lodash.isequal'
 import { Box, Flex } from 'rebass'
 import { Card, Heading, Text } from 'components/UI'
 import { withEllipsis } from 'hocs'
@@ -9,6 +10,8 @@ import ChannelStatus from './ChannelStatus'
 
 const ClippedHeading = withEllipsis(Heading.h1)
 const ClippedText = withEllipsis(Text)
+
+const areEqual = (prevProps, nextProps) => isEqual(prevProps, nextProps)
 
 const ChannelSummaryListItem = React.memo(props => {
   const { channel, openModal, setSelectedChannel, ...rest } = props
@@ -58,7 +61,7 @@ const ChannelSummaryListItem = React.memo(props => {
       </Flex>
     </Card>
   )
-})
+}, areEqual)
 
 ChannelSummaryListItem.displayName = 'ChannelSummaryListItem'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10567,7 +10567,7 @@ lodash.get@4.4.2, lodash.get@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
-lodash.isequal@^4.5.0:
+lodash.isequal@4.5.0, lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Improve channels virtualized list rendering by reducing overscan for the card view, removing dynamic objects (css style) and introducing deep compare for the props. We have a complex `channel` object which is produced by a selector and is additionally decorated. This was causing redundant re-renders of the channel list items. Overscan count was reduced only  for the card view because are a lot larger than summary items.
<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes:
Perf improvement
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
