### PR TITLE
feat(wallet): ability to include invoice routing hints

### DIFF
--- a/renderer/components/Request/Request.js
+++ b/renderer/components/Request/Request.js
@@ -1,10 +1,23 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Box } from 'rebass'
+import { Box, Flex } from 'rebass'
 import { FormattedMessage, injectIntl, intlShape } from 'react-intl'
-import { Bar, Button, Form, Header, Panel, Text, TextArea } from 'components/UI'
+import {
+  Bar,
+  Button,
+  Form,
+  Header,
+  Label,
+  Panel,
+  Span,
+  Text,
+  TextArea,
+  Toggle,
+  Tooltip,
+} from 'components/UI'
 import { CurrencyFieldGroup } from 'containers/UI'
 import Lightning from 'components/Icon/Lightning'
+import Padlock from 'components/Icon/Padlock'
 import RequestSummary from './RequestSummary'
 import messages from './messages'
 
@@ -17,23 +30,17 @@ class Request extends React.Component {
   }
 
   static propTypes = {
-    /** Currently selected cryptocurrency (key). */
+    activeWalletSettings: PropTypes.shape({
+      type: PropTypes.string.isRequired,
+    }).isRequired,
     createInvoice: PropTypes.func.isRequired,
-    /** Human readable chain name */
     cryptoCurrency: PropTypes.string.isRequired,
-    /** Ticker symbol of the currently selected cryptocurrency. */
     cryptoCurrencyTicker: PropTypes.string.isRequired,
-    /** Boolean indicating wether the form is being processed. If true, form buttons are disabled. */
     cryptoName: PropTypes.string.isRequired,
-    /** Fetch fiat ticker data. */
     fetchTickers: PropTypes.func.isRequired,
-    /** Lnd invoice object for the payment request */
     intl: intlShape.isRequired,
-    /** Lightning Payment request. */
     invoice: PropTypes.object,
-    /** Show a notification */
     isProcessing: PropTypes.bool,
-    /** Create an invoice using the supplied details */
     payReq: PropTypes.string,
     showNotification: PropTypes.func.isRequired,
   }
