### PR TITLE
fix(grpc): subscribe for topology update only after sync is done

### DIFF
--- a/package.json
+++ b/package.json
@@ -345,6 +345,7 @@
     "lndconnect": "0.2.5",
     "lodash.debounce": "4.0.8",
     "lodash.get": "4.4.2",
+    "lodash.intersection": "4.4.0",
     "lodash.isequal": "4.5.0",
     "lodash.matches": "4.6.0",
     "lodash.merge": "4.6.1",

--- a/services/grpc/grpcService.js
+++ b/services/grpc/grpcService.js
@@ -155,6 +155,13 @@ class GrpcService extends EventEmitter {
         grpcLog.info(`gRPC subscription "${this.serviceName}.${key}" ended.`)
         delete this.subscriptions[key]
       })
+
+      call.on('status', callStatus => {
+        if (callStatus.code === status.CANCELLED) {
+          delete this.subscriptions[key]
+          grpcLog.info(`gRPC subscription "${this.serviceName}.${key}" ended.`)
+        }
+      })
     })
   }
 
@@ -199,7 +206,7 @@ class GrpcService extends EventEmitter {
 
     // Initiate cancellation request.
     call.cancel()
-    // Resolve once we recieve confirmation of the call's cancellation.
+    // Resolve once we receive confirmation of the call's cancellation.
     return result
   }
 

--- a/services/grpc/lightning/lightning.js
+++ b/services/grpc/lightning/lightning.js
@@ -49,19 +49,19 @@ class Lightning extends GrpcService {
     }
   }
 
-  // ------------------------------------
-  // Helpers
-  // ------------------------------------
-
-  /**
-   * Subscribe to all bi-directional streams.
-   */
-  subscribe() {
-    grpcLog.info('Subscribing to Lightning gRPC streams')
+  onAfterConnect() {
     this.subscriptions['channelGraph'] = this.subscribeChannelGraph()
     this.subscriptions['invoices'] = this.subscribeInvoices()
     this.subscriptions['transactions'] = this.subscribeTransactions()
-    super.subscribe()
+    this.subscriptions['getinfo'] = this.subscribeGetInfo()
+    super.subscribe('invoices', 'transactions', 'getinfo')
+    grpcLog.info(`Connected to ${this.serviceName} gRPC service`)
+  }
+
+  async subscribeChannelGraph() {
+    grpcLog.info('resubscribeChannelGraph')
+    await this.unsubscribe('channelGraph')
+    return await this.subscribe('channelGraph')
   }
 }
 

--- a/services/grpc/lightning/lightning.subscriptions.js
+++ b/services/grpc/lightning/lightning.subscriptions.js
@@ -1,6 +1,7 @@
 import { grpcLog } from '@zap/utils/log'
 import { status } from '@grpc/grpc-js'
-
+import methods from './lightning.methods'
+import streamify from './streamify'
 /**
  * Call lnd grpc subscribeChannelGraph method and emit events on updates to the stream
  * @return {Call} Grpc Call
@@ -81,9 +82,21 @@ function subscribeTransactions() {
   })
   return call
 }
+/**
+ * Virtual getInfo stream
+ */
+function subscribeGetInfo() {
+  return streamify.call(this, {
+    command: methods.getInfo.bind(this),
+    dataEventName: 'subscribeGetInfo.data',
+    errorEventName: 'subscribeGetInfo.error',
+    pollInterval: 5000,
+  })
+}
 
 export default {
   subscribeChannelGraph,
   subscribeInvoices,
   subscribeTransactions,
+  subscribeGetInfo,
 }

--- a/services/grpc/lightning/streamify.js
+++ b/services/grpc/lightning/streamify.js
@@ -1,0 +1,61 @@
+import createScheduler from '@zap/utils/scheduler'
+import isEqual from 'lodash.isequal'
+import EventEmitter from 'events'
+import { grpcLog } from '@zap/utils/log'
+
+/**
+ * Creates polling stream for the specified LND command
+ * streamify must be called in a `EventEmitter` context, meaning `this.emit` should exist.
+ * e.g streamify.call(this,{...})
+ * @export
+ * @param {Object} streamDefinition - stream params
+ * @param {function} streamDefinition.command - `grpc` command,
+ * @param {string} streamDefinition.dataEventName - event name to that it used to dispatch `data` event,
+ * @param {string} streamDefinition.errorEventName - event name to that it used to dispatch `error` event,
+ * @param {number} streamDefinition.pollInterval - how frequent to execute `command`,
+ * @param {boolean} streamDefinition.cancelOnError - if `cancel` should be called when `command` throws an exception,
+ * @returns {Object} - returns stream-like object that has `on` and `cancel` methods
+ */
+export default function streamify({
+  command,
+  dataEventName,
+  errorEventName,
+  pollInterval,
+  cancelOnError,
+}) {
+  // internal emitter to create stream-like behavior
+  const emitter = new EventEmitter()
+  const scheduler = createScheduler()
+
+  const cancel = () => {
+    scheduler.removeAllTasks()
+    emitter.emit('end')
+  }
+
+  let prevResult = null
+  const task = async () => {
+    try {
+      const result = await command()
+      // only dispatch update if we got new results
+      if (!isEqual(result, prevResult)) {
+        prevResult = result
+        this.emit(dataEventName, result)
+        emitter.emit(errorEventName, result)
+      }
+    } catch (e) {
+      grpcLog.info(e)
+      this.emit(errorEventName, e)
+      emitter.emit(errorEventName, e)
+      if (cancelOnError) {
+        cancel()
+      }
+    }
+  }
+
+  scheduler.addTask({ task, baseDelay: pollInterval })
+
+  return {
+    on: emitter.on.bind(emitter),
+    cancel,
+  }
+}

--- a/services/grpc/walletUnlocker/walletUnlocker.js
+++ b/services/grpc/walletUnlocker/walletUnlocker.js
@@ -1,4 +1,5 @@
 import GrpcService from '@zap/services/grpc/grpcService'
+import { grpcLog } from '@zap/utils/log'
 import methods from './walletUnlocker.methods'
 
 /**
@@ -9,6 +10,11 @@ class WalletUnlocker extends GrpcService {
   constructor(lndConfig) {
     super('WalletUnlocker', lndConfig)
     this.useMacaroon = false
+  }
+
+  onAfterConnect() {
+    super.subscribe()
+    grpcLog.info(`Connected to ${this.serviceName} gRPC service`)
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10578,6 +10578,11 @@ lodash.get@4.4.2, lodash.get@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
+lodash.intersection@4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.intersection/-/lodash.intersection-4.4.0.tgz#0a11ba631d0e95c23c7f2f4cbb9a692ed178e705"
+  integrity sha1-ChG6Yx0OlcI8fy9Mu5ppLtF45wU=
+
 lodash.isequal@4.5.0, lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Resolves #2128 
This PR builds on top of #2134 `scheduler` functionality. So ideally that one should be merged first. The idea of the PR is to create a poll service (streamify util) for grpc commands which allows outer code to work with them as with regular LND subscriptions.  To solve #2128 we need to subscribe to topology update only after sync process is complete. To achieve this  `getInfo` is streamified and channel graph stream is set only after `sycned_to_chain` is true  
<!--- Describe your changes in detail -->


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes:
Refactor/bugfix
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
