### PR TITLE
build(webpack): ensure NODE_ENV=production for prod build

### DIFF
--- a/webpack/prod/main.config.js
+++ b/webpack/prod/main.config.js
@@ -4,9 +4,8 @@
 
 import path from 'path'
 import merge from 'webpack-merge'
-import { EnvironmentPlugin } from 'webpack'
-import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer'
 import baseConfig, { rootDir } from '../webpack.config.base'
+import plugins from './common/plugins'
 
 const config = merge.smart(baseConfig, {
   name: 'main',
@@ -20,15 +19,7 @@ const config = merge.smart(baseConfig, {
     filename: '[name].js',
     path: path.join(rootDir, 'dist'),
   },
-  plugins: [
-    new EnvironmentPlugin({
-      NODE_ENV: 'development',
-    }),
-    new BundleAnalyzerPlugin({
-      analyzerMode: process.env.OPEN_ANALYZER === 'true' ? 'server' : 'disabled',
-      openAnalyzer: process.env.OPEN_ANALYZER === 'true',
-    }),
-  ],
+  plugins,
   node: {
     __dirname: false,
     __filename: false,


### PR DESCRIPTION
## Description:

Ensure NODE_ENV=production for prod build

## Motivation and Context:

Build made with `yarn package` has dev tools enabled when it should not.

## How Has This Been Tested?

`yarn package`

## Types of changes:

Build fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
