### PR TITLE
fix: dom props warning

### DIFF
--- a/renderer/components/Home/WalletUnlocker.js
+++ b/renderer/components/Home/WalletUnlocker.js
@@ -24,6 +24,7 @@ class WalletUnlocker extends React.Component {
     isLightningGrpcActive: PropTypes.bool.isRequired,
     isUnlockingWallet: PropTypes.bool,
     setUnlockWalletError: PropTypes.func.isRequired,
+    staticContext: PropTypes.object,
     unlockWallet: PropTypes.func.isRequired,
     unlockWalletError: PropTypes.string,
     wallet: PropTypes.object.isRequired,
@@ -72,9 +73,9 @@ class WalletUnlocker extends React.Component {
       unlockWallet,
       unlockWalletError,
       wallet,
+      staticContext,
       ...rest
     } = this.props
-
     return (
       <Form
         key={`wallet-unlocker-form-${wallet.id}`}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Recent migration to `withRouter` HOC usage instead of `connected-router-dom` results in `staticContext` prop being added to wrapped components, which is not recognized as a DOM prop when spread onto `Form`
<!--- Describe your changes in detail -->


## How Has This Been Tested?
Dev tools monitoring
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes:
Refactor
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
