### PR TITLE
fix(ui): ipv6 validation and formatting issues when connecting to a remote node

### DIFF
--- a/electron/preload.js
+++ b/electron/preload.js
@@ -15,6 +15,7 @@ import { getAllLocalWallets } from '@zap/utils/localWallets'
 import lndBinaryPath from '@zap/utils/lndBinaryPath'
 import lndGrpcProtoDir from '@zap/utils/lndGrpcProtoDir'
 import validateHost from '@zap/utils/validateHost'
+import splitHostname from '@zap/utils/splitHostname'
 import LndConfig from '@zap/utils/lndConfig'
 
 const fsReadFile = promisify(fs.readFile)
@@ -181,6 +182,7 @@ window.Zap = {
   validateHost,
   fileExists,
   killNeutrino,
+  splitHostname,
 }
 
 // Provide access to ipcRenderer.

--- a/renderer/components/Onboarding/Steps/ConnectionConfirm.js
+++ b/renderer/components/Onboarding/Steps/ConnectionConfirm.js
@@ -7,6 +7,7 @@ import parseConnectionString from '@zap/utils/btcpayserver'
 import { Bar, Form, Header, Span, Text } from 'components/UI'
 import messages from './messages'
 
+const { splitHostname } = window.Zap
 class ConnectionConfirm extends React.Component {
   static propTypes = {
     connectionCert: PropTypes.string,
@@ -165,7 +166,7 @@ class ConnectionConfirm extends React.Component {
           <>
             <Text>
               <FormattedMessage {...messages.verify_host_title} />{' '}
-              <Span color="superGreen">{hostname.split(':')[0]}</Span>?{' '}
+              <Span color="superGreen">{splitHostname(hostname).host}</Span>?{' '}
             </Text>
             <Text mt={2}>
               <FormattedMessage {...messages.verify_host_description} />

--- a/test/unit/utils/splitHostname.spec.js
+++ b/test/unit/utils/splitHostname.spec.js
@@ -1,0 +1,21 @@
+import splitHostname from '@zap/utils/splitHostname'
+
+describe('splitHostname', () => {
+  it('Correctly sanitize host names', () => {
+    const hosts = [
+      '[1fff:0:a88:85a3::ac1f]:1',
+      '[1fff:0:a88:85a3::ac1f]',
+      '192.168.1.1:10009',
+      'www.example.com:10009',
+    ]
+
+    const sanitized = hosts.map(splitHostname)
+
+    expect(sanitized).toEqual([
+      { host: '1fff:0:a88:85a3::ac1f', port: '1' },
+      { host: '1fff:0:a88:85a3::ac1f', port: null },
+      { host: '192.168.1.1', port: '10009' },
+      { host: 'www.example.com', port: '10009' },
+    ])
+  })
+})

--- a/utils/splitHostname.js
+++ b/utils/splitHostname.js
@@ -1,0 +1,13 @@
+import { parse } from 'url'
+
+/**
+ * Splits hostname into a host+port
+ * @param {string} host
+ * @returns {Object} {host,port}
+ */
+export default function splitHostname(host) {
+  const { hostname = host, port } = parse(`http://${host}`)
+  // if hostname is not set it means `parse` was unable to parse
+  // in this case just return whatever came in as a host
+  return { host: hostname, port }
+}

--- a/utils/validateHost.js
+++ b/utils/validateHost.js
@@ -3,6 +3,7 @@ import { promisify } from 'util'
 import isFQDN from 'validator/lib/isFQDN'
 import isIP from 'validator/lib/isIP'
 import isPort from 'validator/lib/isPort'
+import splitHostname from '@zap/utils/splitHostname'
 
 const dnsLookup = promisify(dns.lookup)
 
@@ -19,7 +20,7 @@ const validateHost = async host => {
   }
 
   try {
-    const [lndHost, lndPort] = host.split(':')
+    const { host: lndHost, port: lndPort } = splitHostname(host)
 
     // If the hostname starts with a number, ensure that it is a valid IP address.
     if (!isFQDN(lndHost, { require_tld: false }) && !isIP(lndHost)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Resolve #2172
Resolve #2270 

<!--- Describe your changes in detail -->

## Motivation and Context:
Currently, ipv6 addresses are sanitized incorrectly when using lndconnect string or manual connection. E.g
`lndconnect://[1fff:0:a88:85a3::ac1f]:10009?cert=x&macaroon=y`


## How Has This Been Tested?
Manually
`lndconnect://[1fff:0:a88:85a3::ac1f]:10009?cert=x&macaroon=y`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/14069193/58344366-26884080-7e5e-11e9-815d-a319fb6649d1.png)

![image](https://user-images.githubusercontent.com/14069193/58423769-91c05580-809e-11e9-95cd-da12d490203a.png)

## Types of changes:
Bugfix/enhancement
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
