### PR TITLE
feat(config): read autoupdate settings from global config

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -7,10 +7,19 @@
     "domain": "DB_DOMAIN"
   },
 
+  "autoupdate": {
+    "active": {
+      "__name": "AUTOUPDATE_ACTIVE",
+      "__format": "json"
+    },
+    "channel": "AUTOUPDATE_CHANNEL"
+  },
+
   "chains": {
     "__name": "CHAINS",
     "__format": "json"
   },
+
   "networks": {
     "__name": "NETWORKS",
     "__format": "json"

--- a/config/default.js
+++ b/config/default.js
@@ -16,6 +16,11 @@ module.exports = {
     domain: isStableVersion(getPackageDetails().version, STABLE_VERSION) ? null : 'next',
   },
 
+  autoupdate: {
+    active: true,
+    channel: 'beta',
+  },
+
   // Supported chains.
   chains: ['bitcoin', 'litecoin'],
 

--- a/electron/updater.js
+++ b/electron/updater.js
@@ -1,36 +1,27 @@
 import { dialog } from 'electron'
 import { autoUpdater } from 'electron-updater'
 import isDev from 'electron-is-dev'
+import config from 'config'
 import { updaterLog } from '@zap/utils/log'
 import delay from '@zap/utils/delay'
 
 autoUpdater.logger = updaterLog
-
-/**
- * Update Channel
- * supported channels are 'alpha', 'beta' and 'latest'
- * Refer electron-builder docs
- */
-autoUpdater.channel = process.env.AUTOUPDATE_CHANNEL || 'beta'
+autoUpdater.channel = config.autoupdate.channel
 autoUpdater.allowDowngrade = false
 
 /**
- * @class ZapController
+ * @class ZapUpdater
  *
  * The ZapUpdater class manages the electron auto update process.
  */
 class ZapUpdater {
-  /**
-   * Create a new ZapUpdater instance.
-   * @param  {BrowserWindow} mainWindow BrowserWindow instance to interact with
-   */
   constructor(mainWindow) {
     this.mainWindow = mainWindow
   }
 
   init() {
-    // Do not run the updater if we are running in dev mode.
-    if (isDev) {
+    // Do not run the updater if we are running in dev mode or if autoupdates are disabled.
+    if (isDev || !config.autoupdate.active) {
       return
     }
 


### PR DESCRIPTION
## Description:

Read autoupdate config from global config rather than hardcoding into the autoupdater class.

## Motivation and Context:

Consolidate settings and make easier to change config.

## How Has This Been Tested?

Manually

## Types of changes:

Enhancement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
