### PR TITLE
fix(lnd): allow to simultaniously run lnd and local zap locally on win

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -1,6 +1,5 @@
 import getPackageDetails from '../utils/getPackageDetails'
 import isStableVersion from '../utils/isStableVersion'
-
 // The current stable base version.
 // If the current version is in the same range asd this, the default database domain will be used.
 const STABLE_VERSION = '0.4.x'
@@ -70,7 +69,7 @@ module.exports = {
       port: [8080, 8081, 8082, 8083, 8084, 8085, 8086, 8087, 8088, 8089],
     },
     p2p: {
-      host: '0.0.0.0',
+      host: '', // disable p2p
       port: [9735, 9734, 9733, 9732, 9731, 9736, 9737, 9738, 9739],
     },
 
@@ -89,7 +88,7 @@ module.exports = {
     recoveryWindow: 2500,
   },
 
-  // Default curreny units.
+  // Default currency units.
   units: {
     bitcoin: 'sats',
     litecoin: 'lits',

--- a/config/production.js
+++ b/config/production.js
@@ -9,7 +9,7 @@ module.exports = {
       port: 8180,
     },
     p2p: {
-      host: '0.0.0.0',
+      host: '', //disable p2p interface
       port: 9735,
     },
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Currently, it's not possible to simultaneously run standalone LND and  Zap with a local setup on the same machine on Windows. At least with my current setup. Upon investigation, the issue appeared to be incorrect free p2p port resolution by `get-port`. Could be related to
https://github.com/sindresorhus/get-port/issues/8
<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually. Launch local lnd and then launch zap with neutrino wallet
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes:
Bugfix
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
