### PR TITLE
fix(grpc): setup channel graph stream after sync

### DIFF
--- a/services/grpc/lightning.subscriptions.js
+++ b/services/grpc/lightning.subscriptions.js
@@ -20,11 +20,11 @@ function subscribeChannelGraph() {
     }
   })
   call.on('status', status => {
-    grpcLog.debug('CHANNELGRAPH STATUS: %o', status)
+    grpcLog.info('CHANNELGRAPH STATUS: %o', status)
     this.emit('subscribeChannelGraph.status', status)
   })
   call.on('end', () => {
-    grpcLog.debug('CHANNELGRAPH END')
+    grpcLog.info('CHANNELGRAPH END')
     this.emit('subscribeChannelGraph.end')
   })
   return call
@@ -47,11 +47,11 @@ function subscribeInvoices(payload = {}) {
     }
   })
   call.on('status', status => {
-    grpcLog.debug('INVOICES STATUS: %o', status)
+    grpcLog.info('INVOICES STATUS: %o', status)
     this.emit('subscribeInvoices.status', status)
   })
   call.on('end', () => {
-    grpcLog.debug('INVOICES END')
+    grpcLog.info('INVOICES END')
     this.emit('subscribeInvoices.end')
   })
   return call
@@ -74,11 +74,11 @@ function subscribeTransactions() {
     }
   })
   call.on('status', status => {
-    grpcLog.debug('TRANSACTIONS STATUS: %o', status)
+    grpcLog.info('TRANSACTIONS STATUS: %o', status)
     this.emit('subscribeTransactions.status', status)
   })
   call.on('end', () => {
-    grpcLog.debug('TRANSACTIONS END')
+    grpcLog.info('TRANSACTIONS END')
     this.emit('subscribeTransactions.end')
   })
   return call


### PR DESCRIPTION
## Description:

If we fail to subscribe to the channel graph after initial sync has completed keep retrying until we get a successful connection.

## Motivation and Context:

Fix #2226

## How Has This Been Tested?

Manually

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
