### PR TITLE
refactor: pluck unused props before passing to dom

### DIFF
--- a/renderer/components/Pay/Pay.js
+++ b/renderer/components/Pay/Pay.js
@@ -632,6 +632,7 @@ class Pay extends React.Component {
       cryptoCurrency,
       cryptoCurrencyTicker,
       cryptoName,
+      fetchTickers,
       payReq,
       initialAmountCrypto,
       initialAmountFiat,

--- a/renderer/components/Request/Request.js
+++ b/renderer/components/Request/Request.js
@@ -165,6 +165,7 @@ class Request extends React.Component {
       cryptoCurrency,
       cryptoCurrencyTicker,
       cryptoName,
+      fetchTickers,
       intl,
       isProcessing,
       invoice,


### PR DESCRIPTION
## Description:

Pluck unused props before passing to dom

## Motivation and Context:

Warning like this when accessing Pay and Request forms:

```
react-dom.development.js:507 Warning: React does not recognize the `fetchTickers` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `fetchtickers` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

## Types of changes:

Refactor

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
