### PR TITLE
fix(ui): empty suggested nodes after logout

### DIFF
--- a/renderer/components/App/App.js
+++ b/renderer/components/App/App.js
@@ -35,6 +35,7 @@ function App({
   fetchTransactions,
   setModals,
   initBackupService,
+  fetchSuggestedNodes,
 }) {
   /**
    * App scheduler / polling service setup. Add new app-wide polls here
@@ -78,12 +79,14 @@ function App({
     fetchPeers()
     // Update autopilot node scores.
     updateAutopilotNodeScores()
+    fetchSuggestedNodes()
     // initialize backup service in forceUseTokens mode to avoid
     // launching it for wallets that don't have backup setup
     initBackupService(undefined, true)
   }, [
     fetchActivityHistory,
     fetchPeers,
+    fetchSuggestedNodes,
     initBackupService,
     setIsWalletOpen,
     updateAutopilotNodeScores,
@@ -113,6 +116,7 @@ function App({
 App.propTypes = {
   fetchActivityHistory: PropTypes.func.isRequired,
   fetchPeers: PropTypes.func.isRequired,
+  fetchSuggestedNodes: PropTypes.func.isRequired,
   fetchTransactions: PropTypes.func.isRequired,
   initBackupService: PropTypes.func.isRequired,
   isAppReady: PropTypes.bool.isRequired,

--- a/renderer/containers/App.js
+++ b/renderer/containers/App.js
@@ -7,6 +7,8 @@ import { fetchTransactions } from 'reducers/transaction'
 import { appSelectors } from 'reducers/app'
 import { initBackupService } from 'reducers/backup'
 import { setModals, modalSelectors } from 'reducers/modal'
+import { fetchSuggestedNodes } from 'reducers/channels'
+
 import App from 'components/App'
 
 const mapStateToProps = state => ({
@@ -23,6 +25,7 @@ const mapDispatchToProps = {
   fetchTransactions,
   setModals,
   initBackupService,
+  fetchSuggestedNodes,
 }
 
 export default connect(

--- a/renderer/containers/Initializer.js
+++ b/renderer/containers/Initializer.js
@@ -8,7 +8,7 @@ import { initNeutrino } from 'reducers/neutrino'
 import { startActiveWallet } from 'reducers/lnd'
 import { initTickers } from 'reducers/ticker'
 import { initAutopay } from 'reducers/autopay'
-import { fetchSuggestedNodes, initChannels } from 'reducers/channels'
+import { initChannels } from 'reducers/channels'
 
 /**
  * Root component that deals with mounting the app and managing top level routing.
@@ -17,7 +17,6 @@ class Initializer extends React.Component {
   static propTypes = {
     activeWallet: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     activeWalletSettings: PropTypes.object,
-    fetchSuggestedNodes: PropTypes.func.isRequired,
     hasWallets: PropTypes.bool,
     initAutopay: PropTypes.func.isRequired,
     initChannels: PropTypes.func.isRequired,
@@ -36,7 +35,6 @@ class Initializer extends React.Component {
    */
   componentDidMount() {
     const {
-      fetchSuggestedNodes,
       initTickers,
       initLocale,
       initCurrency,
@@ -52,7 +50,6 @@ class Initializer extends React.Component {
     initAutopay()
     initWallets()
     initChannels()
-    fetchSuggestedNodes()
   }
 
   /**
@@ -106,7 +103,6 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = {
   startActiveWallet,
-  fetchSuggestedNodes,
   initNeutrino,
   initTickers,
   initCurrency,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Suggested nodes list goes empty after logout because of app state reset. This PR fixes this by re-fetching suggested nodes every time the user logs into a wallet
<!--- Describe your changes in detail -->


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually. Login into a wallet and then logout and then login again
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes:
Bugfix
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
