### PR TITLE
chore: add new build flags to lnd build script

### DIFF
--- a/scripts/lnd-release/.goreleaser.yml
+++ b/scripts/lnd-release/.goreleaser.yml
@@ -6,10 +6,11 @@ builds:
     goarch:
       - amd64
       - '386'
+    binary: lnd
     ldflags:
       - -X github.com/lightningnetwork/lnd/build.Commit={{.Tag}}
     flags:
-      - -tags="experimental"
+      - -tags=experimental autopilotrpc signrpc walletrpc chainrpc invoicesrpc routerrpc
   - goos:
       - linux
       - darwin
@@ -22,7 +23,7 @@ builds:
     ldflags:
       - -X github.com/lightningnetwork/lnd/build.Commit={{.Tag}}
     flags:
-      - -tags="experimental"
+      - -tags=experimental autopilotrpc signrpc walletrpc chainrpc invoicesrpc routerrpc
 archive:
   name_template: '{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}{{ .Arm }}-v{{ .Version }}'
   format: tar.gz


### PR DESCRIPTION
## Description:

Updates our lnd build script to include new tags for the new grpc subservices.

## Motivation and Context:

Enabling the new services in our lnd build is a pre-requisite to being able to use them (needed to implement autopilot BOS scoring for example)