### PR TITLE
test(e2e): fix tests getting stuck on win in some cases

### DIFF
--- a/test/e2e/utils/helpers.js
+++ b/test/e2e/utils/helpers.js
@@ -1,6 +1,7 @@
 import { ClientFunction } from 'testcafe'
 import path from 'path'
 import rimraf from 'rimraf'
+import os from 'os'
 import ps from 'ps-node'
 import { promisify } from 'util'
 import delay from '../../../utils/delay'
@@ -37,8 +38,12 @@ export const assertNoConsoleErrors = async t => {
 }
 
 const printLndProcesses = async () => {
-  const processes = await psLookup({ command: 'lnd' })
-  console.log('lnd processes', processes)
+  // under windows platform psLookup may cause issues which results
+  // in unpredictable behavior of e2e tests
+  if (os.platform() !== 'win32') {
+    const processes = await psLookup({ command: 'lnd' })
+    console.log('lnd processes', processes)
+  }
 }
 
 // Clean out test environment.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Fix e2e tests getting stuck in windows under certain circumstances
Resolve #2076 
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
`yarn test-e2e`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes:
e2e tests fix 
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x ] My commits have been squashed into a concise set of changes.
