### PR TITLE
fix(wallet): store and reuse unused address

### DIFF
--- a/renderer/reducers/address.js
+++ b/renderer/reducers/address.js
@@ -72,12 +72,11 @@ export const receiveAddressSuccess = ({ type, address }) => async (dispatch, get
 
   // If we know the node's public key, store the address for reuse.
   if (pubKey) {
-    const typeName = Object.keys(addressTypes).find(key => addressTypes[key] === type)
     const node = await window.db.nodes.get(pubKey)
     if (node) {
-      await node.setCurrentAddress(typeName, address)
+      await node.setCurrentAddress(type, address)
     } else {
-      await window.db.nodes.put({ id: pubKey, addresses: { [typeName]: address } })
+      await window.db.nodes.put({ id: pubKey, addresses: { [type]: address } })
     }
   }
 


### PR DESCRIPTION
## Description:

Store and reuse unused address.

## Motivation and Context:

This fixes a bug in the next branch in which fetched addresses are not being stored properly in the database, resulting in a new address being generated every time a wallet is launched.

## How Has This Been Tested?

1. Create a new wallet
2. Note the address that is shown in the sync screen
3. Exit the sync process
4. Relaunch the wallet and verify that the same address is shown.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
