### PR TITLE
feat(wallet): set default address type to Bech32

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -39,7 +39,7 @@ module.exports = {
   network: 'mainnet',
 
   // Default address format (p2wkh|np2wkh)
-  address: 'np2wkh',
+  address: 'p2wkh',
 
   // Default settings for lnd.
   lnd: {


### PR DESCRIPTION
## Description:

Set default address type to Bech32

## Motivation and Context:

Address type is now configurable via the settings page. Users that don't want to use Bech32 can switch if they like.

## How Has This Been Tested?

Manually

## Types of changes:

Enhancement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
