### PR TITLE
fix(onboarding): correctly handle ipv6 lndconnect host

### DIFF
--- a/package.json
+++ b/package.json
@@ -337,6 +337,7 @@
     "get-port": "5.0.0",
     "history": "4.9.0",
     "informed": "2.7.2",
+    "ipaddr.js": "1.9.0",
     "is-electron-renderer": "2.0.1",
     "jstimezonedetect": "1.0.6",
     "lnd-grpc": "0.2.9",

--- a/renderer/components/Onboarding/Steps/ConnectionConfirm.js
+++ b/renderer/components/Onboarding/Steps/ConnectionConfirm.js
@@ -4,8 +4,23 @@ import { FormattedMessage } from 'react-intl'
 import encode from 'lndconnect/encode'
 import decode from 'lndconnect/decode'
 import parseConnectionString from '@zap/utils/btcpayserver'
+import { isIpV6, stripIpV6Port } from '@zap/utils/ipv6'
+
 import { Bar, Form, Header, Span, Text } from 'components/UI'
 import messages from './messages'
+
+/**
+ * Removes port from a host string
+ *
+ * @param {string} host
+ * @returns host without a port part
+ */
+function sanitizeHost(host) {
+  if (isIpV6(host)) {
+    return stripIpV6Port(host)
+  }
+  return host.split(':')[0]
+}
 
 class ConnectionConfirm extends React.Component {
   static propTypes = {
@@ -165,7 +180,7 @@ class ConnectionConfirm extends React.Component {
           <>
             <Text>
               <FormattedMessage {...messages.verify_host_title} />{' '}
-              <Span color="superGreen">{hostname.split(':')[0]}</Span>?{' '}
+              <Span color="superGreen">{sanitizeHost(hostname)}</Span>?{' '}
             </Text>
             <Text mt={2}>
               <FormattedMessage {...messages.verify_host_description} />

--- a/test/unit/utils/ipv6.spec.js
+++ b/test/unit/utils/ipv6.spec.js
@@ -1,0 +1,30 @@
+import { isIpV6, splitIpV6, stripIpV6Port } from '@zap/utils/ipv6'
+
+describe('ipv6 utils', () => {
+  it('Detect valid ipv6 addresses', () => {
+    expect(isIpV6('1fff:0:a88:85a3::ac1f')).toBe(true)
+    expect(isIpV6('::1')).toBe(true)
+    expect(isIpV6('192.168.1.1')).toBe(false)
+    expect(isIpV6('localhost')).toBe(false)
+  })
+
+  it('Detect valid ipv6 addresses in port notation', () => {
+    expect(isIpV6('[1fff:0:a88:85a3::ac1f]:1')).toBe(true)
+    expect(isIpV6('[::1]:1')).toBe(true)
+    expect(isIpV6('[192.168.1.1]:8080')).toBe(false)
+    expect(isIpV6('localhost:10009')).toBe(false)
+  })
+
+  it('Split ipv6 addresses correctly', () => {
+    expect(splitIpV6('[1fff:0:a88:85a3::ac1f]:1')).toEqual(['1fff:0:a88:85a3::ac1f', '1'])
+    expect(splitIpV6('1fff:0:a88:85a3::ac1f')).toEqual(['1fff:0:a88:85a3::ac1f'])
+  })
+
+  it('Strip port from ipv6 addresses correctly', () => {
+    expect(stripIpV6Port('[1fff:0:a88:85a3::ac1f]:1')).toEqual('1fff:0:a88:85a3::ac1f')
+    expect(stripIpV6Port('1fff:0:a88:85a3::ac1f')).toEqual('1fff:0:a88:85a3::ac1f')
+    expect(stripIpV6Port('localhost')).toEqual('localhost')
+    // For a not valid ipv6 with port, should just received initial string
+    expect(stripIpV6Port('localhost:10009')).toEqual('localhost:10009')
+  })
+})

--- a/utils/ipv6.js
+++ b/utils/ipv6.js
@@ -1,0 +1,46 @@
+import ipaddr from 'ipaddr.js'
+
+/**
+ * Checks if specified address is a valid ipv6 address. Supports regular and port notation
+ * e.g [::1]:8080
+ *
+ * @export
+ * @param {string} ip
+ * @returns {Boolean}
+ */
+export function isIpV6(ip) {
+  const { IPv6 } = ipaddr
+  if (IPv6.isValid(ip)) {
+    return true
+  }
+  const [host] = splitIpV6(ip)
+  return IPv6.isValid(host)
+}
+
+/**
+ * Splits valid ipv6 address into host + port
+ *
+ * @export
+ * @param {string} ip valid ipv6 address
+ * @returns {Array|null} [host, port] or just [host] or null if `ip` is not set
+ */
+export function splitIpV6(ip) {
+  if (!ip) {
+    return null
+  }
+  return ip.charAt(0) === '[' ? ip.substr(1).split(']:') : [ip]
+}
+
+/**
+ * Removes port part from the ipv6 address. Checks for `ip` to be valid ipv6 address
+ *
+ * @export
+ * @param {string} ip
+ * @returns {string} ipv6 host
+ */
+export function stripIpV6Port(ip) {
+  if (isIpV6(ip)) {
+    return splitIpV6(ip)[0]
+  }
+  return ip
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Resolve #2172

<!--- Describe your changes in detail -->

## Motivation and Context:
Currently, ipv6 addresses are sanitized incorrectly when using lndconnect string. E.g
`lndconnect://[1fff:0:a88:85a3::ac1f]:10009?cert=x&macaroon=y`
PR resolves this issue. There is another issue wich is outside of scope of this PR and it's the inability to create a connection using ipv6 host and manual mode (where you input host, path to cert and macaroon)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
`lndconnect://[1fff:0:a88:85a3::ac1f]:10009?cert=x&macaroon=y`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/14069193/58344366-26884080-7e5e-11e9-815d-a319fb6649d1.png)

## Types of changes:
Bugfix/enhancement
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
