### PR TITLE
refactor: fix appRootPath to run in main or preload process

### DIFF
--- a/utils/appRootPath.js
+++ b/utils/appRootPath.js
@@ -1,5 +1,7 @@
 import { normalize } from 'path'
-import { remote } from 'electron'
+import electron, { remote } from 'electron'
+
+const app = electron.app || remote.app
 
 /**
  * Get a path to prepend to any nodejs calls that are getting at files in the package,
@@ -15,9 +17,7 @@ import { remote } from 'electron'
  * @return {String} Path to the lnd binary.
  */
 const appRootPath = () => {
-  return remote.app.getAppPath().indexOf('default_app.asar') < 0
-    ? normalize(`${remote.app.getAppPath()}/..`)
-    : ''
+  return app.getAppPath().indexOf('default_app.asar') < 0 ? normalize(`${app.getAppPath()}/..`) : ''
 }
 
 export default appRootPath


### PR DESCRIPTION
## Description:

fix appRootPath to run in main or preload process

## Motivation and Context:

Fixes an issue that prevents that app from starting up in production mode `yarn package`

## How Has This Been Tested?

- `yarn dev`
- `yarn start`
- `yarn package`

## Types of changes:

Fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
