### PR TITLE
refactor(grpc): notify after state transitions

### DIFF
--- a/services/grpc/grpc.js
+++ b/services/grpc/grpc.js
@@ -28,9 +28,7 @@ class Grpc extends EventEmitter {
       ],
       methods: {
         onBeforeActivateWalletUnlocker: this.onBeforeActivateWalletUnlocker.bind(this),
-        onAfterActivateWalletUnlocker: this.onAfterActivateWalletUnlocker.bind(this),
         onBeforeActivateLightning: this.onBeforeActivateLightning.bind(this),
-        onAfterActivateLightning: this.onAfterActivateLightning.bind(this),
         onBeforeDisconnect: this.onBeforeDisconnect.bind(this),
         onAfterDisconnect: this.onAfterDisconnect.bind(this),
         onLeaveActive: this.onLeaveActive.bind(this),
@@ -103,11 +101,13 @@ class Grpc extends EventEmitter {
   }
 
   async activateWalletUnlocker(...args) {
-    return this.fsm.activateWalletUnlocker(args)
+    await this.fsm.activateWalletUnlocker(args)
+    this.emit('GRPC_WALLET_UNLOCKER_SERVICE_ACTIVE')
   }
 
   async activateLightning(...args) {
-    return this.fsm.activateLightning(args)
+    await this.fsm.activateLightning(args)
+    this.emit('GRPC_LIGHTNING_SERVICE_ACTIVE')
   }
 
   // ------------------------------------
@@ -134,9 +134,6 @@ class Grpc extends EventEmitter {
   async onBeforeActivateWalletUnlocker() {
     await this.services.WalletUnlocker.connect()
   }
-  async onAfterActivateWalletUnlocker() {
-    this.emit('GRPC_WALLET_UNLOCKER_SERVICE_ACTIVE')
-  }
 
   /**
    * Rejig connections as needed before activating the lightning service.
@@ -160,10 +157,6 @@ class Grpc extends EventEmitter {
     forwardAll('subscribeChannelGraph')
     forwardAll('subscribeTransactions')
     forwardAll('subscribeGetInfo')
-  }
-
-  async onAfterActivateLightning() {
-    this.emit('GRPC_LIGHTNING_SERVICE_ACTIVE')
   }
 
   onLeaveActive() {


### PR DESCRIPTION
## Description:

Ensure that we wait for gRPC state transitions to complete before emitting events indicating that they have.

## Motivation and Context:

Guard against potential issues arising from us thinking that a grpc state change had completed before it actually had.

## How Has This Been Tested?

Manually

## Types of changes:

Refactor / bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
