### PR TITLE
[WIP] feat(wallet): add skeleton activity list

### DIFF
--- a/renderer/components/Activity/Activity.js
+++ b/renderer/components/Activity/Activity.js
@@ -7,6 +7,7 @@ import { FormattedDate } from 'react-intl'
 import { Box } from 'rebass'
 import { Bar, Heading, Panel } from 'components/UI'
 import ActivityActions from 'containers/Activity/ActivityActions'
+import ActivityPlaceholderList from 'containers/Activity/ActivityPlaceholderList'
 import ActivityListItem from './ActivityListItem'
 
 const StyledList = styled(List)`
@@ -41,6 +42,10 @@ class Activity extends Component {
 
   renderActivityList = () => {
     let { currentActivity } = this.props
+
+    if (currentActivity.length === 0) {
+      return <ActivityPlaceholderList mt={4} pr={4} />
+    }
 
     const renderRow = ({ index, key, style, parent }) => {
       const item = currentActivity[index]

--- a/renderer/components/Activity/ActivityListItem.js
+++ b/renderer/components/Activity/ActivityListItem.js
@@ -8,6 +8,8 @@ import ChainLink from 'components/Icon/ChainLink'
 import Clock from 'components/Icon/Clock'
 import Zap from 'components/Icon/Zap'
 import { Text } from 'components/UI'
+import ActivityPlaceholderItem from './ActivityPlaceholderItem'
+import ActivityPlaceholderGroup from './ActivityPlaceholderGroup'
 
 const ZapIcon = () => <Zap height="1.6em" width="1.6em" />
 
@@ -15,6 +17,8 @@ const ACTIVITY_ITEM_TYPES = {
   transaction: Transaction,
   invoice: Invoice,
   payment: Payment,
+  placeholderItem: ActivityPlaceholderItem,
+  placeholderGroup: ActivityPlaceholderGroup,
 }
 
 const ActivityIcon = ({ activity }) => {

--- a/renderer/components/Activity/ActivityPlaceholderGroup.js
+++ b/renderer/components/Activity/ActivityPlaceholderGroup.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import { Box } from 'rebass'
+import random from 'lodash/random'
+import styled from 'styled-components'
+import { height } from 'styled-system'
+import { Bar } from 'components/UI'
+
+const StyledBox = styled(Box)(height)
+
+const ActivityPlaceholderGroup = () => {
+  return (
+    <Box alignItems="center" justifyContent="space-between" py={2}>
+      <StyledBox bg="secondaryColor" height={14} mb={1} width={random(50, 60)} />
+      <Bar bg="secondaryColor" variant="thin" />
+    </Box>
+  )
+}
+
+export default React.memo(ActivityPlaceholderGroup)

--- a/renderer/components/Activity/ActivityPlaceholderItem.js
+++ b/renderer/components/Activity/ActivityPlaceholderItem.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import { Box, Flex } from 'rebass'
+import random from 'lodash/random'
+import styled from 'styled-components'
+import { height } from 'styled-system'
+
+const StyledBox = styled(Box)(height)
+
+const ActivityPlaceholderItem = () => {
+  return (
+    <Flex alignItems="center" justifyContent="space-between" py={2}>
+      <Flex alignItems="flex-start" flexDirection="column" width={3 / 4}>
+        <StyledBox bg="secondaryColor" height={14} mb={1} width={random(60, 200)} />
+        <StyledBox bg="secondaryColor" height="8px" mb={1} width={random(40, 60)} />
+      </Flex>
+
+      <Flex alignItems="flex-end" flexDirection="column" width={1 / 4}>
+        <StyledBox bg="secondaryColor" height="14px" mb={1} width={random(50, 80)} />
+        <StyledBox bg="secondaryColor" height="8px" width={random(30, 40)} />
+      </Flex>
+    </Flex>
+  )
+}
+
+export default React.memo(ActivityPlaceholderItem)

--- a/renderer/components/Activity/ActivityPlaceholderList.js
+++ b/renderer/components/Activity/ActivityPlaceholderList.js
@@ -1,0 +1,60 @@
+import React, { useMemo, useState } from 'react'
+import PropTypes from 'prop-types'
+import { Box } from 'rebass'
+import random from 'lodash/random'
+import genId from '@zap/utils/genId'
+import ActivityListItem from './ActivityListItem'
+
+const createItem = type => ({
+  type,
+  id: genId(),
+})
+
+const createItemGroup = limit => {
+  // Create intiial list of items.
+  const items = [
+    createItem('placeholderGroup'),
+    ...Array.from(Array(limit).keys()).map(() => createItem('placeholderItem')),
+  ]
+  // Insert one new group item for every 3 items.
+  if (limit > 2) {
+    items.splice(random(2, limit - 1), 0, createItem('placeholderGroup'))
+  }
+  return items
+}
+
+const numberOfItemsByFilter = {
+  ALL_ACTIVITY: 6,
+  SENT_ACTIVITY: 2,
+  RECEIVED_ACTIVITY: 2,
+  PENDING_ACTIVITY: 1,
+  EXPIRED_ACTIVITY: 3,
+  INTERNAL_ACTIVITY: 1,
+}
+
+const ActivityPlaceholderList = ({ filter, ...rest }) => {
+  // const cache = useRef(cacheBin)
+  const [cache, setCache] = useState({})
+  const items = useMemo(() => {
+    if (cache[filter]) {
+      return cache[filter]
+    }
+    cache[filter] = createItemGroup(numberOfItemsByFilter[filter] || 2)
+    setCache(cache)
+    return cache[filter]
+  }, [cache, filter])
+
+  return (
+    <Box {...rest}>
+      {items.map(activity => (
+        <ActivityListItem key={activity.id} activity={activity} />
+      ))}
+    </Box>
+  )
+}
+
+export default React.memo(ActivityPlaceholderList)
+
+ActivityPlaceholderList.propTypes = {
+  filter: PropTypes.string,
+}

--- a/renderer/containers/Activity/ActivityPlaceholderList.js
+++ b/renderer/containers/Activity/ActivityPlaceholderList.js
@@ -1,0 +1,10 @@
+import { connect } from 'react-redux'
+import { activitySelectors } from 'reducers/activity'
+
+import ActivityPlaceholderList from 'components/Activity/ActivityPlaceholderList'
+
+const mapStateToProps = state => ({
+  filter: activitySelectors.filter(state),
+})
+
+export default connect(mapStateToProps)(ActivityPlaceholderList)


### PR DESCRIPTION
## Description:

Display a skeleton activity list for new/empty wallets

## Motivation and Context:

Fill out the gaping great big hole that users are initially presented with after setting up a new wallet with something a little less intimidating.

NOTE: Builds on https://github.com/LN-Zap/zap-desktop/pull/2416

## How Has This Been Tested?

## Screenshots

![image](https://user-images.githubusercontent.com/200251/59390736-6c0b9f80-8d72-11e9-8434-776cf599517c.png)


## Types of changes:

UI enhancement

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] I have reviewed and updated the documentation accordingly.
- [ ] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [ ] My commits have been squashed into a concise set of changes.
