### PR TITLE
fix(ui): retain selected theme on reload

### DIFF
--- a/renderer/reducers/app.js
+++ b/renderer/reducers/app.js
@@ -5,7 +5,7 @@ import { initDb } from '@zap/renderer/store/db'
 import { showError } from 'reducers/notification'
 import { tickerSelectors } from './ticker'
 import { setIsWalletOpen, walletSelectors } from './wallet'
-import { setTheme } from './theme'
+import { setTheme, themeSelectors } from './theme'
 import { stopLnd } from './lnd'
 
 // ------------------------------------
@@ -84,8 +84,10 @@ export const initDatabase = () => async dispatch => {
  */
 export const initApp = (event, options = {}) => async (dispatch, getState) => {
   dispatch({ type: INIT_APP, options })
+
+  // Set the theme from incoming init options if the theme is not already set.
   if (options.theme) {
-    dispatch(setTheme(options.theme))
+    !themeSelectors.currentTheme(getState()) && dispatch(setTheme(options.theme))
   }
   // add some delay if the app is starting for the first time vs logging out of the the opened wallet
   await delay(walletSelectors.isWalletOpen(getState()) ? 0 : 1500)


### PR DESCRIPTION
## Description:

Retain selected theme on reload

## Motivation and Context:

This fixes a bug that occurs when you do `crtl+r` to reload the app in which the theme gets reset back to what it was when you launched the app= even if you have since changed it.

## How Has This Been Tested?

1. Launch the app
2. Change the theme
3. Reload with `crtl+r` and verify that your theme selection is retained

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
