### PR TITLE
perf(app): prevent superfluous top level re-renders

### DIFF
--- a/test/unit/utils/scheduler.spec.js
+++ b/test/unit/utils/scheduler.spec.js
@@ -1,0 +1,121 @@
+import createScheduler from '@zap/utils/scheduler'
+import delay from '@zap/utils/delay'
+import promiseTimeout from '@zap/utils/promiseTimeout'
+
+describe('createScheduler tasks management', () => {
+  it('add task by task callback', () => {
+    const scheduler = createScheduler()
+    const task = () => {}
+    scheduler.addTask({ task })
+    expect(scheduler.isScheduled(task)).toEqual(true)
+  })
+
+  it('add task by taskId', () => {
+    const scheduler = createScheduler()
+    const task = () => {}
+    scheduler.addTask({ task, taskId: 'taskId' })
+    expect(scheduler.isScheduled('taskId')).toEqual(true)
+  })
+
+  it('remove task by task callback', () => {
+    const scheduler = createScheduler()
+    const task = () => {}
+    scheduler.addTask({ task })
+    scheduler.removeTask(task)
+    expect(scheduler.isScheduled(task)).toEqual(false)
+  })
+
+  it('remove task by taskId', () => {
+    const scheduler = createScheduler()
+    const task = () => {}
+    scheduler.addTask({ task, taskId: 'taskId' })
+    scheduler.removeTask('taskId')
+    expect(scheduler.isScheduled('taskId')).toEqual(false)
+  })
+
+  it('correctly remove all tasks', () => {
+    const scheduler = createScheduler()
+    const task = () => {}
+    scheduler.addTask({ task })
+    scheduler.removeAllTasks()
+    expect(scheduler.isScheduled(task)).toEqual(false)
+  })
+
+  it('correctly replace task ', () => {
+    const scheduler = createScheduler()
+    const task1 = () => {}
+    const task2 = () => {}
+    scheduler.addTask({ task: task1, taskId: 'myTask' })
+    scheduler.addTask({ task: task2, taskId: 'myTask' })
+    expect([scheduler.isScheduled(task1), scheduler.isScheduled(task2)]).toEqual([false, true])
+  })
+})
+
+describe('createScheduler tasks execution', () => {
+  test(`doesn't exeacture before delay`, () => {
+    const scheduler = createScheduler()
+    const promise = new Promise((resolve, reject) => {
+      scheduler.addTask({ task: reject, taskId: 'taskId', baseDelay: 100 })
+    })
+    return expect(Promise.race([delay(50), promise])).resolves.toBe(undefined)
+  })
+
+  test('executes at least 3 times', () => {
+    const scheduler = createScheduler()
+
+    // resolves after 3+ executions
+    const promise = new Promise(resolve => {
+      let times = 0
+      const task = () => {
+        if (times++ > 3) {
+          resolve(true)
+        }
+      }
+      scheduler.addTask({ task, taskId: 'taskId', baseDelay: 100 })
+    })
+    return expect(promiseTimeout(1000, promise)).resolves.toBe(true)
+  })
+
+  test('executes at least 3 times with backoff', () => {
+    const scheduler = createScheduler()
+
+    // resolves after 3+ executions
+    const promise = new Promise(resolve => {
+      let times = 0
+      const task = () => {
+        if (times++ > 3) {
+          resolve(true)
+        }
+      }
+      scheduler.addTask({ task, taskId: 'taskId', baseDelay: 100, backoff: 1.1 })
+    })
+    return expect(promiseTimeout(1000, promise)).resolves.toBe(true)
+  })
+
+  test('cancels execution correctly', () => {
+    const scheduler = createScheduler()
+
+    const promise = new Promise((resolve, reject) => {
+      scheduler.addTask({ task: reject, taskId: 'taskId', baseDelay: 100 })
+      // make sure remove is executed during the next event loop iteration
+      // to make test more robust
+      setTimeout(() => scheduler.removeTask('taskId'), 0)
+    })
+    return expect(Promise.race([delay(200), promise])).resolves.toBe(undefined)
+  })
+
+  test('cancels execution of the replaced callback correctly', () => {
+    const scheduler = createScheduler()
+
+    const originalTask = new Promise((resolve, reject) => {
+      scheduler.addTask({ task: reject, taskId: 'taskId', baseDelay: 100 })
+    })
+
+    const replacedTask = new Promise(resolve => {
+      scheduler.addTask({ task: resolve, taskId: 'taskId', baseDelay: 100 })
+    })
+
+    const promise = Promise.race([originalTask, replacedTask])
+    return expect(promiseTimeout(200, promise)).resolves.toBe(undefined)
+  })
+})

