### PR TITLE
fix(app): wait for settings on app init

### DIFF
--- a/renderer/reducers/app.js
+++ b/renderer/reducers/app.js
@@ -16,6 +16,7 @@ const initialState = {
   isMounted: false,
   isRunning: false,
   isDatabaseReady: false,
+  isSettingsLoaded: false,
   isTerminating: false,
   isLoggingOut: false,
   initDatabaseError: null,
@@ -128,6 +129,7 @@ const appSelectors = {}
 appSelectors.isLoading = state => state.app.isLoading
 appSelectors.isMounted = state => state.app.isMounted
 appSelectors.isDatabaseReady = state => state.app.isDatabaseReady
+appSelectors.isSettingsLoaded = state => state.settings.isSettingsLoaded
 appSelectors.currency = state => state.ticker.currency
 appSelectors.infoLoaded = state => state.info.infoLoaded
 appSelectors.isRunning = state => state.app.isRunning
@@ -137,8 +139,9 @@ appSelectors.channelBalance = state => state.balance.channelBalance
 appSelectors.isRootReady = createSelector(
   appSelectors.isRunning,
   appSelectors.isDatabaseReady,
-  (isRunning, isDatabaseReady) => {
-    return Boolean(isRunning && isDatabaseReady)
+  appSelectors.isSettingsLoaded,
+  (isRunning, isDatabaseReady, isSettingsLoaded) => {
+    return Boolean(isRunning && isDatabaseReady && isSettingsLoaded)
   }
 )
 


### PR DESCRIPTION
## Description:

Wait for settings on app init

## Motivation and Context:

Prevents us from redirecting to the Initialiser before settings have been loaded from the database and ensures that if the user was logged into a wallet when they quit the app, they remain logged into it when then restart the app.

This preserves exist5ing functionality from master which got broken as part of the settings revamp.

## How Has This Been Tested?

Manually

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
