### PR TITLE
fix(ui): prevent double scrollbars on windows

### DIFF
--- a/renderer/components/UI/GlobalStyle.js
+++ b/renderer/components/UI/GlobalStyle.js
@@ -35,6 +35,7 @@ const GlobalStyle = createGlobalStyle`
   body {
     height: 100%;
     position: relative;
+    overflow: hidden;
     -webkit-font-smoothing: antialiased;
     -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
     font-family: 'Roboto', Arial, Helvetica, sans-serif;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
On windows when resizing Windows to a minimum allowed height double scrollbars sometimes appear.
This PR fixes this issue

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/14069193/59366029-423a8480-8d42-11e9-9818-3bd492e7f447.png)

## Types of changes:
Bugfix
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
