### PR TITLE
build(icons): add ability to generate specific icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -343,6 +343,7 @@
     "jstimezonedetect": "1.0.6",
     "lnd-grpc": "0.2.9",
     "lndconnect": "0.2.7",
+    "lodash.camelcase": "4.3.0",
     "lodash.debounce": "4.0.8",
     "lodash.get": "4.4.2",
     "lodash.intersection": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev": "cross-env HOT=1 npm run start-renderer-dev",
     "extract-messages": "extract-messages -l=af-ZA,ca-ES,de-DE,es-ES,ga-IE,hr-HR,ja-JP,no-NO,pt-PT,sr-SP,uk-UA,zh-TW,ar-SA,cs-CZ,el-GR,fi-FI,he-IL,hu-HU,ko-KR,pl-PL,ro-RO,sv-SE,vi-VN,bg-BG,da-DK,en,fr-FR,hi-IN,it-IT,nl-NL,pt-BR,ru-RU,tr-TR,zh-CN -o translations -d en --flat true renderer/**/messages.js",
     "fetch-lnd": "node ./scripts/fetch-lnd-for-packaging.js",
-    "generate-icons": "npx @svgr/cli --icon -d renderer/components/Icon icons && npm run lint-fix -- renderer/components/Icon",
+    "generate-icon": "node ./scripts/genIcons.js",
     "lint-base": "eslint --cache --format=node_modules/eslint-formatter-pretty",
     "lint": "npm run lint-base -- .",
     "lint-fix-base": "npm run lint-base -- --fix",

--- a/scripts/genIcons.js
+++ b/scripts/genIcons.js
@@ -1,0 +1,34 @@
+const { execSync } = require('child_process')
+const camelCase = require('lodash.camelcase')
+const path = require('path')
+
+const OUTPUT_DIR = 'renderer/components/Icon'
+const TMP_DIR = 'icon_gen_temp'
+
+const iconPath = process.argv[2] || ''
+
+/**
+ * Converts iconPath to pascal case icon name
+ *
+ * @returns {string}
+ */
+function getIconName() {
+  const [icon] = path.basename(iconPath).split('.')
+  const camelCaseName = camelCase(icon)
+  const pascalCaseName = camelCaseName[0].toUpperCase() + camelCaseName.slice(1)
+  return `${pascalCaseName}.js`
+}
+
+try {
+  execSync(
+    `rm -rf ${TMP_DIR} &&\
+     mkdir ${TMP_DIR} &&\
+     cp ${iconPath} ${TMP_DIR} &&\
+     npx @svgr/cli --icon -d ${OUTPUT_DIR} ${TMP_DIR} &&\
+     npm run lint-fix-base -- renderer/components/Icon/${getIconName()}
+   `,
+    { stdio: [0, 1, 2] }
+  )
+} finally {
+  execSync(`rm -rf ${TMP_DIR}`, { stdio: [0, 1, 2] })
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10481,7 +10481,7 @@ lodash._reinterpolate@~3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
-lodash.camelcase@^4.3.0:
+lodash.camelcase@4.3.0, lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Add ability to generate a specific SVG icon instead of re-generating all of them
<!--- Describe your changes in detail -->

## Motivation and Context:
Currently `genereate-icons` re-generates all icons every time, which is redundant since icons are added one by one to the project
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
`yarn generate-icon icons/icon.svg`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes:
Devops change
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
