### PR TITLE
fix(electron): use os rather than platform name for releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
         ]
       }
     ],
-    "artifactName": "${productName}-${platform}-${arch}-v${version}.${ext}",
+    "artifactName": "${productName}-${os}-${arch}-v${version}.${ext}",
     "mac": {
       "category": "public.app-category.finance",
       "icon": "resources/icon.icns",


### PR DESCRIPTION
## Description:

Use os rather than platform name for releases. 

## Motivation and Context:

Create releases with more human friendly names.

before:

```
Zap-darwin-v0.5.0-alpha.dmg
Zap-linux-amd64-v0.5.0-alpha.deb
Zap-win32-v0.5.0-alpha.exe
```

after:
```
Zap-mac-v0.5.0-alpha.dmg
Zap-linux-amd64-v0.5.0-alpha.deb
Zap-windows-v0.5.0-alpha.exe
```
## How Has This Been Tested?

`yarn package -mlw`

## Types of changes:

Build fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