--- a/utils/scheduler.js
+++ b/utils/scheduler.js
@@ -1,0 +1,142 @@
+import delay from './delay'
+
+/**
+ * Recursive timeout function
+ *
+ * @param {*} { task, baseDelay, maxDelay, checkIsCancelled, backoff }
+ * @returns
+ */
+async function retry({
+  getTask,
+  baseDelay,
+  maxDelay,
+  checkIsCancelled,
+  backoff,
+  onCancelComplete,
+}) {
+  await delay(baseDelay)
+
+  if (checkIsCancelled()) {
+    onCancelComplete && onCancelComplete()
+  } else {
+    try {
+      const task = getTask()
+      task && task()
+    } finally {
+      // re-schedule next execution regardless of task result
+      const nextDelay = baseDelay * backoff
+      retry({
+        getTask,
+        baseDelay: maxDelay ? Math.min(maxDelay, nextDelay) : nextDelay,
+        maxDelay,
+        checkIsCancelled,
+        backoff,
+      })
+    }
+  }
+}
+
+/**
+ * Creates scheduler instance. It is allowed to have unlimited scheduler instances
+ * Schedulers allow to add and remove tasks with flat or backoff schedules
+ */
+export default function createScheduler() {
+  const taskList = {}
+
+  /**
+   * Physically removes `taskDefinition` from the execution queue
+   * @param {string|function} task - either original callback or `taskId`
+   */
+  const onCancelComplete = task => {
+    const taskDesc = findTask(task)
+    if (taskDesc) {
+      const keyToRemove = Object.keys(taskList).find(key => taskList[key] === taskDesc)
+      if (keyToRemove) {
+        delete taskList[keyToRemove]
+      }
+    }
+  }
+
+  /**
+   * Searches for the `taskDefinition` is in the execution queue
+   * @param {string|function} task - either original callback or `taskId`
+   */
+  const findTask = task => {
+    // search by taskId first
+    const { [task]: taskDesc } = taskList
+    if (taskDesc) {
+      return taskDesc
+    }
+
+    // else try to find by task callback
+    return Object.values(taskList).find(entry => entry.task === task)
+  }
+
+  /**
+   * Enqueues `task` for the continuous execution
+   * @param {Object} taskDefinition - task configuration
+   * @param {function} taskDefinition.task - task callback
+   * @param {string} taskDefinition.taskId - unique task identifier. Is required if there is an
+   * intention to replace `task`
+   * @param {number} taskDefinition.baseDelay - base delay in ms
+   * @param {number} taskDefinition.backoff - delay multiplier. Is multiplies `baseDelay` to
+   * produce next iteration delay. Use 1 for constant delay
+   * @param {number} taskDefinition.maxDelay - maximum delay. Only useful if `@backoff` is set
+   */
+  const addTask = ({ task, taskId, baseDelay, maxDelay, backoff = 1 }) => {
+    const getTask = () => {
+      if (!taskId) {
+        return task
+      }
+      const taskDesc = findTask(taskId)
+      return taskDesc && taskDesc.task
+    }
+
+    const checkIsCancelled = () => !isScheduled(taskId || task)
+    taskList[taskId || task] = { isCancelled: false, task }
+    retry({
+      getTask,
+      baseDelay,
+      maxDelay,
+      checkIsCancelled,
+      backoff,
+      onCancelComplete: () => onCancelComplete(task),
+    })
+  }
+
+  /**
+   * Removes `task` from the execution queue
+   * @param {string|function} task - either original callback or `taskId`
+   */
+  const removeTask = task => {
+    const taskDesc = findTask(task)
+    if (taskDesc) {
+      taskDesc.isCancelled = true
+      return true
+    }
+    return false
+  }
+
+  /**
+   * Clears the entire execution queue
+   */
+  const removeAllTasks = () => {
+    Object.keys(taskList).forEach(removeTask)
+  }
+
+  /**
+   * Checks whether `task` is in the execution queue
+   * @param {string|function} task - either original callback or `taskId`
+   */
+  const isScheduled = task => {
+    const taskDesc = findTask(task)
+    return Boolean(taskDesc && !taskDesc.isCancelled)
+  }
+
+  return {
+    addTask,
+    removeTask,
+    removeAllTasks,
+    isScheduled,
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Prevent unnecessary `App` re-renders by extracting peer poll timeout from the `state` into a ref
<!--- Describe your changes in detail -->

## Motivation and Context:
`nextFetchIn` doesn't  influence anything in render func so can be safely extracted into a ref
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually by monitoring redux log
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes:
Refactor/perf improvement
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
