### PR TITLE
fix(lnd): increase lnd debug level

### DIFF
--- a/lnd/neutrino.js
+++ b/lnd/neutrino.js
@@ -124,6 +124,7 @@ class Neutrino extends EventEmitter {
       `--listen=${listen}`,
       `--restlisten=${restlisten}`,
       `--routing.assumechanvalid`,
+      '--debuglevel=debug',
       `${this.lndConfig.alias ? `--alias=${this.lndConfig.alias}` : ''}`,
       `${this.lndConfig.autopilot ? '--autopilot.active' : ''}`,
       `${this.lndConfig.autopilotPrivate ? '--autopilot.private' : ''}`,


### PR DESCRIPTION
## Description:

Increase lnd debug level

## Motivation and Context:

At some point recently, the lnd log level has reverted from `debug` to `info`. We rely on debug level log output from lnd in order to monitor it's sync process when running as a local neutrino client. We are missing some of the messages that only show on the debug level, which we use to determine the sync state and as a result the progress bnar is updating very infrequently.

## How Has This Been Tested?

Manually - note, granularity and regularity of sync progress updates is increased.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
