### PR TITLE
refactor: consolidate/optimise grpc subscription setup code

### DIFF
--- a/services/grpc/grpc.js
+++ b/services/grpc/grpc.js
@@ -127,6 +127,7 @@ class ZapGrpc extends EventEmitter {
         const { Lightning } = this.services
         this.subscriptions['channelGraph'] = Lightning.subscribeChannelGraph()
         this.subscribe('channelGraph')
+        this.unsubscribe('getinfo')
       }
     })
   }

--- a/services/grpc/grpc.js
+++ b/services/grpc/grpc.js
@@ -63,9 +63,6 @@ class ZapGrpc extends EventEmitter {
       this.emit(GRPC_LIGHTNING_SERVICE_ACTIVE)
       this.subscribeAll()
     })
-    this.grpc.on('disconnected', () => {
-      this.unsubscribe()
-    })
 
     // Connect the service.
     return this.grpc.connect(options)
@@ -75,6 +72,8 @@ class ZapGrpc extends EventEmitter {
    * Disconnect gRPC service.
    */
   async disconnect(...args) {
+    await this.unsubscribe()
+
     if (this.grpc) {
       if (this.grpc.can('disconnect')) {
         await this.grpc.disconnect(args)
@@ -82,7 +81,6 @@ class ZapGrpc extends EventEmitter {
       // Remove gRPC event handlers.
       this.grpc.removeAllListeners('locked')
       this.grpc.removeAllListeners('active')
-      this.grpc.removeAllListeners('disconnected')
     }
 
     // Reset the state.


### PR DESCRIPTION
## Description:

- disconnect getinfo stream on chain sync complete
- consolidate grpc subscription setup code
- unsubscribe streams before disconnecting
- dynamic gRPC subscription registration

## Motivation and Context:

Fix #2166 

Since we are not making use of the info subscription after the initial sync has completed I have opted to disable it once the sync has completed and we have activated the channel subscription. 

## How Has This Been Tested?

Manually

## Types of changes:

Refactor / fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
