### PR TITLE
refactor: update rebass and styled components css props

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -18,7 +18,10 @@ const BackgroundPrimaryWithTheme = withTheme(({ theme, ...rest }) => (
   <BackgroundPrimary
     className={theme.name}
     p={3}
-    css={{ height: '100vh', 'overflow-y': 'auto !important' }}
+    css={`
+      height: 100vh;
+      overflow-y: auto !important;
+    `}
     {...rest}
   />
 ))

--- a/package.json
+++ b/package.json
@@ -371,7 +371,7 @@
     "react-spring": "8.0.20",
     "react-textfit": "1.1.0",
     "react-virtualized": "9.21.1",
-    "rebass": "3.0.0-9",
+    "rebass": "3.1.1",
     "redux": "4.0.1",
     "redux-electron-ipc": "https://github.com/LN-Zap/redux-electron-ipc#b513220d085ad3e96e459d7efcdfc37bf75417b6",
     "redux-thunk": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -245,7 +245,7 @@
     "babel-plugin-module-resolver": "3.2.0",
     "babel-plugin-react-intl": "3.1.3",
     "babel-plugin-react-intl-auto": "1.7.0",
-    "babel-plugin-styled-components": "1.8.0",
+    "babel-plugin-styled-components": "1.10.0",
     "babel-plugin-transform-react-pure-class-to-function": "1.0.1",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24",
     "browserslist": "4.6.1",

