### PR TITLE
test(e2e): ensure lnd is killed after tests

### DIFF
--- a/electron/controller.js
+++ b/electron/controller.js
@@ -20,9 +20,9 @@ class ZapController {
     this.processes = {}
 
     // Register IPC listeners so that we can react to instructions coming from the app.
-    ipcMain.on('killLnd', () => {
-      ipcMain.once('killLndSuccess', () => this.sendMessage('killLndSuccess'))
-      this.sendMessage('terminateApp', 'killLndSuccess')
+    ipcMain.on('killNeutrino', (event, signal) => {
+      ipcMain.once('killNeutrinoSuccess', () => this.sendMessage('killNeutrinoSuccess'))
+      this.sendMessage('killNeutrino', signal)
     })
     ipcMain.on('processSpawn', (event, { name, pid }) => {
       this.processes[name] = pid
@@ -78,7 +78,7 @@ class ZapController {
     // Send a message to the renderer process telling it to to gracefully shutdown. We register a success callback with
     // it so that we can complete the termination and quit electon once the app has been fully shutdown.
     ipcMain.on('terminateAppSuccess', () => app.quit())
-    this.sendMessage('terminateApp', 'terminateAppSuccess')
+    this.sendMessage('terminateApp')
   }
 
   /**

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -68,10 +68,10 @@ function openTestnetFaucet() {
   openExternal('https://coinfaucet.eu/en/btc-testnet/')
 }
 
-function killLnd() {
+function killNeutrino(signal) {
   return new Promise(resolve => {
-    ipcRenderer.once('killLndSuccess', resolve)
-    ipcRenderer.send('killLnd')
+    ipcRenderer.once('killNeutrinoSuccess', resolve)
+    ipcRenderer.send('killNeutrino', signal)
   })
 }
 
@@ -194,7 +194,7 @@ window.Zap = {
   getUserDataDir,
   validateHost,
   fileExists,
-  killLnd,
+  killNeutrino,
 }
 
 // Provide access to ipcRenderer.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test-unit": "jest --coverage ./test/unit",
     "test-ci": "npm run test-e2e && npm run test-unit",
     "pretest-e2e": "npm run build-e2e",
-    "test-e2e": "cross-env DISABLE_INIT=1 ELECTRON_USER_DIR_TEMP=1 testcafe --selector-timeout 30000 --assertion-timeout 30000 --screenshots ./screenshots --screenshots-on-fails electron:./ ./test/e2e"
+    "test-e2e": "cross-env DISABLE_INIT=1 ELECTRON_USER_DIR_TEMP=1 testcafe --selector-timeout 60000 --assertion-timeout 60000 --screenshots ./screenshots --screenshots-on-fails electron:./ ./test/e2e"
   },
   "config": {
     "style_paths": "renderer/components/**/*.js",

--- a/renderer/reducers/app.js
+++ b/renderer/reducers/app.js
@@ -70,18 +70,11 @@ export const initApp = () => async (dispatch, getState) => {
 /**
  * IPC handler for 'terminateApp' message
  */
-export const terminateApp = (event, handler) => async dispatch => {
+export const terminateApp = () => async dispatch => {
   dispatch({ type: TERMINATE_APP })
-
-  // Shutdown lnd before terminating.
   await dispatch(stopLnd())
-
-  dispatch(terminateAppSuccess(handler))
-}
-
-export const terminateAppSuccess = handler => async dispatch => {
   dispatch({ type: TERMINATE_APP_SUCCESS })
-  dispatch(send(handler))
+  dispatch(send('terminateAppSuccess'))
 }
 
 // ------------------------------------

--- a/renderer/reducers/ipc.js
+++ b/renderer/reducers/ipc.js
@@ -1,5 +1,6 @@
 import createIpc from 'redux-electron-ipc'
 import { initApp, terminateApp } from './app'
+import { killNeutrino } from './neutrino'
 import { receiveLocale } from './locale'
 import { bitcoinPaymentUri, lightningPaymentUri } from './pay'
 import { lndconnectUri } from './onboarding'
@@ -7,6 +8,7 @@ import { lndconnectUri } from './onboarding'
 const ipc = createIpc({
   initApp,
   terminateApp,
+  killNeutrino,
   receiveLocale,
   bitcoinPaymentUri,
   lightningPaymentUri,

--- a/renderer/reducers/neutrino.js
+++ b/renderer/reducers/neutrino.js
@@ -265,6 +265,15 @@ export const neutrinoSyncStatus = status => async dispatch => {
   }
 }
 
+/**
+ * IPC handler for 'killNeutrino' message
+ */
+export const killNeutrino = (event, signal) => async dispatch => {
+  const neutrino = await neutrinoService
+  await neutrino.shutdown({ signal })
+  dispatch(send('killNeutrinoSuccess'))
+}
+
 // ------------------------------------
 // Action Handlers
 // ------------------------------------

--- a/test/e2e/onboarding-connect-manual.spec.js
+++ b/test/e2e/onboarding-connect-manual.spec.js
@@ -39,9 +39,11 @@ test('should connect to an external wallet (manual)', async t => {
     .expect(onboarding.connectionDetails.exists)
     .ok()
     .click(onboarding.connectionDetailsTabs.manual.button)
-    .typeText(onboarding.hostInput, 'testnet1-lnd.zaphq.io:10009')
-    .typeText(onboarding.certInput, path.join(__dirname, 'fixtures', 'tls.cert'))
-    .typeText(onboarding.macaroonInput, path.join(__dirname, 'fixtures', 'readonly.macaroon'))
+    .typeText(onboarding.hostInput, 'testnet1-lnd.zaphq.io:10009', { paste: true })
+    .typeText(onboarding.certInput, path.join(__dirname, 'fixtures', 'tls.cert'), { paste: true })
+    .typeText(onboarding.macaroonInput, path.join(__dirname, 'fixtures', 'readonly.macaroon'), {
+      paste: true,
+    })
     .click(onboarding.nextButton)
 
     // Confirm connection details and submit

--- a/test/e2e/onboarding-create.spec.js
+++ b/test/e2e/onboarding-create.spec.js
@@ -7,12 +7,10 @@ import {
   cleanElectronEnvironment,
 } from './utils/helpers'
 import Onboarding from './pages/onboarding'
-import Syncing from './pages/syncing'
 import Loading from './pages/loading'
 import { isMainnetAutopilot, isNetworkSelectionEnabled } from '../../utils/featureFlag'
 
 const onboarding = new Onboarding()
-const syncing = new Syncing()
 const loading = new Loading()
 
 fixture('Onboarding (create)')
@@ -56,17 +54,17 @@ test('should create a new wallet', async t => {
 
   // Fill out and submit SeedConfirm form.
   await t
-    .typeText(onboarding.seeedWordInput1, word1)
-    .typeText(onboarding.seeedWordInput2, word2)
-    .typeText(onboarding.seeedWordInput3, word3)
+    .typeText(onboarding.seeedWordInput1, word1, { paste: true })
+    .typeText(onboarding.seeedWordInput2, word2, { paste: true })
+    .typeText(onboarding.seeedWordInput3, word3, { paste: true })
     .click(onboarding.nextButton)
 
     // Fill out and submit Password form.
-    .typeText(onboarding.passwordInput, 'password')
+    .typeText(onboarding.passwordInput, 'password', { paste: true })
     .click(onboarding.nextButton)
 
     // Fill out and submit Name form.
-    .typeText(onboarding.nameInput, 'My Test Wallet')
+    .typeText(onboarding.nameInput, 'My Test Wallet', { paste: true })
     .click(onboarding.nextButton)
 
     // Fill out and submit Network form.
@@ -81,7 +79,5 @@ test('should create a new wallet', async t => {
 
     // Verify that we show the loading bolt and syncing page.
     .expect(loading.loadingBolt.exists)
-    .ok()
-    .expect(syncing.syncing.exists)
     .ok()
 })

--- a/test/e2e/onboarding-import.spec.js
+++ b/test/e2e/onboarding-import.spec.js
@@ -7,12 +7,10 @@ import {
   cleanElectronEnvironment,
 } from './utils/helpers'
 import Onboarding from './pages/onboarding'
-import Syncing from './pages/syncing'
 import Loading from './pages/loading'
 import { isNetworkSelectionEnabled, isMainnetAutopilot } from '../../utils/featureFlag'
 
 const onboarding = new Onboarding()
-const syncing = new Syncing()
 const loading = new Loading()
 
 fixture('Onboarding (import)')
@@ -66,7 +64,7 @@ test('should import a wallet from an existing seed', async t => {
 
   // Fill in the seed form.
   Array.from(Array(24).keys()).forEach(async index => {
-    await t.typeText(onboarding.seedWordInputs[index], seed[index])
+    await t.typeText(onboarding.seedWordInputs[index], seed[index], { paste: true })
   })
 
   // Submit the seed.
@@ -74,11 +72,11 @@ test('should import a wallet from an existing seed', async t => {
     .click(onboarding.nextButton)
 
     // Fill out and submit Password form.
-    .typeText(onboarding.passwordInput, 'password')
+    .typeText(onboarding.passwordInput, 'password', { paste: true })
     .click(onboarding.nextButton)
 
     // Fill out and submit Name form.
-    .typeText(onboarding.nameInput, 'My Test Wallet')
+    .typeText(onboarding.nameInput, 'My Test Wallet', { paste: true })
     .click(onboarding.nextButton)
 
     // Fill out and submit Network form.
@@ -93,7 +91,5 @@ test('should import a wallet from an existing seed', async t => {
 
     // Verify that we show the loading bolt and syncing page.
     .expect(loading.loadingBolt.exists)
-    .ok()
-    .expect(syncing.syncing.exists)
     .ok()
 })

--- a/test/e2e/utils/helpers.js
+++ b/test/e2e/utils/helpers.js
@@ -4,7 +4,6 @@ import rimraf from 'rimraf'
 import os from 'os'
 import ps from 'ps-node'
 import { promisify } from 'util'
-import delay from '../../../utils/delay'
 
 const rimrafPromise = promisify(rimraf)
 const psLookup = promisify(ps.lookup)
@@ -19,7 +18,7 @@ export const getPageTitle = ClientFunction(() => document.title)
 export const getUserDataDir = ClientFunction(() => window.Zap.getUserDataDir())
 
 // Kill the client's active lnd instance, if there is one
-export const killLnd = ClientFunction(() => window.Zap.killLnd())
+export const killNeutrino = ClientFunction(signal => window.Zap.killNeutrino(signal))
 
 // Delete persistent data from indexeddb.
 export const deleteDatabase = ClientFunction(() => {
@@ -49,15 +48,11 @@ const printLndProcesses = async () => {
 // Clean out test environment.
 export const cleanTestEnvironment = async () => {
   console.log('cleanTestEnvironment')
-  console.log('waiting 3 seconds for app state to settle')
-  await delay(3000)
 
   await printLndProcesses()
-
   console.log('killing lnd')
-  await killLnd()
+  await killNeutrino('SIGKILL')
   console.log('lnd killed')
-
   await printLndProcesses()
 
   console.log('deleting database')


### PR DESCRIPTION
## Description:

Kill lnd directly after e2e tests rather than trying to do a clean app shutdown.

## Motivation and Context:

Sometimes lnd doesn't get properly killed. In the previous setup this could potentially happen if lnd/neutrino processes are already in the process of being shutdown when we attempt to kill them from the test suite.

## How Has This Been Tested?

Rn e2e tests several times.

## Types of changes:

Test improvements

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
