### PR TITLE
feat(ui): make wallet connection indicator more informative

### DIFF
--- a/renderer/components/Settings/SettingsMenu/SettingsMenu.js
+++ b/renderer/components/Settings/SettingsMenu/SettingsMenu.js
@@ -55,6 +55,7 @@ const SettingsMenu = ({
   fiatProps,
   activeWalletSettings,
   openModal,
+  isWalletReady,
   history,
   ...rest
 }) => {
@@ -99,7 +100,7 @@ const SettingsMenu = ({
   return (
     <Dropmenu items={items} justify="right" {...rest}>
       <Flex alignItems="center">
-        <StatusIndicator mr={2} variant="online" />
+        <StatusIndicator mr={2} variant={isWalletReady ? 'online' : 'loading'} />
         <WalletName wallet={activeWalletSettings} />
       </Flex>
     </Dropmenu>
@@ -117,6 +118,7 @@ SettingsMenu.propTypes = {
     push: PropTypes.func.isRequired,
   }),
   isSettingsMenuOpen: PropTypes.bool,
+  isWalletReady: PropTypes.bool.isRequired,
   localeProps: PropTypes.object.isRequired,
   openModal: PropTypes.func.isRequired,
   openSettingsMenu: PropTypes.func.isRequired,

--- a/renderer/containers/Settings/SettingsMenu.js
+++ b/renderer/containers/Settings/SettingsMenu.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux'
 import { setLocale } from 'reducers/locale'
 import { setFiatTicker, tickerSelectors } from 'reducers/ticker'
+import { infoSelectors } from 'reducers/info'
 import {
   openSettingsMenu,
   closeSettingsMenu,
@@ -22,6 +23,7 @@ const mapStateToProps = state => ({
   themes: state.theme.themes,
   currentTheme: themeSelectors.currentTheme(state),
   isSettingsMenuOpen: state.settingsmenu.isSettingsMenuOpen,
+  isWalletReady: infoSelectors.isSyncedToChain(state),
 })
 
 const mapDispatchToProps = {
@@ -37,6 +39,7 @@ const mapDispatchToProps = {
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   activeWalletSettings: stateProps.activeWalletSettings,
+  isWalletReady: stateProps.isWalletReady,
   activeSubMenu: stateProps.activeSubMenu,
   isSettingsMenuOpen: stateProps.isSettingsMenuOpen,
   openModal: dispatchProps.openModal,

--- a/renderer/reducers/info.js
+++ b/renderer/reducers/info.js
@@ -50,10 +50,14 @@ export const fetchInfo = () => async dispatch => {
   dispatch(receiveInfo(info))
 }
 
+export function setInfo(data) {
+  return { type: RECEIVE_INFO, data }
+}
+
 // Receive IPC event for info
 export const receiveInfo = data => async (dispatch, getState) => {
   // Save the node info.
-  dispatch({ type: RECEIVE_INFO, data })
+  dispatch(setInfo(data))
 
   const state = getState()
 

--- a/renderer/reducers/info.js
+++ b/renderer/reducers/info.js
@@ -180,6 +180,7 @@ infoSelectors.networksSelector = state => state.info.networks
 infoSelectors.infoLoading = state => state.info.infoLoading
 infoSelectors.infoLoaded = state => state.info.infoLoaded
 infoSelectors.hasSynced = state => state.info.hasSynced
+infoSelectors.isSyncedToChain = state => get(state.info, 'data.synced_to_chain', false)
 
 infoSelectors.nodePub = state => {
   const parseFromDataUri = () => {

--- a/services/grpc/grpc.js
+++ b/services/grpc/grpc.js
@@ -5,6 +5,7 @@ import { status } from '@grpc/grpc-js'
 import LndGrpc from 'lnd-grpc'
 import { grpcLog } from '@zap/utils/log'
 import delay from '@zap/utils/delay'
+import isObject from '@zap/utils/isObject'
 import { forwardAll, unforwardAll } from '@zap/utils/events'
 import lightningMethods from './lightning.methods'
 import lightningSubscriptions from './lightning.subscriptions'
@@ -117,13 +118,34 @@ class ZapGrpc extends EventEmitter {
   }
 
   /**
-   * @param {...string} streams optional list of streams to subscribe to. if omitted, uses all available streams
+   * @param {...string|object} streams optional list of streams to subscribe to. if omitted, uses all available streams
+   * if `stream` is to be called with params array element must be of {name, params} format
    * @streams must be a subset of `this.availableSubscriptions`
    */
   subscribe(...streams) {
+    // some of the streams may have params
+    // create a map <streamName, params> out of them
+    const getSubscriptionParams = streams => {
+      if (!(streams && streams.length)) {
+        return {}
+      }
+      return streams.reduce((acc, next) => {
+        if (isObject(next)) {
+          acc[next.name] = next.params
+        }
+        return acc
+      }, {})
+    }
+    // flattens @streams into an Array<string> of stream names to subscribe to
+    const getSubscriptionsNames = streams =>
+      streams && streams.map(entry => (isObject(entry) ? entry.name : entry))
     // make sure we are subscribing to known streams if a specific list is provided
     const allSubKeys = Object.keys(this.availableSubscriptions)
-    const activeSubKeys = streams && streams.length ? intersection(allSubKeys, streams) : allSubKeys
+
+    const params = getSubscriptionParams(streams)
+    const subNames = getSubscriptionsNames(streams)
+    const activeSubKeys =
+      subNames && subNames.length ? intersection(allSubKeys, subNames) : allSubKeys
 
     if (!activeSubKeys.length) {
       return
@@ -141,7 +163,8 @@ class ZapGrpc extends EventEmitter {
       // Set up the subscription.
       const { serviceName, methodName } = this.availableSubscriptions[key]
       const service = this.services[serviceName]
-      this.activeSubscriptions[key] = service[methodName]()
+      const subscriptionParams = params[key] || {}
+      this.activeSubscriptions[key] = service[methodName](subscriptionParams)
       grpcLog.info(`gRPC subscription "${key}" started.`)
 
       // Setup subscription event forwarders.

--- a/services/grpc/grpc.js
+++ b/services/grpc/grpc.js
@@ -111,7 +111,9 @@ class ZapGrpc extends EventEmitter {
     this.on('subscribeGetInfo.data', async data => {
       const { synced_to_chain } = data
       if (synced_to_chain && !this.activeSubscriptions.channelgraph) {
-        this.unsubscribe('info')
+        // reduce poll interval to once a minute after synced_to_chain is true
+        await this.unsubscribe('info')
+        this.subscribe({ name: 'info', params: { pollInterval: 60000 } })
         this.subscribeChannelGraph()
       }
     })

--- a/services/grpc/lightning.subscriptions.js
+++ b/services/grpc/lightning.subscriptions.js
@@ -120,12 +120,12 @@ function subscribeChannelBackups() {
 /**
  * Virtual getInfo stream
  */
-function subscribeGetInfo() {
+function subscribeGetInfo({ pollInterval = 5000 } = {}) {
   return streamify.call(this, {
     command: methods.getInfo.bind(this),
     dataEventName: 'subscribeGetInfo.data',
     errorEventName: 'subscribeGetInfo.error',
-    pollInterval: 5000,
+    pollInterval,
   })
 }
 

--- a/stories/containers/settingsmenu.stories.js
+++ b/stories/containers/settingsmenu.stories.js
@@ -7,4 +7,6 @@ import { Window } from '../helpers'
 storiesOf('Containers.SettingsMenu', module)
   .addDecorator(story => <Window>{story()}</Window>)
   .addDecorator(story => <Provider story={story()} />)
-  .add('SettingsMenu', () => <SettingsMenu activeWalletSettings={{ id: 1, type: 'local' }} />)
+  .add('SettingsMenu', () => (
+    <SettingsMenu activeWalletSettings={{ id: 1, type: 'local' }} isWalletReady />
+  ))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Use `busy` state of the wallet connectivity indicator if `synced_to_chain` is false to give the user more info on the current state of the wallet. This is especially useful when used with remote nodes. This PR also re-instates `getInfo` polling after initial sync is done, but does it in a less resource-consuming manner by reducing the polling interval
<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually. Connected to a node that was in a process of sync
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/14069193/59186965-ee327300-8b7c-11e9-8eea-40183adc85c1.png)

## Types of changes:
Enhancement
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
