### PR TITLE
ci: pin node to version 11.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ os:
   - osx
 
 language: node_js
-node_js: stable
+node_js:
+  - '11'
 
 cache:
   apt: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ os: unstable
 environment:
   DEBUG: electron-builder
   matrix:
-    - nodejs_version: STABLE
+    - nodejs_version: '11'
 
 cache:
   - node_modules -> package.json


### PR DESCRIPTION
## Description:

Pin node to version 11 on ci environments.

## Motivation and Context:

Travis just updated node to v12, and it's not building properly (eg https://travis-ci.com/LN-Zap/zap-desktop/jobs/195058149)