### PR TITLE
fix(ui): display channel cards at equal heights

### DIFF
--- a/renderer/components/Channels/ChannelCardList.js
+++ b/renderer/components/Channels/ChannelCardList.js
@@ -43,6 +43,7 @@ const ChannelCardList = ({
         <ChannelCardListItem
           channel={channel}
           currencyName={currencyName}
+          height="100%"
           networkInfo={networkInfo}
           openModal={openModal}
           setSelectedChannel={setSelectedChannel}

--- a/renderer/components/Channels/ChannelCardListItem.js
+++ b/renderer/components/Channels/ChannelCardListItem.js
@@ -21,7 +21,7 @@ const Flex = styled(BaseFlex)(opacity)
 const areEqual = (prevProps, nextProps) => isEqual(prevProps, nextProps)
 
 const ChannelCardListItem = React.memo(
-  ({ channel, currencyName, openModal, setSelectedChannel, networkInfo }) => {
+  ({ channel, currencyName, openModal, setSelectedChannel, networkInfo, ...rest }) => {
     const {
       channel_point,
       display_name,
@@ -34,7 +34,7 @@ const ChannelCardListItem = React.memo(
     const opacity = active ? 1 : 0.3
 
     return (
-      <Card>
+      <Card {...rest}>
         <Panel>
           <Panel.Header>
             <Flex justifyContent="space-between">

--- a/renderer/components/UI/Card.js
+++ b/renderer/components/UI/Card.js
@@ -1,9 +1,13 @@
 import React from 'react'
+import styled from 'styled-components'
+import { height } from 'styled-system'
 import { Card as BaseCard } from 'rebass'
+
+const StyledCard = styled(BaseCard)(height)
 
 const Card = React.forwardRef((props, ref) => {
   return (
-    <BaseCard
+    <StyledCard
       ref={ref}
       as="section"
       bg="primaryColor"

--- a/test/unit/components/UI/__snapshots__/Card.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Card.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`component.UI.Card should render correctly 1`] = `
-<Styled(styled.div)
+<Styled(Styled(styled.div))
   as="section"
   bg="primaryColor"
   borderRadius={5}
@@ -10,5 +10,5 @@ exports[`component.UI.Card should render correctly 1`] = `
   p={3}
 >
   content
-</Styled(styled.div)>
+</Styled(Styled(styled.div))>
 `;


### PR DESCRIPTION
## Description:

Display channel cards at equal heights

## Motivation and Context:

Fix #2327

## How Has This Been Tested?

Manually

## Screenshots:

![image](https://user-images.githubusercontent.com/200251/58936402-f26f2280-876f-11e9-8dbf-bad2c8cc1866.png)


## Types of changes:

UI enhancement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