@@ -94,7 +101,7 @@ class Request extends React.Component {
    */
   onSubmit = values => {
     const { cryptoCurrency, createInvoice } = this.props
-    createInvoice(values.amountCrypto, cryptoCurrency, values.memo)
+    createInvoice(values.amountCrypto, cryptoCurrency, values.memo, values.routingHints)
   }
 
   /**
@@ -145,6 +152,7 @@ class Request extends React.Component {
         css={{ resize: 'vertical', 'min-height': '48px' }}
         field="memo"
         label={intl.formatMessage({ ...messages.memo })}
+        mb={3}
         name="memo"
         placeholder={intl.formatMessage({ ...messages.memo_placeholder })}
         rows={3}
@@ -156,11 +164,31 @@ class Request extends React.Component {
     )
   }
 
+  renderRoutingHints = () => (
+    <Flex alignItems="center" justifyContent="space-between">
+      <Flex>
+        <Span color="gray" fontSize="s" mr={2}>
+          <Padlock />
+        </Span>
+        <Flex>
+          <Label htmlFor="routingHints">
+            <FormattedMessage {...messages.routing_hints_label} />
+          </Label>
+          <Tooltip ml={1}>
+            <FormattedMessage {...messages.routing_hints_tooltip} />
+          </Tooltip>
+        </Flex>
+      </Flex>
+      <Toggle field="routingHints" />
+    </Flex>
+  )
+
   /**
    * Form renderer.
    */
   render() {
     const {
+      activeWalletSettings,
       createInvoice,
       cryptoCurrency,
       cryptoCurrencyTicker,
@@ -209,6 +237,7 @@ class Request extends React.Component {
                     {this.renderHelpText()}
                     {this.renderAmountFields()}
                     {this.renderMemoField()}
+                    {activeWalletSettings.type !== 'local' && this.renderRoutingHints()}
                   </React.Fragment>
                 ) : (
                   <RequestSummary

--- a/renderer/components/Request/messages.js
+++ b/renderer/components/Request/messages.js
@@ -12,6 +12,8 @@ export default defineMessages({
   total: 'Total',
   memo: 'Memo',
   memo_placeholder: 'For example "Dinner last night"',
+  routing_hints_label: 'Include routing hints',
+  routing_hints_tooltip: 'Whether this invoice should include routing hints for private channels.',
   memo_tooltip:
     'Add some describer text to your payment request for the recipient to see when paying.',
   not_paid: 'not paid',

--- a/renderer/containers/Request.js
+++ b/renderer/containers/Request.js
@@ -3,8 +3,10 @@ import { Request } from 'components/Request'
 import { fetchTickers, tickerSelectors } from 'reducers/ticker'
 import { createInvoice, invoiceSelectors } from 'reducers/invoice'
 import { showNotification } from 'reducers/notification'
+import { walletSelectors } from 'reducers/wallet'
 
 const mapStateToProps = state => ({
+  activeWalletSettings: walletSelectors.activeWalletSettings(state),
   cryptoName: tickerSelectors.cryptoName(state),
   cryptoCurrency: state.ticker.currency,
   cryptoCurrencyTicker: tickerSelectors.currencyName(state),

--- a/renderer/reducers/invoice.js
+++ b/renderer/reducers/invoice.js
@@ -96,7 +96,7 @@ export const receiveInvoices = ({ invoices }) => dispatch => {
 }
 
 // Send IPC event for creating an invoice
-export const createInvoice = (amount, currency, memo) => async (dispatch, getState) => {
+export const createInvoice = (amount, currency, memo, isPrivate) => async (dispatch, getState) => {
   const state = getState()
 
   // backend needs value in satoshis no matter what currency we are using
@@ -107,7 +107,7 @@ export const createInvoice = (amount, currency, memo) => async (dispatch, getSta
   // Grab the activeWallet type from our local store. If the active connection type is local (light clients using
   // neutrino) we will have to flag private as true when creating this invoice. All light cliets open private channels
   // (both manual and autopilot ones). In order for these clients to receive money through these channels the invoices
-  // need to come with routing hints for private channels
+  // need to come with routing hints for private channels.
   const activeWalletSettings = walletSelectors.activeWalletSettings(state)
 
   try {
@@ -115,7 +115,7 @@ export const createInvoice = (amount, currency, memo) => async (dispatch, getSta
     const invoice = await grpc.services.Lightning.createInvoice({
       value,
       memo,
-      private: activeWalletSettings.type === 'local',
+      private: isPrivate || activeWalletSettings.type === 'local',
     })
     dispatch(createdInvoice(invoice))
   } catch (e) {

--- a/services/grpc/lightning.methods.js
+++ b/services/grpc/lightning.methods.js
@@ -89,11 +89,11 @@ async function getChannels() {
 async function createInvoice(payload) {
   const invoice = await this.addInvoice(payload)
   const decodedInvoice = await this.decodePayReq({ pay_req: invoice.payment_request })
-
   return {
     ...decodedInvoice,
     memo: payload.memo,
     value: payload.value,
+    private: payload.private,
     r_hash: Buffer.from(invoice.r_hash, 'hex').toString('hex'),
     payment_request: invoice.payment_request,
     creation_date: Date.now() / 1000,

--- a/translations/af-ZA.json
+++ b/translations/af-ZA.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "",
   "components.Request.payment_request": "",
   "components.Request.qrcode": "",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "",
   "components.Request.subtitle": "",
   "components.Request.title": "",

--- a/translations/ar-SA.json
+++ b/translations/ar-SA.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "",
   "components.Request.payment_request": "",
   "components.Request.qrcode": "",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "",
   "components.Request.subtitle": "",
   "components.Request.title": "",

--- a/translations/bg-BG.json
+++ b/translations/bg-BG.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "Платени",
   "components.Request.payment_request": "",
   "components.Request.qrcode": "",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "",
   "components.Request.subtitle": "",
   "components.Request.title": "Заявка за плащане",

--- a/translations/ca-ES.json
+++ b/translations/ca-ES.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "",
   "components.Request.payment_request": "",
   "components.Request.qrcode": "",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "",
   "components.Request.subtitle": "",
   "components.Request.title": "",

--- a/translations/cs-CZ.json
+++ b/translations/cs-CZ.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "Zaplaceno",
   "components.Request.payment_request": "",
   "components.Request.qrcode": "",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "",
   "components.Request.subtitle": "",
   "components.Request.title": "Vyžádat platbu",

--- a/translations/da-DK.json
+++ b/translations/da-DK.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "betalt",
   "components.Request.payment_request": "Betalings Anmodning",
   "components.Request.qrcode": "QR-Kode",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "Anmodning Status",
   "components.Request.subtitle": "gennem Lightning Network",
   "components.Request.title": "Anmod",

--- a/translations/de-DE.json
+++ b/translations/de-DE.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "Bezahlt",
   "components.Request.payment_request": "Zahlungsanfrage",
   "components.Request.qrcode": "QR-Code",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "Anfragenstatus",
   "components.Request.subtitle": "durch das Lightning Netzwerk",
   "components.Request.title": "Zahlung anfordern",

--- a/translations/el-GR.json
+++ b/translations/el-GR.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "Καταβάλλεται",
   "components.Request.payment_request": "",
   "components.Request.qrcode": "",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "",
   "components.Request.subtitle": "",
   "components.Request.title": "Αίτηση πληρωμής",

--- a/translations/en.json
+++ b/translations/en.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "paid",
   "components.Request.payment_request": "Payment Request",
   "components.Request.qrcode": "QR-Code",
+  "components.Request.routing_hints_label": "Include routing hints",
+  "components.Request.routing_hints_tooltip": "Whether this invoice should include routing hints for private channels.",
   "components.Request.status": "Request Status",
   "components.Request.subtitle": "through the Lightning Network",
   "components.Request.title": "Request",

--- a/translations/es-ES.json
+++ b/translations/es-ES.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "Pagado",
   "components.Request.payment_request": "Solicitud de Pago",
   "components.Request.qrcode": "Codigo-QR",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "Estado de solicitud",
   "components.Request.subtitle": "a través de la red Lightning",
   "components.Request.title": "Solicitud de Pago",

--- a/translations/fi-FI.json
+++ b/translations/fi-FI.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "",
   "components.Request.payment_request": "",
   "components.Request.qrcode": "",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "",
   "components.Request.subtitle": "",
   "components.Request.title": "",

--- a/translations/fr-FR.json
+++ b/translations/fr-FR.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "Payé",
   "components.Request.payment_request": "",
   "components.Request.qrcode": "",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "",
   "components.Request.subtitle": "",
   "components.Request.title": "Demande de paiement",

--- a/translations/ga-IE.json
+++ b/translations/ga-IE.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "Íoctha",
   "components.Request.payment_request": "",
   "components.Request.qrcode": "",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "",
   "components.Request.subtitle": "",
   "components.Request.title": "Iarratas ar Íocaíocht",

--- a/translations/he-IL.json
+++ b/translations/he-IL.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "",
   "components.Request.payment_request": "",
   "components.Request.qrcode": "",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "",
   "components.Request.subtitle": "",
   "components.Request.title": "",

--- a/translations/hi-IN.json
+++ b/translations/hi-IN.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "भुगतान किया",
   "components.Request.payment_request": "",
   "components.Request.qrcode": "",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "",
   "components.Request.subtitle": "",
   "components.Request.title": "",

--- a/translations/hr-HR.json
+++ b/translations/hr-HR.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "Plaćeno",
   "components.Request.payment_request": "Zahtjev za plaćanje",
   "components.Request.qrcode": "QR-kod",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "Stanje zahtjeva",
   "components.Request.subtitle": "kroz LN mrežu",
   "components.Request.title": "Zahtjev za plaćanjem",

--- a/translations/hu-HU.json
+++ b/translations/hu-HU.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "",
   "components.Request.payment_request": "",
   "components.Request.qrcode": "",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "",
   "components.Request.subtitle": "",
   "components.Request.title": "",

--- a/translations/it-IT.json
+++ b/translations/it-IT.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "",
   "components.Request.payment_request": "",
   "components.Request.qrcode": "",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "",
   "components.Request.subtitle": "",
   "components.Request.title": "",

--- a/translations/ja-JP.json
+++ b/translations/ja-JP.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "支払った",
   "components.Request.payment_request": "",
   "components.Request.qrcode": "",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "",
   "components.Request.subtitle": "",
   "components.Request.title": "支払請求",

--- a/translations/ko-KR.json
+++ b/translations/ko-KR.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "",
   "components.Request.payment_request": "",
   "components.Request.qrcode": "",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "",
   "components.Request.subtitle": "",
   "components.Request.title": "",

--- a/translations/nl-NL.json
+++ b/translations/nl-NL.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "Betaald",
   "components.Request.payment_request": "",
   "components.Request.qrcode": "",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "",
   "components.Request.subtitle": "",
   "components.Request.title": "Verzoek betaling",

--- a/translations/no-NO.json
+++ b/translations/no-NO.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "",
   "components.Request.payment_request": "",
   "components.Request.qrcode": "",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "",
   "components.Request.subtitle": "",
   "components.Request.title": "",

--- a/translations/pl-PL.json
+++ b/translations/pl-PL.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "",
   "components.Request.payment_request": "",
   "components.Request.qrcode": "",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "",
   "components.Request.subtitle": "",
   "components.Request.title": "",

--- a/translations/pt-BR.json
+++ b/translations/pt-BR.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "Pago",
   "components.Request.payment_request": "",
   "components.Request.qrcode": "",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "",
   "components.Request.subtitle": "",
   "components.Request.title": "Solicitar Pagamento",

--- a/translations/pt-PT.json
+++ b/translations/pt-PT.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "",
   "components.Request.payment_request": "",
   "components.Request.qrcode": "",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "",
   "components.Request.subtitle": "",
   "components.Request.title": "",

--- a/translations/ro-RO.json
+++ b/translations/ro-RO.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "Plătit",
   "components.Request.payment_request": "",
   "components.Request.qrcode": "",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "",
   "components.Request.subtitle": "",
   "components.Request.title": "Cere plată",

--- a/translations/ru-RU.json
+++ b/translations/ru-RU.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "Oплаченный",
   "components.Request.payment_request": "",
   "components.Request.qrcode": "QR-код",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "Статус запроса",
   "components.Request.subtitle": "",
   "components.Request.title": "Запрос платежа",

--- a/translations/sr-SP.json
+++ b/translations/sr-SP.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "",
   "components.Request.payment_request": "",
   "components.Request.qrcode": "",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "",
   "components.Request.subtitle": "",
   "components.Request.title": "",

--- a/translations/sv-SE.json
+++ b/translations/sv-SE.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "Betald",
   "components.Request.payment_request": "",
   "components.Request.qrcode": "",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "",
   "components.Request.subtitle": "",
   "components.Request.title": "Begär betalning",

--- a/translations/tr-TR.json
+++ b/translations/tr-TR.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "Ödenen",
   "components.Request.payment_request": "",
   "components.Request.qrcode": "",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "",
   "components.Request.subtitle": "",
   "components.Request.title": "Ödeme talebi",

--- a/translations/uk-UA.json
+++ b/translations/uk-UA.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "Сплачені",
   "components.Request.payment_request": "",
   "components.Request.qrcode": "",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "",
   "components.Request.subtitle": "",
   "components.Request.title": "Запит на оплату",

--- a/translations/vi-VN.json
+++ b/translations/vi-VN.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "",
   "components.Request.payment_request": "",
   "components.Request.qrcode": "",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "",
   "components.Request.subtitle": "",
   "components.Request.title": "",

--- a/translations/zh-CN.json
+++ b/translations/zh-CN.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "已支付",
   "components.Request.payment_request": "",
   "components.Request.qrcode": "",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "",
   "components.Request.subtitle": "",
   "components.Request.title": "请求付款",

--- a/translations/zh-TW.json
+++ b/translations/zh-TW.json
@@ -371,6 +371,8 @@
   "components.Request.paid": "已支付",
   "components.Request.payment_request": "",
   "components.Request.qrcode": "",
+  "components.Request.routing_hints_label": "",
+  "components.Request.routing_hints_tooltip": "",
   "components.Request.status": "",
   "components.Request.subtitle": "",
   "components.Request.title": "请求付款",


### PR DESCRIPTION
## Description:

Add the ability for remote node operators to specify wether or not routing hints should be included in invoices. This enables users of remote nodes to better operate over private channels.

The toggle only shows for remote nodes. Local nodes continue to always include routing hints in their invoices as they do now.

## Motivation and Context:

Fix #2165 

## How Has This Been Tested?

Manually

## Screenshots

![image](https://user-images.githubusercontent.com/200251/57573962-de662880-7430-11e9-8c2e-9f63a67d066d.png)

![image](https://user-images.githubusercontent.com/200251/57573963-e4f4a000-7430-11e9-8d97-6556e4d397da.png)

## Types of changes:

New feature

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
