### PR TITLE
fix(wallet): fetch upto 2500 invoices

### DIFF
--- a/renderer/reducers/invoice.js
+++ b/renderer/reducers/invoice.js
@@ -85,7 +85,7 @@ export function sendInvoice() {
 export const fetchInvoices = () => async dispatch => {
   dispatch(getInvoices())
   const grpc = await grpcService
-  const invoices = await grpc.services.Lightning.listInvoices()
+  const invoices = await grpc.services.Lightning.listInvoices({ num_max_invoices: 2500 })
   dispatch(receiveInvoices(invoices))
 }
 


### PR DESCRIPTION
## Description:

This is another kick the can down the road fix to increase the number of invoices we will fetch until we get round to implementing pagination.

See Ref https://github.com/LN-Zap/zap-desktop/search?q=pagination&type=Issues

In the current release we had already increased to the `1000`. But there is a regression in `next` that resets this back to the default of `100`.

In this PR we bump it to `2500` to buy us some time.

## Motivation and Context:

Some users with large number of invoices have complained about invoices not showing in Zap (eg https://github.com/LN-Zap/zap-desktop/issues/2404)

## How Has This Been Tested?

Manually

## Types of changes:

Fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
