### PR TITLE
refactor: rename Grpc service class

### DIFF
--- a/services/grpc/grpc.js
+++ b/services/grpc/grpc.js
@@ -12,10 +12,10 @@ const WALLET_STATE_LOCKED = 'WALLET_STATE_LOCKED'
 const WALLET_STATE_ACTIVE = 'WALLET_STATE_ACTIVE'
 
 /**
- * Creates an lnd grpc client service.
- * @returns {GrpcService}
+ * Wrapper and controller for multiple GrpcService instances.
+ * @extends EventEmitter
  */
-class GrpcService extends EventEmitter {
+class Grpc extends EventEmitter {
   constructor() {
     super()
     this.fsm = new StateMachine({
@@ -248,4 +248,4 @@ class GrpcService extends EventEmitter {
   }
 }
 
-export default GrpcService
+export default Grpc

--- a/services/grpc/grpcService.js
+++ b/services/grpc/grpcService.js
@@ -15,8 +15,8 @@ import createMacaroonCreds from '@zap/utils/createMacaroonCreds'
 export const SUPPORTED_SERVICES = ['WalletUnlocker', 'Lightning']
 
 /**
- * Creates an lnd grpc client service.
- * @returns {GrpcService}
+ * Base class for lnd gRPC services.
+ * @extends EventEmitter
  */
 class GrpcService extends EventEmitter {
   constructor(serviceName, lndConfig) {

--- a/services/grpc/lightning/lightning.js
+++ b/services/grpc/lightning/lightning.js
@@ -1,14 +1,14 @@
 import { grpcLog } from '@zap/utils/log'
 import lndgrpc from 'lnd-grpc'
-import LndGrpcService from '@zap/services/grpc/grpcService'
+import GrpcService from '@zap/services/grpc/grpcService'
 import subscriptions from './lightning.subscriptions'
 import methods from './lightning.methods'
 
 /**
- * Creates an LND grpc client Lightning service.
- * @returns {Lightning}
+ * Lightning service controller.
+ * @extends GrpcService
  */
-class Lightning extends LndGrpcService {
+class Lightning extends GrpcService {
   constructor(lndConfig) {
     super('Lightning', lndConfig)
   }

--- a/services/grpc/walletUnlocker/walletUnlocker.js
+++ b/services/grpc/walletUnlocker/walletUnlocker.js
@@ -1,11 +1,11 @@
-import LndGrpcService from '@zap/services/grpc/grpcService'
+import GrpcService from '@zap/services/grpc/grpcService'
 import methods from './walletUnlocker.methods'
 
 /**
- * Creates an LND grpc client WalletUnlocker service.
- * @returns {WalletUnlocker}
+ * WalletUnlocker service controller.
+ * @extends GrpcService
  */
-class WalletUnlocker extends LndGrpcService {
+class WalletUnlocker extends GrpcService {
   constructor(lndConfig) {
     super('WalletUnlocker', lndConfig)
     this.useMacaroon = false


### PR DESCRIPTION
## Description:

Rename `Grpc` service to avoid conflict with `GrpcServce` and document classes.

## Motivation and Context:

Confusion/conflict between `Grpc` and `GrpcService` (both were called `GrpcService`)

## How Has This Been Tested?

CI

## Types of changes:

Refactor

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