--- a/renderer/components/Autopay/Autopay.js
+++ b/renderer/components/Autopay/Autopay.js
@@ -25,7 +25,12 @@ const Autopay = props => (
         <Panel.Header mx={4}>
           <AutopayHeader />
         </Panel.Header>
-        <Panel.Body css={{ 'overflow-y': 'overlay', 'overflow-x': 'hidden' }}>
+        <Panel.Body
+          css={`
+            overflow-y: overlay;
+            overflow-x: hidden;
+          `}
+        >
           <AutopayList />
           <Heading.h1 mt={4} mx={4}>
             <FormattedMessage {...messages.merchant_list_title} />

--- a/renderer/components/Autopay/AutopayAddButton.js
+++ b/renderer/components/Autopay/AutopayAddButton.js
@@ -19,11 +19,19 @@ const AutopayAddButton = props => {
       bg="lightningOrange"
       borderRadius="50%"
       boxShadow={`0 0 24px 0 ${themeGet('colors.lightningOrange')(props)}`}
-      css={{ height: '35px' }}
+      css={`
+        height: 35px;
+      `}
       width={35}
       {...props}
     >
-      <Flex alignItems="center" css={{ height: '100%' }} justifyContent="center">
+      <Flex
+        alignItems="center"
+        css={`
+          height: 100%;
+        `}
+        justifyContent="center"
+      >
         <Text fontSize="xl">+</Text>
       </Flex>
     </Gradient>

--- a/renderer/components/Autopay/AutopayCreateForm.js
+++ b/renderer/components/Autopay/AutopayCreateForm.js
@@ -119,7 +119,11 @@ const AutopayCreateForm = props => {
               </Heading.h1>
               <Bar my={2} />
             </Panel.Header>
-            <Panel.Body css={{ height: isEditMode ? '250px' : '195px' }}>
+            <Panel.Body
+              css={`
+                height: ${isEditMode ? '250px' : '195px'};
+              `}
+            >
               <Spring
                 native
                 to={{

--- a/renderer/components/Autopay/AutopayLimitBadge.js
+++ b/renderer/components/Autopay/AutopayLimitBadge.js
@@ -20,11 +20,19 @@ const AutopayLimitBadge = ({ limit, limitCurrency, ...rest }) => {
       bg="lightningOrange"
       borderRadius="14px"
       boxShadow={`0 0 24px 0 ${themeGet('colors.lightningOrange')(rest)}`}
-      css={{ height: '27px' }}
+      css={`
+        height: 27px;
+      `}
       px={2}
       {...rest}
     >
-      <Flex alignItems="center" css={{ height: '100%' }} justifyContent="center">
+      <Flex
+        alignItems="center"
+        css={`
+          height: 100%;
+        `}
+        justifyContent="center"
+      >
         <Box color="white">
           {limit} {limitCurrency}
         </Box>

--- a/renderer/components/Autopay/AutopayList.js
+++ b/renderer/components/Autopay/AutopayList.js
@@ -26,7 +26,13 @@ const AutopayList = ({ merchants, openAutopayCreateModal, ...rest }) => {
       <Heading.h1 mb={3} ml={4} mt={4}>
         <FormattedMessage {...messages.active_list_title} />
       </Heading.h1>
-      <Flex ref={scroller} css={{ width: '100%', overflowX: 'hidden' }}>
+      <Flex
+        ref={scroller}
+        css={`
+          overflow-x: hidden;
+        `}
+        width={1}
+      >
         {merchants.map((item, index) => {
           return (
             <CardContainer key={item.pubkey} p={2} pl={index ? 2 : 4}>

--- a/renderer/components/Autopay/AutopayModalBody.js
+++ b/renderer/components/Autopay/AutopayModalBody.js
@@ -5,14 +5,33 @@ import { Card, CloseButton } from 'components/UI'
 import Autopay from 'components/Icon/Autopay'
 
 const AutopayModalBody = ({ children, onClose }) => (
-  <Box css={{ position: 'relative' }}>
-    <CloseButton css={{ position: 'absolute', right: 0 }} m={3} onClick={onClose} size="s" />
+  <Box
+    css={`
+      position: relative;
+    `}
+  >
+    <CloseButton
+      css={`
+        position: absolute;
+        right: 0;
+      `}
+      m={3}
+      onClick={onClose}
+      size="s"
+    />
     <Card borderRadius={40} width={640}>
       <Box mt={2} p={2}>
         {children}
       </Box>
     </Card>
-    <Flex css={{ position: 'absolute', top: '-25px' }} justifyContent="center" width={1}>
+    <Flex
+      css={`
+        position: absolute;
+        top: -25px;
+      `}
+      justifyContent="center"
+      width={1}
+    >
       <Autopay height={50} mt="-102px" width={50} />
     </Flex>
   </Box>

--- a/renderer/components/Channels/ChannelCreate.js
+++ b/renderer/components/Channels/ChannelCreate.js
@@ -33,8 +33,19 @@ class ChannelCreate extends React.Component {
             </Panel.Header>
           </Flex>
 
-          <Panel.Body css={{ 'overflow-y': 'overlay', 'overflow-x': 'hidden' }}>
-            <Flex alignItems="center" css={{ height: '100%' }} flexDirection="column">
+          <Panel.Body
+            css={`
+              overflow-y: overlay;
+              overflow-x: hidden;
+            `}
+          >
+            <Flex
+              alignItems="center"
+              css={`
+                height: 100%;
+              `}
+              flexDirection="column"
+            >
               {isSearchValidNodeAddress ? (
                 <ChannelCreateForm mx="auto" onSubmit={onSubmit} width={9 / 16} />
               ) : (

--- a/renderer/components/Channels/ChannelCreateForm.js
+++ b/renderer/components/Channels/ChannelCreateForm.js
@@ -281,7 +281,9 @@ class ChannelCreateForm extends React.Component {
         <Bar my={3} variant="light" />
 
         <CurrencyFieldGroup
-          css={{ height: '88px' }}
+          css={`
+            height: 88px;
+          `}
           formApi={this.formApi}
           forwardedRef={this.amountInput}
           isRequired
@@ -364,7 +366,9 @@ class ChannelCreateForm extends React.Component {
 
     return (
       <Form
-        css={{ height: '100%' }}
+        css={`
+          height: 100%;
+        `}
         {...rest}
         getApi={this.setFormApi}
         onSubmit={this.handleSubmit}
@@ -374,10 +378,19 @@ class ChannelCreateForm extends React.Component {
 
           return (
             <Panel>
-              <Panel.Body css={{ position: 'relative' }}>
+              <Panel.Body
+                css={`
+                  position: relative;
+                `}
+              >
                 <ShowHide context={this} state={step === 'form' ? 'show' : 'hide'}>
                   {styles => (
-                    <Box css={{ position: 'absolute' }} style={styles}>
+                    <Box
+                      css={`
+                        position: absolute;
+                      `}
+                      style={styles}
+                    >
                       {this.renderFormFields()}
                     </Box>
                   )}

--- a/renderer/components/Channels/ChannelDetail.js
+++ b/renderer/components/Channels/ChannelDetail.js
@@ -20,7 +20,12 @@ const ChannelDetail = ({
       <Panel.Header mx="auto" width={9 / 16}>
         <ChannelHeader channel={channel} />
       </Panel.Header>
-      <Panel.Body css={{ 'overflow-y': 'overlay', 'overflow-x': 'hidden' }}>
+      <Panel.Body
+        css={`
+          overflow-y: overlay;
+          overflow-x: hidden;
+        `}
+      >
         <ChannelCapacity
           localBalance={channel.local_balance}
           mx="auto"

--- a/renderer/components/Channels/Channels.js
+++ b/renderer/components/Channels/Channels.js
@@ -51,7 +51,11 @@ class Channels extends React.Component {
         <Panel.Header>
           <ChannelsHeader updateChannelSearchQuery={this.updateChannelSearchQuery} />
         </Panel.Header>
-        <Panel.Body css={{ overflow: 'hidden' }}>
+        <Panel.Body
+          css={`
+            overflow: hidden;
+          `}
+        >
           <StyledPersistentTabControl
             activeTab={channelViewMode === CHANNEL_LIST_VIEW_MODE_CARD ? 0 : 1}
           >

--- a/renderer/components/Channels/ChannelsMenu/ChannelsMenuSummary.js
+++ b/renderer/components/Channels/ChannelsMenu/ChannelsMenuSummary.js
@@ -61,7 +61,9 @@ const ChannelsMenuSummary = ({
         </>
       }
       color="gray"
-      css={{ opacity: 0.5 }}
+      css={`
+        opacity: 0.5;
+      `}
       title={<FormattedMessage {...messages.summary_row_onchain_title} />}
     />
   </Box>

--- a/renderer/components/Home/AutopilotAllocation.js
+++ b/renderer/components/Home/AutopilotAllocation.js
@@ -20,7 +20,9 @@ const AutopilotAllocation = ({ fieldState, fieldApi, sliderWidthNumber }) => {
         step="1"
       />
       <BasicInput
-        css={{ 'text-align': 'right' }}
+        css={`
+          text-align: right;
+        `}
         field="autopilotAllocation"
         fieldApi={fieldApi}
         fieldState={fieldState}

--- a/renderer/components/Home/Home.js
+++ b/renderer/components/Home/Home.js
@@ -11,7 +11,14 @@ import WalletsMenu from './WalletsMenu'
 import WalletUnlocker from './WalletUnlocker'
 
 const NoMatch = ({ history, wallets }) => (
-  <Flex alignItems="center" css={{ height: '100%' }} flexDirection="column" justifyContent="center">
+  <Flex
+    alignItems="center"
+    css={`
+      height: 100%;
+    `}
+    flexDirection="column"
+    justifyContent="center"
+  >
     <NoWallets history={history} wallets={wallets} />
   </Flex>
 )
@@ -99,7 +106,11 @@ class Home extends React.Component {
             <Panel.Header mb={40} px={4}>
               <ZapLogo height={28} width={28} />
             </Panel.Header>
-            <Panel.Body css={{ 'overflow-y': 'overlay' }}>
+            <Panel.Body
+              css={`
+                overflow-y: overlay;
+              `}
+            >
               <WalletsMenu
                 activeWallet={activeWallet}
                 setActiveWallet={setActiveWallet}

--- a/renderer/components/Home/NoWallets.js
+++ b/renderer/components/Home/NoWallets.js
@@ -7,7 +7,14 @@ import CreateWalletButton from './CreateWalletButton'
 import messages from './messages'
 
 const NoWallets = ({ history, wallets }) => (
-  <Flex alignItems="center" css={{ height: '100%' }} flexDirection="column" justifyContent="center">
+  <Flex
+    alignItems="center"
+    css={`
+      height: 100%;
+    `}
+    flexDirection="column"
+    justifyContent="center"
+  >
     {wallets.length === 0 ? (
       <>
         <Heading.h4>

--- a/renderer/components/Home/WalletSettingsFormLocal.js
+++ b/renderer/components/Home/WalletSettingsFormLocal.js
@@ -69,7 +69,9 @@ class WalletSettingsFormLocal extends React.Component {
             right={
               <Input
                 allowEmptyString
-                css={{ 'text-align': 'right' }}
+                css={`
+                  text-align: right;
+                `}
                 field="name"
                 id="name"
                 justifyContent="right"
@@ -98,7 +100,9 @@ class WalletSettingsFormLocal extends React.Component {
             right={
               <Input
                 allowEmptyString
-                css={{ 'text-align': 'right' }}
+                css={`
+                  text-align: right;
+                `}
                 field="alias"
                 id="alias"
                 justifyContent="right"
@@ -153,7 +157,9 @@ class WalletSettingsFormLocal extends React.Component {
                 py={2}
                 right={
                   <Input
-                    css={{ 'text-align': 'right' }}
+                    css={`
+                      text-align: right;
+                    `}
                     field="autopilotMaxchannels"
                     id="autopilotMaxchannels"
                     initialValue={autopilotMaxchannels || autopilotDefaults.autopilotMaxchannels}
@@ -176,7 +182,9 @@ class WalletSettingsFormLocal extends React.Component {
                 py={2}
                 right={
                   <Input
-                    css={{ 'text-align': 'right' }}
+                    css={`
+                      text-align: right;
+                    `}
                     field="autopilotMinchansize"
                     id="autopilotMinchansize"
                     initialValue={autopilotMinchansize || autopilotDefaults.autopilotMinchansize}
@@ -200,7 +208,9 @@ class WalletSettingsFormLocal extends React.Component {
                 py={2}
                 right={
                   <Input
-                    css={{ 'text-align': 'right' }}
+                    css={`
+                      text-align: right;
+                    `}
                     field="autopilotMaxchansize"
                     id="autopilotMaxchansize"
                     initialValue={autopilotMaxchansize || autopilotDefaults.autopilotMaxchansize}

--- a/renderer/components/Home/WalletSettingsFormRemote.js
+++ b/renderer/components/Home/WalletSettingsFormRemote.js
@@ -68,7 +68,9 @@ const WalletSettingsFormRemote = ({
               py={2}
               right={
                 <Input
-                  css={{ 'text-align': 'right' }}
+                  css={`
+                    text-align: right;
+                  `}
                   field="host"
                   id="host"
                   initialValue={host}
@@ -132,7 +134,9 @@ const WalletSettingsFormRemote = ({
           right={
             <Input
               allowEmptyString
-              css={{ 'text-align': 'right' }}
+              css={`
+                text-align: right;
+              `}
               field="name"
               id="name"
               justifyContent="right"

--- a/renderer/components/Home/WalletsMenu.js
+++ b/renderer/components/Home/WalletsMenu.js
@@ -9,7 +9,14 @@ import messages from './messages'
 
 const WalletGroup = withRouter(({ location, setActiveWallet, title, wallets, ...rest }) => (
   <Box p={2} {...rest}>
-    <Text css={{ 'text-transform': 'uppercase' }} fontWeight="normal" mb={2} px={3}>
+    <Text
+      css={`
+        text-transform: uppercase;
+      `}
+      fontWeight="normal"
+      mb={2}
+      px={3}
+    >
       {title}
     </Text>
     {wallets.map(wallet => (

--- a/renderer/components/Onboarding/Steps/ConnectionDetails.js
+++ b/renderer/components/Onboarding/Steps/ConnectionDetails.js
@@ -103,7 +103,12 @@ class ConnectionDetails extends React.Component {
     }
 
     return (
-      <Box css={{ visibility: lndConnect ? 'hidden' : 'visible', width: '100%' }}>
+      <Box
+        css={`
+          visibility: ${lndConnect ? 'hidden' : 'visible'};
+        `}
+        width={1}
+      >
         <ConnectionDetailsContext.Provider
           value={{
             formType,

--- a/renderer/components/Onboarding/Steps/SeedView.js
+++ b/renderer/components/Onboarding/Steps/SeedView.js
@@ -68,7 +68,6 @@ class SeedView extends React.Component {
     return (
       <Form
         {...rest}
-        css={{ width: '100%' }}
         getApi={formApi => {
           this.setFormApi(formApi)
           if (getApi) {
@@ -78,6 +77,7 @@ class SeedView extends React.Component {
         onChange={onChange && (formState => onChange(formState, currentItem))}
         onSubmit={onSubmit}
         onSubmitFailure={onSubmitFailure}
+        width={1}
       >
         {() => (
           <>

--- a/renderer/components/Pay/Pay.js
+++ b/renderer/components/Pay/Pay.js
@@ -469,10 +469,10 @@ class Pay extends React.Component {
             <React.Fragment>
               <LightningInvoiceInput
                 chain={chain}
-                css={{
-                  resize: 'vertical',
-                  'min-height': '48px',
-                }}
+                css={`
+                  resize: vertical;
+                  min-height: 48px;
+                `}
                 field="payReq"
                 forwardedRef={this.payReqInput}
                 initialValue={payReq && payReq.address}
@@ -644,7 +644,9 @@ class Pay extends React.Component {
     } = this.props
     return (
       <Form
-        css={{ height: '100%' }}
+        css={`
+          height: 100%;
+        `}
         width={1}
         {...rest}
         getApi={this.setFormApi}

--- a/renderer/components/Request/Request.js
+++ b/renderer/components/Request/Request.js
@@ -150,7 +150,10 @@ class Request extends React.Component {
     const { intl } = this.props
     return (
       <TextArea
-        css={{ resize: 'vertical', 'min-height': '48px' }}
+        css={`
+          resize: vertical;
+          min-height: 48px;
+        `}
         field="memo"
         label={intl.formatMessage({ ...messages.memo })}
         mb={3}
@@ -205,7 +208,9 @@ class Request extends React.Component {
     const { currentStep } = this.state
     return (
       <Form
-        css={{ height: '100%' }}
+        css={`
+          height: 100%;
+        `}
         width={1}
         {...rest}
         getApi={this.setFormApi}

--- a/renderer/components/Request/RequestSummary.js
+++ b/renderer/components/Request/RequestSummary.js
@@ -124,7 +124,9 @@ class RequestSummary extends React.Component {
               <FormattedMessage {...messages.payment_request} />
               <Text
                 className="hint--bottom-left"
-                css={{ 'word-wrap': 'break-word' }}
+                css={`
+                  word-wrap: break-word;
+                `}
                 data-hint={payReq}
                 fontSize="xs"
                 fontWeight="light"

--- a/renderer/components/Settings/SettingsFieldHelpers.js
+++ b/renderer/components/Settings/SettingsFieldHelpers.js
@@ -25,7 +25,9 @@ FieldLabel.propTypes = {
 
 export const NumberField = props => (
   <Input
-    css={{ 'text-align': 'right' }}
+    css={`
+      text-align: right;
+    `}
     highlightOnValid={false}
     isRequired
     min="1"

--- a/renderer/components/Settings/SettingsPage.js
+++ b/renderer/components/Settings/SettingsPage.js
@@ -98,7 +98,11 @@ const SettingsPage = ({ currentConfig, ...rest }) => {
           <Panel.Header mb={40} px={4}>
             <ZapLogo height={28} width={28} />
           </Panel.Header>
-          <Panel.Body css={{ 'overflow-y': 'overlay' }}>
+          <Panel.Body
+            css={`
+              overflow-y: overlay;
+            `}
+          >
             <SettingsMenu group={group} items={items} setGroup={setGroup} />
           </Panel.Body>
         </Panel>

--- a/renderer/components/Syncing/Syncing.js
+++ b/renderer/components/Syncing/Syncing.js
@@ -40,12 +40,30 @@ const Syncing = ({
 
       <Panel.Body mb={3} mx="auto" width={9 / 16}>
         {!hasSynced && address && address.length && (
-          <Address address={address} css={{ height: '100%' }} showNotification={showNotification} />
+          <Address
+            address={address}
+            css={`
+              height: 100%;
+            `}
+            showNotification={showNotification}
+          />
         )}
-        {hasSynced && <Tutorials css={{ height: '100%' }} />}
+        {hasSynced && (
+          <Tutorials
+            css={`
+              height: 100%;
+            `}
+          />
+        )}
       </Panel.Body>
 
-      <Panel.Footer bg="secondaryColor" css={{ 'min-height': '160px' }} p={3}>
+      <Panel.Footer
+        bg="secondaryColor"
+        css={`
+          min-height: 160px;
+        `}
+        p={3}
+      >
         <Progress
           blockHeight={blockHeight}
           mx="auto"

--- a/renderer/components/UI/DataRow.js
+++ b/renderer/components/UI/DataRow.js
@@ -30,7 +30,13 @@ class DataRow extends React.PureComponent {
       <Box py={3} {...rest}>
         <Flex alignItems="center" justifyContent="space-between">
           {body ? (
-            <Flex alignItems="center" css={{ cursor: 'pointer' }} onClick={this.toggleBody}>
+            <Flex
+              alignItems="center"
+              css={`
+                cursor: pointer;
+              `}
+              onClick={this.toggleBody}
+            >
               <Flex alignItems="center" flexDirection="column" mr={2} width={8}>
                 {collapsed ? <AngleRight height="8px" /> : <AngleDown width="8px" />}
               </Flex>

--- a/renderer/components/UI/Dropdown.js
+++ b/renderer/components/UI/Dropdown.js
@@ -74,26 +74,26 @@ Menu.defaultProps = {
   bg: 'secondaryColor',
 }
 
+const MenuItemText = styled(Box)`
+  cursor: pointer;
+  white-space: nowrap;
+  &:hover {
+    background-color: ${themeGet('colors.primaryColor')};
+  }
+`
+
+MenuItemText.defaultProps = {
+  as: 'li',
+  px: 2,
+  py: 2,
+}
+
 /**
  * MenuItem
  */
 export const MenuItem = withTheme(
   ({ item, onClick, active, theme, hasParent, hasChildren, ...rest }) => (
-    <Text
-      key={item.key}
-      as="li"
-      css={`
-        cursor: pointer;
-        white-space: nowrap;
-        &:hover: {
-          background-color: ${themeGet('colors.primaryColor')};
-        }
-      `}
-      onClick={() => onClick(item.key)}
-      px={2}
-      py={2}
-      {...rest}
-    >
+    <MenuItemText key={item.key} onClick={() => onClick(item.key)} {...rest}>
       <Flex alignItems="center" pr={2}>
         {hasParent && (
           <Flex alignItems="center" color="gray" width="20px">
@@ -111,7 +111,7 @@ export const MenuItem = withTheme(
           {hasChildren && <AngleRight height="8px" />}
         </Flex>
       </Flex>
-    </Text>
+    </MenuItemText>
   )
 )
 

--- a/renderer/components/UI/Dropdown.js
+++ b/renderer/components/UI/Dropdown.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { injectIntl } from 'react-intl'
 import { Box, Flex } from 'rebass'
 import styled, { withTheme } from 'styled-components'
-import { opacity } from 'styled-system'
+import { themeGet, opacity } from 'styled-system'
 import { useOnClickOutside, useIntl } from 'hooks'
 import AngleLeft from 'components/Icon/AngleLeft'
 import AngleRight from 'components/Icon/AngleRight'
@@ -82,13 +82,13 @@ export const MenuItem = withTheme(
     <Text
       key={item.key}
       as="li"
-      css={{
-        cursor: 'pointer',
-        'white-space': 'nowrap',
-        '&:hover': {
-          'background-color': theme.colors.primaryColor,
-        },
-      }}
+      css={`
+        cursor: pointer;
+        white-space: nowrap;
+        &:hover: {
+          background-color: ${themeGet('colors.primaryColor')};
+        }
+      `}
       onClick={() => onClick(item.key)}
       px={2}
       py={2}

--- a/renderer/components/UI/Dropmenu.js
+++ b/renderer/components/UI/Dropmenu.js
@@ -274,7 +274,14 @@ const DropmenuList = React.forwardRef((props, forwardRef) => {
     ref.current.scrollTop -= SCROLL_STEP
   }
   return (
-    <Card css={{ position: 'relative' }} onMouseDown={preventDefault} p={0} width={width}>
+    <Card
+      css={`
+        position: relative;
+      `}
+      onMouseDown={preventDefault}
+      p={0}
+      width={width}
+    >
       <DropmenuListUpScroller
         direction="up"
         hasTopScroll={hasTopScroll}
@@ -349,8 +356,18 @@ DropmenuSubmenu.defaultProps = {
 const DropmenuMenu = ({ menuRef, ...rest }) => {
   const { justify } = useContext(MenuContext)
   return (
-    <Box css={{ position: 'relative' }}>
-      <Flex css={{ position: 'absolute', 'z-index': '1', right: justify === 'right' ? 0 : null }}>
+    <Box
+      css={`
+        position: relative;
+      `}
+    >
+      <Flex
+        css={`
+          position: absolute;
+          z-index: 1;
+          right: ${justify === 'right' ? 0 : null};
+        `}
+      >
         <DropmenuContent {...rest} menuRef={menuRef} />
       </Flex>
     </Box>

--- a/renderer/components/UI/Header.js
+++ b/renderer/components/UI/Header.js
@@ -7,7 +7,7 @@ import Text from './Text'
 const Header = ({ title, subtitle, align, logo }) => (
   <Flex alignItems={align} as="header" flexDirection="column" justifyContent={align}>
     {logo && (
-      <Text css={{ height: '50px' }} fontSize="50px" lineHeight="1" textAlign={align}>
+      <Text fontSize="50px" lineHeight="1" textAlign={align}>
         {logo}
       </Text>
     )}

--- a/renderer/components/UI/Input.js
+++ b/renderer/components/UI/Input.js
@@ -237,7 +237,12 @@ class Input extends React.Component {
             <Label htmlFor={field}>
               {label}
               {isRequired && (
-                <Span css={{ 'vertical-align': 'top' }} fontSize="s">
+                <Span
+                  css={`
+                    vertical-align: top;
+                  `}
+                  fontSize="s"
+                >
                   {' '}
                   *
                 </Span>

--- a/renderer/components/UI/Link.js
+++ b/renderer/components/UI/Link.js
@@ -18,7 +18,14 @@ class Link extends React.PureComponent {
   render() {
     const { children } = this.props
     return (
-      <Text as="a" css={{ cursor: 'pointer', 'text-decoration': 'underline' }} {...this.props}>
+      <Text
+        as="a"
+        css={`
+          cursor: pointer;
+          text-decoration: underline;
+        `}
+        {...this.props}
+      >
         {children}
       </Text>
     )

--- a/renderer/components/UI/LndConnectionStringInput.js
+++ b/renderer/components/UI/LndConnectionStringInput.js
@@ -54,7 +54,9 @@ class LndConnectionStringInput extends React.Component {
 
     return (
       <TextArea
-        css={{ 'word-break': 'break-all' }}
+        css={`
+          word-break: break-all;
+        `}
         initialValue={initialValue}
         placeholder={intl.formatMessage({ ...messages.lnd_connection_string_placeholder })}
         {...rest}

--- a/renderer/components/UI/MainContent.js
+++ b/renderer/components/UI/MainContent.js
@@ -10,7 +10,11 @@ import { Box } from 'rebass'
 const MainContent = props => (
   <Box
     as="article"
-    css={{ height: '100%', 'overflow-y': 'overlay', 'overflow-x': 'hidden' }}
+    css={`
+      height: 100%;
+      overflow-y: overlay;
+      overflow-x: hidden;
+    `}
     width={1}
     {...props}
   />

--- a/renderer/components/UI/Message.js
+++ b/renderer/components/UI/Message.js
@@ -29,7 +29,7 @@ class Message extends React.Component {
   renderIcon = () => {
     const { variant } = this.props
     return (
-      <Box css={{ height: '14px' }} mr={1} width="14px">
+      <Box mr={1} width="14px">
         {variant === 'success' && <Success height="14px" width="14px" />}
         {variant === 'warning' && <Warning height="14px" width="14px" />}
         {variant === 'error' && <Error height="14px" width="14px" />}

--- a/renderer/components/UI/Modal.js
+++ b/renderer/components/UI/Modal.js
@@ -4,7 +4,6 @@ import styled from 'styled-components'
 import { Box, Flex } from 'rebass'
 import CloseButton from 'components/UI/CloseButton'
 import ZapLogo from 'components/Icon/ZapLogo'
-import Panel from './Panel'
 import Page from './Page'
 
 export const ModalOverlayStyles = () => `
@@ -16,7 +15,7 @@ export const ModalOverlayStyles = () => `
   right: 0;
 `
 
-export const ModalHeader = styled(Flex)`
+const ModalHeader = styled(Flex)`
   position: absolute;
   top: 0;
   left: 0;
@@ -25,7 +24,12 @@ export const ModalHeader = styled(Flex)`
   pointer-events: none;
 `
 
-export const ModalCloseWrapper = styled(Box)`
+const ModalContentWrapper = styled(Box)`
+  height: 100%;
+  width: 100%;
+`
+
+const ModalCloseWrapper = styled(Box)`
   pointer-events: auto;
   display: inline-block;
 `
@@ -55,7 +59,7 @@ const Modal = props => {
   const { children, onClose, hasClose, hasLogo, ...rest } = props
 
   return (
-    <Panel bg="primaryColor" color="primaryText">
+    <ModalContentWrapper bg="primaryColor" color="primaryText">
       {(hasClose || hasLogo) && (
         <ModalHeader justifyContent={hasLogo ? 'space-between' : 'flex-end'} pt={3} px={3}>
           {hasLogo && <ModalLogo />}
@@ -63,7 +67,7 @@ const Modal = props => {
         </ModalHeader>
       )}
       <Page {...rest}>{children}</Page>
-    </Panel>
+    </ModalContentWrapper>
   )
 }
 

--- a/renderer/components/UI/Notification.js
+++ b/renderer/components/UI/Notification.js
@@ -44,7 +44,9 @@ class Notification extends React.Component {
       <Card
         borderRadius="5px"
         boxShadow="0 3px 4px 0 rgba(30, 30, 30, 0.5)"
-        css={{ cursor: 'pointer' }}
+        css={`
+          cursor: pointer;
+        `}
         px={3}
         py={3}
         {...this.props}

--- a/renderer/components/UI/Page.js
+++ b/renderer/components/UI/Page.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import { Flex } from 'rebass'
 
 /**
@@ -8,28 +7,21 @@ import { Flex } from 'rebass'
  * @example
  * <Page>Some content</Page>
  */
-const Page = ({ css, ...rest }) => (
+const Page = props => (
   <Flex
     as="article"
     bg="primaryColor"
     color="primaryText"
-    css={Object.assign(
-      {
-        position: 'relative',
-        height: '100%',
-        overflow: 'hidden',
-        'min-width': '900px',
-        'min-height': '425px',
-        'box-shadow': '0 20px 70px rgba(0, 0, 0, 0.55)',
-      },
-      css
-    )}
-    {...rest}
+    css={`
+      position: relative;
+      height: 100%;
+      overflow: hidden;
+      min-width: 900px;
+      min-height: 425px;
+      box-shadow: 0 20px 70px rgba(0, 0, 0, 0.55);
+    `}
+    {...props}
   />
 )
-
-Page.propTypes = {
-  css: PropTypes.object,
-}
 
 export default Page

--- a/renderer/components/UI/Panel.js
+++ b/renderer/components/UI/Panel.js
@@ -10,7 +10,13 @@ const PanelHeader = ({ children, ...rest }) => (
 PanelHeader.propTypes = { children: PropTypes.node }
 
 const PanelBody = ({ children, css, ...rest }) => (
-  <Box {...rest} as="section" css={Object.assign({ flex: 1 }, css)}>
+  <Box
+    {...rest}
+    as="section"
+    css={`
+      flex: 1;
+    `}
+  >
     {children}
   </Box>
 )
@@ -36,7 +42,15 @@ class Panel extends React.Component {
   render() {
     const { children, ...rest } = this.props
     return (
-      <Flex {...rest} as="article" css={{ height: '100%' }} flexDirection="column" {...rest}>
+      <Flex
+        {...rest}
+        as="article"
+        css={`
+          height: 100%;
+        `}
+        flexDirection="column"
+        {...rest}
+      >
         {children}
       </Flex>
     )

--- a/renderer/components/UI/RadioCard.js
+++ b/renderer/components/UI/RadioCard.js
@@ -43,7 +43,13 @@ const RadioCard = ({ fieldApi, icons, value, label, isDisabled, description, ...
       onClick={() => !isDisabled && fieldApi.setValue(value)}
     >
       <Card mb={3}>
-        <Flex alignItems="center" css={{ height: '100%' }} justifyContent="center">
+        <Flex
+          alignItems="center"
+          css={`
+            height: 100%;
+          `}
+          justifyContent="center"
+        >
           <Box color={isSelected ? 'lightningOrange' : 'gray'}>
             <Icon height={iconHeight} width={iconWidth} />
           </Box>

--- a/renderer/components/UI/RadioGroup.js
+++ b/renderer/components/UI/RadioGroup.js
@@ -11,7 +11,12 @@ const RadioGroup = ({ label, field, description, isRequired, children, ...rest }
       <Label htmlFor={field} mb={2}>
         {label}
         {isRequired && (
-          <Span css={{ 'vertical-align': 'top' }} fontSize="s">
+          <Span
+            css={`
+              vertical-align: top;
+            `}
+            fontSize="s"
+          >
             {' '}
             *
           </Span>

--- a/renderer/components/UI/TextArea.js
+++ b/renderer/components/UI/TextArea.js
@@ -192,7 +192,12 @@ class TextArea extends React.PureComponent {
             <Label htmlFor={field} mb={2}>
               {label}
               {isRequired && (
-                <Span css={{ 'vertical-align': 'top' }} fontSize="s">
+                <Span
+                  css={`
+                    vertical-align: top;
+                  `}
+                  fontSize="s"
+                >
                   {' '}
                   *
                 </Span>

--- a/renderer/components/Wallet/WalletMenu.js
+++ b/renderer/components/Wallet/WalletMenu.js
@@ -42,7 +42,13 @@ const WalletMenu = ({ openModal }) => {
     <Flex as="section">
       <ChannelsMenu />
       {isAutopayEnabled() && <AutopayMenuItem openModal={openModal} />}
-      <SettingsMenu css={{ position: 'relative', 'z-index': '40' }} ml={4} />
+      <SettingsMenu
+        css={`
+          position: relative;
+          z-index: 40;
+        `}
+        ml={4}
+      />
     </Flex>
   )
 }

--- a/stories/Provider.js
+++ b/stories/Provider.js
@@ -124,3 +124,17 @@ store.dispatch({
   },
   closedChannels: [],
 })
+store.dispatch({
+  type: 'SET_WALLETS',
+  wallets: [
+    {
+      id: 1,
+      type: 'local',
+    },
+  ],
+})
+store.dispatch({
+  type: 'SET_SETTING',
+  key: 'activeWallet',
+  value: 1,
+})

--- a/stories/_general/color.stories.js
+++ b/stories/_general/color.stories.js
@@ -14,10 +14,10 @@ const Swatch = ({ name, color }) => (
         // bg={color}
         borderRadius={8}
         boxShadow="0 2px 6px rgba(0, 0, 0, 0.3)"
-        css={{
-          background: color,
-          height: '50px',
-        }}
+        css={`
+          background: ${color};
+          height: 50px;
+        `}
         mr={21}
         width={50}
       />

--- a/stories/components/background.stories.js
+++ b/stories/components/background.stories.js
@@ -5,7 +5,14 @@ import { BackgroundPrimary, BackgroundTertiary, BackgroundSecondary, Page } from
 import { Content } from '../helpers'
 
 const Wrapper = ({ children }) => (
-  <Page css={{ height: '50px', 'min-height': '200px' }}>{children}</Page>
+  <Page
+    css={`
+      height: 50px;
+      min-height: 200px;
+    `}
+  >
+    {children}
+  </Page>
 )
 Wrapper.propTypes = {
   children: PropTypes.node,
@@ -21,9 +28,9 @@ storiesOf('Components', module).addWithChapters('Background', {
           },
           sectionFn: () => (
             <BackgroundPrimary
-              css={{
-                height: '100%',
-              }}
+              css={`
+                height: 100%;
+              `}
               width={1}
             >
               <Content>BackgroundPrimary</Content>
@@ -36,9 +43,9 @@ storiesOf('Components', module).addWithChapters('Background', {
           },
           sectionFn: () => (
             <BackgroundSecondary
-              css={{
-                height: '100%',
-              }}
+              css={`
+                height: 100%;
+              `}
               width={1}
             >
               <Content>BackgroundSecondary</Content>
@@ -51,9 +58,9 @@ storiesOf('Components', module).addWithChapters('Background', {
           },
           sectionFn: () => (
             <BackgroundTertiary
-              css={{
-                height: '100%',
-              }}
+              css={`
+                height: 100%;
+              `}
               width={1}
             >
               <Content>BackgroundTertiary</Content>

--- a/stories/components/dialog.stories.js
+++ b/stories/components/dialog.stories.js
@@ -6,7 +6,7 @@ import Globe from 'components/Icon/Globe'
 
 storiesOf('Components', module)
   .addDecorator(story => (
-    <Page css={{ backgroundColor: '#313340' }} pl={4}>
+    <Page bg="secondaryColor" pl={4}>
       {story()}
     </Page>
   ))

--- a/stories/containers/activity.stories.js
+++ b/stories/containers/activity.stories.js
@@ -13,9 +13,8 @@ import { Window } from '../helpers'
 
 storiesOf('Containers.Activity', module)
   .addParameters({ info: { disable: true } })
-  .addDecorator(story => <Window>{story()}</Window>)
   .addDecorator(story => <Provider story={story()} />)
-  .addDecorator(story => <Modal>{story()}</Modal>)
+  .addDecorator(story => <Window>{story()}</Window>)
   .add('InvoiceModal', () => {
     const encoded = lightningPayReq.encode({
       coinType: 'testnet',
@@ -51,12 +50,14 @@ storiesOf('Containers.Activity', module)
       tx_hash: '1ae44a23c141a2892c55eb3fe9de45195d88e89b36b5070e10df92d4130e4028',
     }
     return (
-      <InvoiceModal
-        item={invoice}
-        mx="auto"
-        showNotification={action('showNotification')}
-        width={9 / 16}
-      />
+      <Modal p={4}>
+        <InvoiceModal
+          item={invoice}
+          mx="auto"
+          showNotification={action('showNotification')}
+          width={9 / 16}
+        />
+      </Modal>
     )
   })
   .add('PaymentModal', () => {
@@ -65,7 +66,11 @@ storiesOf('Containers.Activity', module)
       creation_date: Math.round(new Date().getTime() / 1000),
       payment_preimage: '46914421ed5eafea1ec40726338bc5059e80e128660b9c7c8a5817e59429af30',
     }
-    return <PaymentModal item={payment} mx="auto" width={9 / 16} />
+    return (
+      <Modal p={4}>
+        <PaymentModal item={payment} mx="auto" width={9 / 16} />
+      </Modal>
+    )
   })
   .add('TransactionModal', () => {
     const transaction = {
@@ -79,11 +84,13 @@ storiesOf('Containers.Activity', module)
       tx_hash: '1ae44a23c141a2892c55eb3fe9de45195d88e89b36b5070e10df92d4130e4028',
     }
     return (
-      <TransactionModal
-        item={transaction}
-        mx="auto"
-        networkInfo={infoSelectors.networkInfo(store.getState())}
-        width={9 / 16}
-      />
+      <Modal p={4}>
+        <TransactionModal
+          item={transaction}
+          mx="auto"
+          networkInfo={infoSelectors.networkInfo(store.getState())}
+          width={9 / 16}
+        />
+      </Modal>
     )
   })

--- a/stories/containers/channels/channel-create-form.stories.js
+++ b/stories/containers/channels/channel-create-form.stories.js
@@ -11,7 +11,9 @@ storiesOf('Containers.Channels', module)
   .addDecorator(story => <Provider story={story()} />)
   .addDecorator(story => (
     <Window>
-      <Modal onClose={action('clicked')}>{story()}</Modal>
+      <Modal onClose={action('clicked')} p={4}>
+        {story()}
+      </Modal>
     </Window>
   ))
   .add('ChannelCreateForm', () => <ChannelCreateForm mx="auto" width={9 / 16} />)

--- a/stories/containers/onboarding.stories.js
+++ b/stories/containers/onboarding.stories.js
@@ -117,28 +117,29 @@ const createWallet = async () => action('createWallet')
 storiesOf('Containers.Onboarding', module)
   .addParameters({ info: { disable: true } })
   .addDecorator(story => <Window>{story()}</Window>)
-  .addDecorator(story => <Modal onClose={linkTo('Containers.Home', 'Home')}>{story()}</Modal>)
   .add('Onboarding', () => {
     return (
-      <State store={store}>
-        <Onboarding
-          // DISPATCH
-          createWallet={createWallet}
-          fetchSeed={fetchSeed}
-          resetOnboarding={resetOnboarding}
-          setAutopilot={setAutopilot}
-          setConnectionCert={setConnectionCert}
-          setConnectionHost={setConnectionHost}
-          setConnectionMacaroon={setConnectionMacaroon}
-          setConnectionType={setConnectionType}
-          setName={setName}
-          setPassword={setPassword}
-          startLnd={startLnd}
-          stopLnd={stopLnd}
-          validateCert={validateCert}
-          validateHost={validateHost}
-          validateMacaroon={validateMacaroon}
-        />
-      </State>
+      <Modal onClose={linkTo('Containers.Home', 'Home')} p={4}>
+        <State store={store}>
+          <Onboarding
+            // DISPATCH
+            createWallet={createWallet}
+            fetchSeed={fetchSeed}
+            resetOnboarding={resetOnboarding}
+            setAutopilot={setAutopilot}
+            setConnectionCert={setConnectionCert}
+            setConnectionHost={setConnectionHost}
+            setConnectionMacaroon={setConnectionMacaroon}
+            setConnectionType={setConnectionType}
+            setName={setName}
+            setPassword={setPassword}
+            startLnd={startLnd}
+            stopLnd={stopLnd}
+            validateCert={validateCert}
+            validateHost={validateHost}
+            validateMacaroon={validateMacaroon}
+          />
+        </State>
+      </Modal>
     )
   })

--- a/stories/containers/pay.stories.js
+++ b/stories/containers/pay.stories.js
@@ -2,113 +2,19 @@
 
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { action } from '@storybook/addon-actions'
-import { boolean, number, select, text } from '@storybook/addon-knobs'
 import { Modal } from 'components/UI'
-import { Pay } from 'components/Pay'
-import { tickerSelectors } from 'reducers/ticker'
-import { Provider, store } from '../Provider'
-import { Window, mockCreateInvoice } from '../helpers'
-
-const data = {
-  cryptoName: 'Bitcoin',
-  walletBalance: 47238944,
-  walletBalanceConfirmed: 37236599,
-  walletBalanceUnconfirmed: 10002345,
-  channelBalance: 25000,
-  onchainFees: {
-    fast: 100,
-    medium: 70,
-    slow: 30,
-  },
-
-  nodes: [
-    {
-      pub_key: '03c856d2dbec7454c48f311031f06bb99e3ca1ab15a9b9b35de14e139aa663b463',
-      alias: 'htlc.me',
-    },
-  ],
-  routes: [],
-
-  currentTicker: {
-    USD: 6477.78,
-    EUR: 5656.01,
-    GBP: 5052.73,
-  },
-
-  isProcessing: false,
-}
-
-const mockPayInvoice = async () => {
-  action('mockPayInvoice')
-}
-
-const mockSendCoins = async () => {
-  action('mockSendCoins')
-}
-
-const mockQueryRoutes = async pubKey => {
-  action('mockQueryRoutes', pubKey)
-}
-
-const mockSetPayReq = async payReq => {
-  action('mockSetPayReq', payReq)
-}
+import Pay from 'containers/Pay'
+import { Provider } from '../Provider'
+import { Window } from '../helpers'
 
 storiesOf('Containers.Pay', module)
   .addParameters({ info: { disable: true } })
-  .addDecorator(story => <Window>{story()}</Window>)
   .addDecorator(story => <Provider story={story()} />)
-  .addDecorator(story => <Modal onClose={action('clicked')}>{story()}</Modal>)
+  .addDecorator(story => <Window>{story()}</Window>)
   .add('Pay', () => {
-    const hasInvoicePreset = boolean('Use invoice preset', false)
-    const coinType = select(
-      'Coin Type',
-      {
-        'Bitcoin mainnet': 'bitcoin',
-        'Bitcoin testnet': 'testnet',
-        'Litecoin mainnet': 'litecoin',
-        'Litecoin testnet': 'litecoin_testnet',
-      },
-      'bitcoin'
-    )
-    const unit = select(
-      'Unit',
-      {
-        Satoshis: 'satoshis',
-        Millisatoshis: 'millisatoshis',
-      },
-      'satoshis'
-    )
-    const amount = number('Amount')
-    const memo = text('Memo')
-    const payReq = hasInvoicePreset ? mockCreateInvoice(coinType, amount, unit, memo) : null
-
-    const chain = ['bitcoin', 'testnet'].includes(coinType) ? 'bitcoin' : 'litecoin'
-    const network = ['bitcoin', 'testnet'].includes(coinType) ? 'mainnet' : 'testnet'
-
-    const state = store.getState()
-
     return (
-      <Pay
-        chain={chain}
-        channelBalance={data.channelBalance}
-        // State
-        // initialPayReq="lntb100n1pdaetlfpp5rkj5acj5usdlqekv3548nx5zc58tsqghm8qy6pdkrn3h37ep5aqsdqqcqzysxqyz5vq7vsxfsnak9yd0rf0zxpg9tukykxjqwef72apfwq2meg7wlz8zg0nxh3fmmc0ayv8ac5xhnlwlxajatqwnh3qwdx6uruyqn47enq9w6qplzqccc"
-        cryptoCurrency={state.ticker.currency}
-        cryptoCurrencyTicker={tickerSelectors.currencyName(state)}
-        cryptoName={data.cryptoName}
-        isProcessing={data.isProcessing}
-        mx="auto"
-        network={network}
-        payInvoice={mockPayInvoice}
-        payReq={payReq}
-        queryRoutes={mockQueryRoutes}
-        // Dispatch
-        sendCoins={mockSendCoins}
-        setPayReq={mockSetPayReq}
-        walletBalance={data.walletBalance}
-        width={9 / 16}
-      />
+      <Modal p={3}>
+        <Pay mx="auto" width={9 / 16} />
+      </Modal>
     )
   })

--- a/stories/containers/request.stories.js
+++ b/stories/containers/request.stories.js
@@ -2,70 +2,19 @@
 
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { action } from '@storybook/addon-actions'
-import { text } from '@storybook/addon-knobs'
-import lightningPayReq from 'bolt11'
-import { convert } from '@zap/utils/btc'
 import { Modal } from 'components/UI'
-import { Request } from 'components/Request'
-import { tickerSelectors } from 'reducers/ticker'
-import { Provider, store } from '../Provider'
+import Request from 'containers/Request'
+import { Provider } from '../Provider'
 import { Window } from '../helpers'
-
-const mockCreateInvoice = async (amount, currency, memo = '') => {
-  const satoshis = convert(currency, 'sats', amount)
-  var encoded = lightningPayReq.encode({
-    coinType: 'bitcoin',
-    satoshis,
-    tags: [
-      {
-        tagName: 'purpose_commit_hash',
-        data: '3925b6f67e2c340036ed12093dd44e0368df1b6ea26c53dbe4811f58fd5db8c1',
-      },
-      {
-        tagName: 'payment_hash',
-        data: '0001020304050607080900010203040506070809000102030405060708090102',
-      },
-      {
-        tagName: 'expire_time',
-        data: 30,
-      },
-      {
-        tagName: 'description',
-        data: memo,
-      },
-    ],
-  })
-  var privateKeyHex = 'e126f68f7eafcc8b74f54d269fe206be715000f94dac067d1c04a8ca3b2db734'
-  var signed = lightningPayReq.sign(encoded, privateKeyHex)
-  return signed.paymentRequest
-}
-
-const payReq = text(
-  'Payment Request',
-  'lntb10170n1pda7tarpp59kjlzct447ttxper43kek78lhwgxk4gy8nfvpjdr7yzkscu2ds5qdzy2pshjmt9de6zqen0wgsrzvp3xus8q6tcv4k8xgrpwss8xct5daeks6tn9ecxcctrv5hqxqzjccqp2yvpzcn2xazu9rt8nrhn2xf6nyrj8fsfw9hafsf0p80trypu4tp58km5mn7wz50uh06kxf4t8kdj64f86u6l5ksl75r500zl7urhacxspcm4ye9'
-)
 
 storiesOf('Containers.Request', module)
   .addParameters({ info: { disable: true } })
-  .addDecorator(story => <Window>{story()}</Window>)
   .addDecorator(story => <Provider story={story()} />)
-  .addDecorator(story => <Modal onClose={action('clicked')}>{story()}</Modal>)
+  .addDecorator(story => <Window>{story()}</Window>)
   .add('Request', () => {
-    const state = store.getState()
     return (
-      <Request
-        createInvoice={mockCreateInvoice}
-        cryptoCurrency={state.ticker.currency}
-        // State
-        cryptoCurrencyTicker={tickerSelectors.currencyName(state)}
-        cryptoName={tickerSelectors.cryptoName(state)}
-        invoice={mockCreateInvoice()}
-        mx="auto"
-        payReq={payReq}
-        // Dispatch
-        showNotification={action('showNotification')}
-        width={9 / 16}
-      />
+      <Modal p={3}>
+        <Request mx="auto" width={9 / 16} />
+      </Modal>
     )
   })

--- a/stories/containers/settingspage.stories.js
+++ b/stories/containers/settingspage.stories.js
@@ -1,16 +1,11 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { MainContent } from 'components/UI'
-import Wallet from 'containers/Wallet'
+import SettingsPage from 'containers/Settings/SettingsPage'
 import { Provider } from '../Provider'
 import { Window } from '../helpers'
 
-storiesOf('Containers.Wallet', module)
+storiesOf('Containers.SettingsPage', module)
   .addParameters({ info: { disable: true } })
   .addDecorator(story => <Provider story={story()} />)
   .addDecorator(story => <Window>{story()}</Window>)
-  .add('Wallet', () => (
-    <MainContent>
-      <Wallet />
-    </MainContent>
-  ))
+  .add('SettingsPage', () => <SettingsPage />)

--- a/stories/containers/syncing.stories.js
+++ b/stories/containers/syncing.stories.js
@@ -13,13 +13,8 @@ const showNotification = () => ({})
 
 storiesOf('Containers.Syncing', module)
   .addParameters({ info: { disable: true } })
-  .addDecorator(story => <Window>{story()}</Window>)
   .addDecorator(story => <Provider story={story()} />)
-  .addDecorator(story => (
-    <Modal hasLogo onClose={linkTo('Containers.Home', 'Home')} pb={0} px={0}>
-      {story()}
-    </Modal>
-  ))
+  .addDecorator(story => <Window>{story()}</Window>)
   .add('Syncing', () => {
     const state = store.getState()
     const hasSynced = boolean('Has synced', false)
@@ -28,20 +23,23 @@ storiesOf('Containers.Syncing', module)
     const recoveryPercentage = number('Recovery Percentage', 30)
     const network = select('Network', ['mainnet', 'testnet'], 'mainnet')
     return (
-      <Syncing
-        address="2MxZ2z7AodL6gxEgwL5tkq2imDBhkBMq2Jc"
-        blockHeight={neutrinoSelectors.blockHeight(state)}
-        hasSynced={hasSynced}
-        isLightningGrpcActive={state.lnd.isLightningGrpcActive}
-        network={network}
-        neutrinoBlockHeight={neutrinoSelectors.neutrinoBlockHeight(state)}
-        neutrinoCfilterHeight={neutrinoSelectors.neutrinoCfilterHeight(state)}
-        neutrinoRecoveryHeight={neutrinoSelectors.neutrinoRecoveryHeight(state)}
-        recoveryPercentage={recoveryPercentage}
-        setIsWalletOpen={setIsWalletOpen}
-        showNotification={showNotification}
-        syncPercentage={syncPercentage}
-        syncStatus={syncStatus}
-      />
+      <Modal hasLogo onClose={linkTo('Containers.Home', 'Home')} pt={4}>
+        <Syncing
+          address="2MxZ2z7AodL6gxEgwL5tkq2imDBhkBMq2Jc"
+          blockHeight={neutrinoSelectors.blockHeight(state)}
+          hasSynced={hasSynced}
+          isLightningGrpcActive={state.lnd.isLightningGrpcActive}
+          network={network}
+          neutrinoBlockHeight={neutrinoSelectors.neutrinoBlockHeight(state)}
+          neutrinoCfilterHeight={neutrinoSelectors.neutrinoCfilterHeight(state)}
+          neutrinoRecoveryHeight={neutrinoSelectors.neutrinoRecoveryHeight(state)}
+          p={4}
+          recoveryPercentage={recoveryPercentage}
+          setIsWalletOpen={setIsWalletOpen}
+          showNotification={showNotification}
+          syncPercentage={syncPercentage}
+          syncStatus={syncStatus}
+        />
+      </Modal>
     )
   })

--- a/stories/helpers.js
+++ b/stories/helpers.js
@@ -4,7 +4,14 @@ import { Box, Flex } from 'rebass'
 import { Bar, Heading, Page } from '@zap/renderer/components/UI'
 import lightningPayReq from 'bolt11'
 
-export const Window = props => <Page css={{ height: 'calc(100vh - 120px)' }} {...props} />
+export const Window = props => (
+  <Page
+    css={`
+      height: calc(100vh - 40px);
+    `}
+    {...props}
+  />
+)
 export const Column = props => <Box mr={5} width={1 / 2} {...props} />
 export const Group = ({ title, children, hasBar = true }) => (
   <Box mb={4}>
@@ -22,7 +29,13 @@ Group.propTypes = {
 }
 export const Element = props => <Box py={1} {...props} />
 export const Content = ({ children }) => (
-  <Flex alignItems="center" css={{ height: '100%' }} justifyContent="center">
+  <Flex
+    alignItems="center"
+    css={`
+      height: 100%;
+    `}
+    justifyContent="center"
+  >
     <Heading>{children}</Heading>
   </Flex>
 )

--- a/stories/layouts/page.stories.js
+++ b/stories/layouts/page.stories.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { Page, MainContent, Sidebar } from 'components/UI'
-import { Content } from '../helpers'
+import { MainContent, Sidebar } from 'components/UI'
+import { Window, Content } from '../helpers'
 
 storiesOf('Layouts', module).addWithChapters('Page', {
   subtitle: 'The outer most application wrapper.',
@@ -10,30 +10,30 @@ storiesOf('Layouts', module).addWithChapters('Page', {
     {
       sections: [
         {
-          title: 'Page with small left sidebar',
+          title: 'Page with medium left sidebar',
 
           sectionFn: () => (
-            <Page>
-              <Sidebar.small bg="green">
+            <Window>
+              <Sidebar.medium bg="green">
                 <Content>Sidebar</Content>
-              </Sidebar.small>
+              </Sidebar.medium>
               <MainContent bg="blue">
                 <Content>MainContent</Content>
               </MainContent>
-            </Page>
+            </Window>
           ),
         },
         {
           title: 'Page with large right sidebar',
           sectionFn: () => (
-            <Page>
+            <Window>
               <MainContent bg="blue">
                 <Content>MainContent</Content>
               </MainContent>
               <Sidebar.large bg="green">
                 <Content>Sidebar</Content>
               </Sidebar.large>
-            </Page>
+            </Window>
           ),
         },
       ],

--- a/stories/layouts/panel.stories.js
+++ b/stories/layouts/panel.stories.js
@@ -1,15 +1,7 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import { storiesOf } from '@storybook/react'
-import { Page, Panel } from 'components/UI'
-import { Content } from '../helpers'
-
-const Wrapper = ({ children }) => (
-  <Page css={{ height: '500px', 'min-height': '500px' }}>{children}</Page>
-)
-Wrapper.propTypes = {
-  children: PropTypes.node,
-}
+import { Panel } from 'components/UI'
+import { Window, Content } from '../helpers'
 
 storiesOf('Layouts', module).addWithChapters('Panel', {
   subtitle: 'For pages with a fixed header and footer.',
@@ -19,7 +11,7 @@ storiesOf('Layouts', module).addWithChapters('Panel', {
       sections: [
         {
           sectionFn: () => (
-            <Wrapper>
+            <Window>
               <Panel width={1}>
                 <Panel.Header bg="green">
                   <Content>Panel Header</Content>
@@ -31,7 +23,7 @@ storiesOf('Layouts', module).addWithChapters('Panel', {
                   <Content>Panel Footer</Content>
                 </Panel.Footer>
               </Panel>
-            </Wrapper>
+            </Window>
           ),
         },
       ],

--- a/test/unit/components/Home/CreateWalletButton.spec.js
+++ b/test/unit/components/Home/CreateWalletButton.spec.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import toJSON from 'enzyme-to-json'
-import { CreateWalletButton } from 'components/Home'
+import CreateWalletButton from 'components/Home/CreateWalletButton'
 
 const history = { push: jest.fn() }
 

--- a/test/unit/components/Home/NoWallets.spec.js
+++ b/test/unit/components/Home/NoWallets.spec.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import toJSON from 'enzyme-to-json'
-import { NoWallets } from 'components/Home'
+import NoWallets from 'components/Home/NoWallets'
 
 const history = { push: jest.fn() }
 

--- a/test/unit/components/Home/WalletHeader.spec.js
+++ b/test/unit/components/Home/WalletHeader.spec.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import toJSON from 'enzyme-to-json'
-import { WalletHeader } from 'components/Home'
+import WalletHeader from 'components/Home/WalletHeader'
 
 describe('component.WalletHeader', () => {
   it('should render correctly', () => {

--- a/test/unit/components/Home/__snapshots__/NoWallets.spec.js.snap
+++ b/test/unit/components/Home/__snapshots__/NoWallets.spec.js.snap
@@ -1,13 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`component.NoWallets should render correctly (no selected wallet) 1`] = `
-<Styled(styled.div)
+<Styled(Styled(styled.div))
   alignItems="center"
-  css={
-    Object {
-      "height": "100%",
-    }
-  }
   flexDirection="column"
   justifyContent="center"
 >
@@ -35,17 +30,12 @@ exports[`component.NoWallets should render correctly (no selected wallet) 1`] = 
     }
     p={3}
   />
-</Styled(styled.div)>
+</Styled(Styled(styled.div))>
 `;
 
 exports[`component.NoWallets should render correctly (no wallets) 1`] = `
-<Styled(styled.div)
+<Styled(Styled(styled.div))
   alignItems="center"
-  css={
-    Object {
-      "height": "100%",
-    }
-  }
   flexDirection="column"
   justifyContent="center"
 >
@@ -73,5 +63,5 @@ exports[`component.NoWallets should render correctly (no wallets) 1`] = `
     }
     p={3}
   />
-</Styled(styled.div)>
+</Styled(Styled(styled.div))>
 `;

--- a/test/unit/components/Pay/PaySummaryOnchain.spec.js
+++ b/test/unit/components/Pay/PaySummaryOnchain.spec.js
@@ -28,6 +28,11 @@ const props = {
     },
   ],
   fiatCurrency: 'USD',
+  lndTargetConfirmations: {
+    fast: 100,
+    medium: 80,
+    slow: 60,
+  },
   queryFees: jest.fn(),
   setCryptoCurrency: jest.fn(),
 }

--- a/test/unit/components/UI/__snapshots__/ActionBar.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/ActionBar.spec.js.snap
@@ -2,9 +2,10 @@
 
 exports[`component.UI.ActionBar should render correctly 1`] = `
 .c0 {
+  box-sizing: border-box;
+  padding-top: 8px;
   padding-bottom: 8px;
   padding-right: 64px;
-  padding-top: 8px;
   background-color: secondaryColor;
   display: -webkit-box;
   display: -webkit-flex;
@@ -20,17 +21,19 @@ exports[`component.UI.ActionBar should render correctly 1`] = `
 }
 
 .c2 {
+  box-sizing: border-box;
   font-family: sans;
   font-weight: normal;
 }
 
 .c1 {
-  margin: 0px;
+  box-sizing: border-box;
+  margin: 0;
   margin-right: 128px;
-  padding-left: 0px;
-  padding-right: 0px;
   padding-top: 16px;
   padding-bottom: 16px;
+  padding-left: 0;
+  padding-right: 0;
   font-size: inherit;
   color: white;
   background-color: blue;
@@ -44,7 +47,8 @@ exports[`component.UI.ActionBar should render correctly 1`] = `
   text-decoration: none;
   font-weight: bold;
   border: 0;
-  border-radius: 0px;
+  border-radius: 0;
+  border-radius: 0;
   -webkit-transition: all 0.25s;
   transition: all 0.25s;
   outline: none;
@@ -63,12 +67,13 @@ exports[`component.UI.ActionBar should render correctly 1`] = `
 }
 
 .c3 {
-  margin: 0px;
-  margin-right: 0px;
-  padding-left: 64px;
-  padding-right: 64px;
+  box-sizing: border-box;
+  margin: 0;
+  margin-right: 0;
   padding-top: 16px;
   padding-bottom: 16px;
+  padding-left: 64px;
+  padding-right: 64px;
   font-size: inherit;
   color: white;
   background-color: blue;
@@ -82,6 +87,7 @@ exports[`component.UI.ActionBar should render correctly 1`] = `
   text-decoration: none;
   font-weight: bold;
   border: 0;
+  border-radius: 5px;
   border-radius: 5px;
   -webkit-transition: all 0.25s;
   transition: all 0.25s;

--- a/test/unit/components/UI/__snapshots__/BackgroundDark.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/BackgroundDark.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`component.UI.BackgroundPrimary should render correctly 1`] = `
 .c0 {
+  box-sizing: border-box;
   color: primaryText;
   background-color: primaryColor;
   display: -webkit-box;

--- a/test/unit/components/UI/__snapshots__/BackgroundLight.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/BackgroundLight.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`component.UI.BackgroundTertiary should render correctly 1`] = `
 .c0 {
+  box-sizing: border-box;
   color: primaryText;
   background-color: tertiaryColor;
 }

--- a/test/unit/components/UI/__snapshots__/BackgroundLightest.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/BackgroundLightest.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`component.UI.BackgroundSecondary should render correctly 1`] = `
 .c0 {
+  box-sizing: border-box;
   color: primaryText;
   background-color: secondaryColor;
 }

--- a/test/unit/components/UI/__snapshots__/BackgroundPrimary.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/BackgroundPrimary.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`component.UI.BackgroundPrimary should render correctly 1`] = `
 .c0 {
+  box-sizing: border-box;
   color: primaryText;
   background-color: primaryColor;
   display: -webkit-box;

--- a/test/unit/components/UI/__snapshots__/Button.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Button.spec.js.snap
@@ -2,16 +2,18 @@
 
 exports[`component.UI.Button should render correctly 1`] = `
 .c1 {
+  box-sizing: border-box;
   font-family: sans;
   font-weight: normal;
 }
 
 .c0 {
-  margin: 0px;
-  padding-left: 64px;
-  padding-right: 64px;
+  box-sizing: border-box;
+  margin: 0;
   padding-top: 16px;
   padding-bottom: 16px;
+  padding-left: 64px;
+  padding-right: 64px;
   font-size: inherit;
   color: white;
   background-color: blue;
@@ -25,6 +27,7 @@ exports[`component.UI.Button should render correctly 1`] = `
   text-decoration: none;
   font-weight: bold;
   border: 0;
+  border-radius: 5px;
   border-radius: 5px;
   -webkit-transition: all 0.25s;
   transition: all 0.25s;

--- a/test/unit/components/UI/__snapshots__/Checkbox.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Checkbox.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`component.UI.Checkbox should render correctly 1`] = `
 .c4 {
+  box-sizing: border-box;
   margin-left: 8px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -17,12 +18,14 @@ exports[`component.UI.Checkbox should render correctly 1`] = `
 }
 
 .c5 {
+  box-sizing: border-box;
   font-size: 13px;
   color: #ffffff;
   line-height: 1.4;
 }
 
 .c6 {
+  box-sizing: border-box;
   margin-top: 8px;
   font-size: 13px;
   color: #959595;
@@ -30,6 +33,7 @@ exports[`component.UI.Checkbox should render correctly 1`] = `
 }
 
 .c3 {
+  box-sizing: border-box;
   width: 18px;
   color: #242633;
   display: -webkit-box;
@@ -51,6 +55,7 @@ exports[`component.UI.Checkbox should render correctly 1`] = `
 }
 
 .c0 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/test/unit/components/UI/__snapshots__/Dropdown.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Dropdown.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`component.Dropdown should render correctly 1`] = `
 .c2 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -13,6 +14,7 @@ exports[`component.Dropdown should render correctly 1`] = `
 }
 
 .c4 {
+  box-sizing: border-box;
   color: gray;
   display: -webkit-box;
   display: -webkit-flex;
@@ -21,6 +23,7 @@ exports[`component.Dropdown should render correctly 1`] = `
 }
 
 .c3 {
+  box-sizing: border-box;
   margin-right: 4px;
   font-size: m;
   color: primaryText;
@@ -29,6 +32,7 @@ exports[`component.Dropdown should render correctly 1`] = `
 }
 
 .c0 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -42,8 +46,9 @@ exports[`component.Dropdown should render correctly 1`] = `
 }
 
 .c1 {
-  margin: 0px;
-  padding: 0px;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
   font-size: m;
   -webkit-appearance: none;
   -moz-appearance: none;

--- a/test/unit/components/UI/__snapshots__/Header.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Header.spec.js.snap
@@ -17,11 +17,6 @@ exports[`component.UI.Header should render correctly with logo 1`] = `
   justifyContent="center"
 >
   <Text
-    css={
-      Object {
-        "height": "50px",
-      }
-    }
     fontSize="50px"
     lineHeight="1"
     textAlign="center"
@@ -70,11 +65,6 @@ exports[`component.UI.Header should render correctly with title, subtitle, and l
   justifyContent="center"
 >
   <Text
-    css={
-      Object {
-        "height": "50px",
-      }
-    }
     fontSize="50px"
     lineHeight="1"
     textAlign="center"

--- a/test/unit/components/UI/__snapshots__/Heading.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Heading.spec.js.snap
@@ -2,7 +2,8 @@
 
 exports[`component.UI.Heading should render correctly 1`] = `
 .c0 {
-  margin: 0px;
+  box-sizing: border-box;
+  margin: 0;
   font-size: xl;
   color: primaryText;
   font-weight: light;

--- a/test/unit/components/UI/__snapshots__/Input.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Input.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`component.UI.Input should render correctly 1`] = `
 .c0 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12,6 +13,7 @@ exports[`component.UI.Input should render correctly 1`] = `
 }
 
 .c1 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/test/unit/components/UI/__snapshots__/LightningInvoiceInput.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/LightningInvoiceInput.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`component.UI.LightningInvoiceInput should render correctly 1`] = `
 .c0 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/test/unit/components/UI/__snapshots__/Link.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Link.spec.js.snap
@@ -2,18 +2,13 @@
 
 exports[`component.UI.Link should render correctly 1`] = `
 .c0 {
-  font-size: m;
-  color: primaryText;
   cursor: pointer;
   -webkit-text-decoration: underline;
   text-decoration: underline;
-  line-height: normal;
 }
 
 <a
   className="c0"
-  color="primaryText"
-  fontSize="m"
 >
   Link text
 </a>

--- a/test/unit/components/UI/__snapshots__/MainContent.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/MainContent.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`component.UI.MainContent should render correctly 1`] = `
 .c0 {
+  box-sizing: border-box;
   width: 100%;
   height: 100%;
   overflow-y: overlay;

--- a/test/unit/components/UI/__snapshots__/Message.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Message.spec.js.snap
@@ -9,11 +9,6 @@ exports[`component.UI.Message should render correctly with default props 1`] = `
     alignItems="flex-start"
   >
     <styled.div
-      css={
-        Object {
-          "height": "14px",
-        }
-      }
       mr={1}
       width="14px"
     />

--- a/test/unit/components/UI/__snapshots__/Modal.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Modal.spec.js.snap
@@ -1,20 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`component.UI.Modal should render correctly 1`] = `
-.c0 {
-  color: primaryText;
-  background-color: primaryColor;
-  height: 100%;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
 .c3 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -25,22 +13,8 @@ exports[`component.UI.Modal should render correctly 1`] = `
   justify-content: flex-end;
 }
 
-.c5 {
-  color: primaryText;
-  background-color: primaryColor;
-  position: relative;
-  height: 100%;
-  overflow: hidden;
-  min-width: 900px;
-  min-height: 425px;
-  box-shadow: 0 20px 70px rgba(0,0,0,0.55);
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
 .c4 {
+  box-sizing: border-box;
   padding: 8px;
   height: 40px;
   cursor: pointer;
@@ -51,7 +25,24 @@ exports[`component.UI.Modal should render correctly 1`] = `
   opacity: 1;
 }
 
+.c5 {
+  box-sizing: border-box;
+  color: primaryText;
+  background-color: primaryColor;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  height: 100%;
+  overflow: hidden;
+  min-width: 900px;
+  min-height: 425px;
+  box-shadow: 0 20px 70px rgba(0,0,0,0.55);
+}
+
 .c1 {
+  box-sizing: border-box;
   padding-top: 16px;
   padding-left: 16px;
   padding-right: 16px;
@@ -71,13 +62,22 @@ exports[`component.UI.Modal should render correctly 1`] = `
   pointer-events: none;
 }
 
+.c0 {
+  box-sizing: border-box;
+  color: primaryText;
+  background-color: primaryColor;
+  height: 100%;
+  width: 100%;
+}
+
 .c2 {
+  box-sizing: border-box;
   color: primaryText;
   pointer-events: auto;
   display: inline-block;
 }
 
-<article
+<div
   className="c0"
   color="primaryText"
 >
@@ -123,5 +123,5 @@ exports[`component.UI.Modal should render correctly 1`] = `
     className="c5"
     color="primaryText"
   />
-</article>
+</div>
 `;

--- a/test/unit/components/UI/__snapshots__/NodePubkeyInput.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/NodePubkeyInput.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`component.UI.NodePubkeyInput should render correctly 1`] = `
 .c0 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12,6 +13,7 @@ exports[`component.UI.NodePubkeyInput should render correctly 1`] = `
 }
 
 .c1 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/test/unit/components/UI/__snapshots__/Notification.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Notification.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`component.UI.Notification should render correctly 1`] = `
 .c1 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -13,6 +14,7 @@ exports[`component.UI.Notification should render correctly 1`] = `
 }
 
 .c2 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -24,27 +26,32 @@ exports[`component.UI.Notification should render correctly 1`] = `
 }
 
 .c3 {
+  box-sizing: border-box;
   font-size: xl;
 }
 
 .c4 {
+  box-sizing: border-box;
   margin-left: 8px;
   font-weight: normal;
 }
 
 .c5 {
+  box-sizing: border-box;
   margin-top: 4px;
   font-size: xs;
 }
 
 .c0 {
-  padding-left: 16px;
-  padding-right: 16px;
+  box-sizing: border-box;
   padding-top: 16px;
   padding-bottom: 16px;
-  cursor: pointer;
+  padding-left: 16px;
+  padding-right: 16px;
+  border-radius: 5px;
   border-radius: 5px;
   box-shadow: 0 3px 4px 0 rgba(30,30,30,0.5);
+  cursor: pointer;
 }
 
 <div

--- a/test/unit/components/UI/__snapshots__/Page.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Page.spec.js.snap
@@ -2,18 +2,19 @@
 
 exports[`component.UI.Page should render correctly 1`] = `
 .c0 {
+  box-sizing: border-box;
   color: primaryText;
   background-color: primaryColor;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   position: relative;
   height: 100%;
   overflow: hidden;
   min-width: 900px;
   min-height: 425px;
   box-shadow: 0 20px 70px rgba(0,0,0,0.55);
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 <article

--- a/test/unit/components/UI/__snapshots__/Panel.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Panel.spec.js.snap
@@ -2,17 +2,23 @@
 
 exports[`component.UI.Panel should render correctly 1`] = `
 .c1 {
+  box-sizing: border-box;
+}
+
+.c3 {
+  box-sizing: border-box;
+  padding-top: auto;
+}
+
+.c2 {
+  box-sizing: border-box;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
 }
 
-.c2 {
-  padding-top: auto;
-}
-
 .c0 {
-  height: 100%;
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -20,23 +26,24 @@ exports[`component.UI.Panel should render correctly 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  height: 100%;
 }
 
 <article
   className="c0"
 >
   <header
-    className=""
+    className="c1"
   >
     Header here
   </header>
   <section
-    className="c1"
+    className="c2"
   >
     Body here
   </section>
   <footer
-    className="c2"
+    className="c3"
   >
     Footer here
   </footer>

--- a/test/unit/components/UI/__snapshots__/QRCode.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/QRCode.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`component.UI.QRCode should render correctly 1`] = `
 .c0 {
+  box-sizing: border-box;
   position: relative;
   width: 180px;
   height: 180px;
@@ -9,13 +10,17 @@ exports[`component.UI.QRCode should render correctly 1`] = `
 }
 
 .c1 {
+  box-sizing: border-box;
   position: relative;
   width: 180px;
   height: 180px;
 }
 
 .c2 {
-  border: 1px solid;
+  box-sizing: border-box;
+  border: 1px;
+  border-color: #fd9800;
+  border-radius: 10%;
   border-color: #fd9800;
   border-radius: 10%;
   position: absolute;
@@ -29,7 +34,10 @@ exports[`component.UI.QRCode should render correctly 1`] = `
 }
 
 .c3 {
-  border: 1px solid;
+  box-sizing: border-box;
+  border: 1px;
+  border-color: #fd9800;
+  border-radius: 10%;
   border-color: #fd9800;
   border-radius: 10%;
   position: absolute;
@@ -43,7 +51,10 @@ exports[`component.UI.QRCode should render correctly 1`] = `
 }
 
 .c4 {
-  border: 1px solid;
+  box-sizing: border-box;
+  border: 1px;
+  border-color: #fd9800;
+  border-radius: 10%;
   border-color: #fd9800;
   border-radius: 10%;
   position: absolute;
@@ -57,7 +68,10 @@ exports[`component.UI.QRCode should render correctly 1`] = `
 }
 
 .c5 {
-  border: 1px solid;
+  box-sizing: border-box;
+  border: 1px;
+  border-color: #fd9800;
+  border-radius: 10%;
   border-color: #fd9800;
   border-radius: 10%;
   position: absolute;
@@ -71,6 +85,7 @@ exports[`component.UI.QRCode should render correctly 1`] = `
 }
 
 .c6 {
+  box-sizing: border-box;
   border-style: solid;
   border-color: white;
   position: absolute;
@@ -83,6 +98,7 @@ exports[`component.UI.QRCode should render correctly 1`] = `
 }
 
 .c8 {
+  box-sizing: border-box;
   background-color: white;
   border-style: solid;
   border-color: white;

--- a/test/unit/components/UI/__snapshots__/Radio.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Radio.spec.js.snap
@@ -12,16 +12,22 @@ exports[`component.UI.Radio should render correctly 1`] = `
 }
 
 .c2 {
+  box-sizing: border-box;
   font-size: 13px;
   color: #ffffff;
   line-height: 1.4;
 }
 
 .c3 {
+  box-sizing: border-box;
   margin-top: 8px;
   font-size: 13px;
   color: #959595;
   line-height: 1.4;
+}
+
+.c0 {
+  box-sizing: border-box;
 }
 
 .c0 .container {

--- a/test/unit/components/UI/__snapshots__/Select.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Select.spec.js.snap
@@ -1,7 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`component.UI.Toggle should render correctly 1`] = `
+.c4 {
+  box-sizing: border-box;
+}
+
 .c0 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -13,6 +18,7 @@ exports[`component.UI.Toggle should render correctly 1`] = `
 }
 
 .c2 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -47,7 +53,7 @@ exports[`component.UI.Toggle should render correctly 1`] = `
   cursor: pointer;
 }
 
-.c4 {
+.c5 {
   margin-left: -24px;
   width: 8px;
   pointer-events: none;
@@ -112,10 +118,10 @@ exports[`component.UI.Toggle should render correctly 1`] = `
         </div>
       </div>
       <div
-        className=""
+        className="c4"
       >
         <svg
-          className="c4"
+          className="c5"
           height="1em"
           viewBox="6.295 8.295 12 7.41"
           width={8}

--- a/test/unit/components/UI/__snapshots__/Sidebar.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Sidebar.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`component.UI.Sidebar should render correctly 1`] = `
 .c0 {
+  box-sizing: border-box;
   width: 25%;
   color: primaryText;
   background-color: primaryColor;

--- a/test/unit/components/UI/__snapshots__/Spinner.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Spinner.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`component.UI.Spinner should render correctly 1`] = `
 .c0 {
+  box-sizing: border-box;
   color: lightningOrange;
 }
 

--- a/test/unit/components/UI/__snapshots__/Text.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Text.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`component.UI.Text should render correctly 1`] = `
 .c0 {
+  box-sizing: border-box;
   font-size: m;
   color: primaryText;
   line-height: normal;

--- a/test/unit/components/UI/__snapshots__/TextArea.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/TextArea.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`component.UI.Input should render correctly 1`] = `
 .c0 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12,6 +13,7 @@ exports[`component.UI.Input should render correctly 1`] = `
 }
 
 .c1 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/test/unit/components/UI/__snapshots__/Toggle.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Toggle.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`component.UI.Toggle should render correctly 1`] = `
 .c1 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/yarn.lock
+++ b/yarn.lock
@@ -13756,12 +13756,12 @@ realpath-native@^1.1.0:
   dependencies:
     util.promisify "^1.0.0"
 
-rebass@3.0.0-9:
-  version "3.0.0-9"
-  resolved "https://registry.yarnpkg.com/rebass/-/rebass-3.0.0-9.tgz#86da0b51c4c509270a57746464a4aac0c5a168ac"
-  integrity sha512-nvcCWdq1XbVtvbVBUbKYqh+Y4pnJ9pA4Kvt21/cQdsqmfobkWigfmHFGLE9xnuC+zxkezRDGA+KbSV34Pk3kVw==
+rebass@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/rebass/-/rebass-3.1.1.tgz#b318d2f4ed1bb35532392a97e0984474f160122a"
+  integrity sha512-c/mFtt5luxoVHwsRSx5sD27DzLoEIO1gQKSal1RPsj+cf4jfkei3l00eULTm2HA0er0r8fRNZJKTE8AJVc+GRQ==
   dependencies:
-    styled-system "^3.1.4"
+    styled-system "^4.0.8"
 
 recast@^0.14.7:
   version "0.14.7"
@@ -15328,13 +15328,21 @@ styled-reset@2.0.14:
     opencollective "^1.0.3"
     opencollective-postinstall "2.0.2"
 
-styled-system@^3.0.1, styled-system@^3.1.4:
+styled-system@^3.0.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/styled-system/-/styled-system-3.2.1.tgz#491e1e6f88d7ee021f6f49376f12852cde8007cb"
   integrity sha512-ag0Yp7UeVHHc3t+1uM3jvlljaZYzwqpbJ8hMrFvpaKfUd8xsB9JeQXLwMpEsz8iLx8Lz/+9j0coWFZjmw8MogQ==
   dependencies:
     "@babel/runtime" "^7.1.2"
     prop-types "^15.6.2"
+
+styled-system@^4.0.8:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/styled-system/-/styled-system-4.2.4.tgz#8909f91396c30b92295b4eddec5f7b89f8c8d767"
+  integrity sha512-44X7n09gDvwx7yjquEXsjiNALK0dxGgAJdpO5cb/PdL+D4mhSLKWig4/EhH4vHJLbwu/kumURHyvKxygaBfg0A==
+  dependencies:
+    "@babel/runtime" "^7.4.2"
+    prop-types "^15.7.2"
 
 stylelint-config-recommended@2.2.0:
   version "2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3487,15 +3487,7 @@ babel-plugin-react-intl@^3.0.1:
     intl-messageformat-parser "^1.2.0"
     mkdirp "^0.5.1"
 
-babel-plugin-styled-components@1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.8.0.tgz#9dd054c8e86825203449a852a5746f29f2dab857"
-  integrity sha512-PcrdbXFO/9Plo9JURIj8G0Dsz+Ct8r+NvjoLh6qPt8Y/3EIAj1gHGW1ocPY1IkQbXZLBEZZSRBAxJem1KFdBXg==
-  dependencies:
-    "@babel/helper-annotate-as-pure" "^7.0.0"
-    lodash "^4.17.10"
-
-"babel-plugin-styled-components@>= 1":
+babel-plugin-styled-components@1.10.0, "babel-plugin-styled-components@>= 1":
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.0.tgz#ff1f42ad2cc78c21f26b62266b8f564dbc862939"
   integrity sha512-sQVKG8irFXx14ZfaK1bBePirfkacl3j8nZwSZK+ZjsbnadRHKQTbhXbe/RB1vT6Vgkz45E+V95LBq4KqdhZUNw==


### PR DESCRIPTION
## Description:

Update rebass and babel-plugin-styled-components.

Convert all old style rebass css props to native styled-components css props.

NOTE: There is further optimisation that could be done such as converting some of the common css props to styled-system props, other native props, or extracting into standalone styled components, but that's outside of the scope of this PR where the main goal is just to get onto the current version of rebass.

## Motivation and Context:

Closes https://github.com/LN-Zap/zap-desktop/pull/982
Closes https://github.com/LN-Zap/zap-desktop/pull/2266

## How Has This Been Tested?

Manually

## Types of changes:

Refactor

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
