### PR TITLE
feat(onboarding): paste seed support in wallet recover

### DIFF
--- a/renderer/components/Onboarding/Steps/ConnectionDetailsManual.js
+++ b/renderer/components/Onboarding/Steps/ConnectionDetailsManual.js
@@ -199,7 +199,6 @@ class ConnectionDetailsManual extends React.Component {
                 mb={3}
                 name="connectionCert"
                 onBlur={this.validateCert}
-                onValueChange={this.handleConnectionCertChange}
                 validateOnBlur={shouldValidateInline}
                 validateOnChange={shouldValidateInline}
                 width={1}
@@ -213,7 +212,6 @@ class ConnectionDetailsManual extends React.Component {
                 label="Macaroon"
                 name="connectionMacaroon"
                 onBlur={this.validateMacaroon}
-                onValueChange={this.handleConnectionMacaroonChange}
                 validateOnBlur={shouldValidateInline}
                 validateOnChange={shouldValidateInline}
                 width={1}

--- a/renderer/components/UI/Input.js
+++ b/renderer/components/UI/Input.js
@@ -216,7 +216,9 @@ class Input extends React.Component {
       if (typeof value === 'undefined') {
         return initialValue
       }
-      return !value && value !== 0 ? '' : value
+      const { fieldState } = this.props
+      const { maskedValue } = fieldState
+      return !maskedValue && maskedValue !== 0 ? '' : maskedValue
     }
 
     return (

--- a/renderer/components/UI/TextArea.js
+++ b/renderer/components/UI/TextArea.js
@@ -168,7 +168,7 @@ class TextArea extends React.PureComponent {
     } = this.props
     const { hasFocus } = this.state
     const { setValue, setTouched } = fieldApi
-    const { value } = fieldState
+    const { maskedValue } = fieldState
 
     // Extract any styled-system space props so that we can apply them directly to the wrapper.
     const spaceProps = {}
@@ -227,7 +227,7 @@ class TextArea extends React.PureComponent {
           readOnly={isReadOnly}
           required={isRequired}
           theme={theme}
-          value={!value && value !== 0 ? '' : value}
+          value={!maskedValue && maskedValue !== 0 ? '' : maskedValue}
           {...rest}
         />
         {description && (

--- a/test/unit/utils/parseSeed.spec.js
+++ b/test/unit/utils/parseSeed.spec.js
@@ -1,0 +1,64 @@
+import parseSeed from '@zap/utils/parseSeed'
+
+const SEEDWORDS = [
+  'abstract',
+  'win',
+  'toilet',
+  'oxygen',
+  'culture',
+  'march',
+  'ladder',
+  'runway',
+  'cruel',
+  'nut',
+  'uniform',
+  'deer',
+  'fetch',
+  'type',
+  'attitude',
+  'occur',
+  'shy',
+  'radar',
+  'unit',
+  'begin',
+  'crater',
+  'adult',
+  'plastic',
+  'fabric',
+]
+
+describe('parseSeed', () => {
+  const allTests = [
+    [
+      /* eslint max-len: 0 */
+      'abstract win toilet oxygen culture march ladder runway cruel nut uniform deer fetch type attitude occur shy radar unit begin crater adult plastic fabric',
+      'delimited by spaces',
+    ],
+    [
+      /* eslint max-len: 0 */
+      'abstract, win, toilet, oxygen, culture, march, ladder, runway, cruel, nut, uniform, deer, fetch, type, attitude, occur, shy, radar, unit, begin, crater, adult, plastic, fabric',
+      'delimited by commas',
+    ],
+    [
+      /* eslint max-len: 0 */
+      '   123.  abstract, win, toilet, oxygen, culture, march, ladder, runway, cruel, nut, uniform, deer, fetch, type, attitude, occur, shy, radar, unit, begin, crater, adult, plastic, fabric  ',
+      'with leading and trailing characters',
+    ],
+    [
+      `1. abstract   2. win     3. toilet     4. oxygen
+5. culture    6. march   7. ladder     8. runway
+9. cruel     10. nut    11. uniform   12. deer
+13. fetch     14. type   15. attitude  16. occur
+17. shy       18. radar  19. unit      20. begin
+21. crater    22. adult  23. plastic   24. fabric`,
+      'as output from lnd genSeed',
+    ],
+  ]
+
+  allTests.forEach(test => {
+    const [seed, description] = test
+    it(`should parse a valid seed ${description}`, () => {
+      expect(parseSeed(seed)).toEqual(SEEDWORDS)
+    })
+  })
+})

--- a/utils/parseSeed.js
+++ b/utils/parseSeed.js
@@ -1,0 +1,22 @@
+const parseSeed = seed => {
+  if (typeof seed === 'string') {
+    return (
+      seed
+        // Convert to lowercase.
+        .toLowerCase()
+        // Replace commas with spaces.
+        .replace(/[,]/g, ' ')
+        // Replace everything except for lowercase letters and spaces.
+        .replace(/[^a-z\s]/g, '')
+        // Replace multiple spaces with a single space.
+        .replace(/\s+/g, ' ')
+        // Trim any leading and reailing spaces.
+        .trim()
+        // Split into individual words.
+        .split(' ')
+    )
+  }
+  return []
+}
+
+export default parseSeed


### PR DESCRIPTION
## Description:

If the user pastes a valid 24 word seed into the first input of the wallet recovery form, parse the seed from the clipboard into individual words and paste the words into each of the 24 inputs.

## Motivation and Context:

Entering a seed into the wallet recovery pager is tedious and slow.

## How Has This Been Tested?

- Added unit tests
- Manual test of recover UI

## Types of changes:

New feature

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
