### PR TITLE
fix(electron): handle autoupdate errors

### DIFF
--- a/electron/updater.js
+++ b/electron/updater.js
@@ -53,10 +53,14 @@ class ZapUpdater {
     this.initAutoUpdate()
   }
 
-  initAutoUpdate() {
-    autoUpdater.checkForUpdates()
-    const oneHour = 60 * 60 * 1000
-    setInterval(() => autoUpdater.checkForUpdates(), oneHour)
+  async initAutoUpdate() {
+    try {
+      await autoUpdater.checkForUpdates()
+      const oneHour = 60 * 60 * 1000
+      setInterval(() => autoUpdater.checkForUpdates(), oneHour)
+    } catch (error) {
+      updaterLog.warn('Cannot check for updates', error.message)
+    }
   }
 }
 


### PR DESCRIPTION
## Description:

Handle autoupdate errors and do not retry updates in the event that the first attempt was unsuccessful.

## Motivation and Context:

Autoupdate is not supported for the `.deb` release, so gracefully handle errors caused by trying to run the updater.

Fix #2070

## How Has This Been Tested?

Manually

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
