### PR TITLE
fix(wallet): clear lightning link payment request after use

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -99,8 +99,8 @@ const handleBitcoinLink = input => {
  * Handler for lightning: links
  */
 const handleLightningLink = input => {
-  const payReq = input.split(':')[1]
-  zap.sendMessage('lightningPaymentUri', { payReq })
+  const address = input.split(':')[1]
+  zap.sendMessage('lightningPaymentUri', { address })
   mainWindow.show()
 }
 

--- a/renderer/components/App/App.js
+++ b/renderer/components/App/App.js
@@ -27,7 +27,7 @@ const appScheduler = createScheduler()
 function App({
   isAppReady,
   modals,
-  payReq,
+  redirectPayReq,
   updateAutopilotNodeScores,
   fetchActivityHistory,
   setIsWalletOpen,
@@ -97,12 +97,12 @@ function App({
 
   // Open the pay form when a payment link is used.
   useEffect(() => {
-    if (isAppReady && payReq) {
+    if (isAppReady && redirectPayReq) {
       if (!modals.find(m => m.type === 'PAY_FORM')) {
         setModals([{ type: 'PAY_FORM' }])
       }
     }
-  }, [payReq, isAppReady, modals, setModals])
+  }, [redirectPayReq, isAppReady, modals, setModals])
 
   if (!isAppReady) {
     return null
@@ -125,7 +125,7 @@ App.propTypes = {
   initTickers: PropTypes.func.isRequired,
   isAppReady: PropTypes.bool.isRequired,
   modals: PropTypes.array.isRequired,
-  payReq: PropTypes.object,
+  redirectPayReq: PropTypes.object,
   setIsWalletOpen: PropTypes.func.isRequired,
   setModals: PropTypes.func.isRequired,
   updateAutopilotNodeScores: PropTypes.func.isRequired,

--- a/renderer/containers/App.js
+++ b/renderer/containers/App.js
@@ -14,7 +14,7 @@ import App from 'components/App'
 
 const mapStateToProps = state => ({
   isAppReady: appSelectors.isAppReady(state),
-  payReq: state.pay.payReq,
+  redirectPayReq: state.pay.redirectPayReq,
   modals: modalSelectors.getModalState(state),
 })
 

--- a/renderer/containers/Pay.js
+++ b/renderer/containers/Pay.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux'
 import { Pay } from 'components/Pay'
 import { fetchTickers, tickerSelectors } from 'reducers/ticker'
-import { setPayReq, queryFees, queryRoutes } from 'reducers/pay'
+import { setRedirectPayReq, queryFees, queryRoutes } from 'reducers/pay'
 import { balanceSelectors } from 'reducers/balance'
 import { changeFilter } from 'reducers/activity'
 import { sendCoins } from 'reducers/transaction'
@@ -19,7 +19,7 @@ const mapStateToProps = state => ({
   cryptoUnitName: tickerSelectors.cryptoUnitName(state),
   isQueryingFees: state.pay.isQueryingFees,
   lndTargetConfirmations: settingsSelectors.currentConfig(state).lndTargetConfirmations,
-  payReq: state.pay.payReq,
+  redirectPayReq: state.pay.redirectPayReq,
   onchainFees: state.pay.onchainFees,
   routes: state.pay.routes,
   walletBalanceConfirmed: balanceSelectors.walletBalanceConfirmed(state),
@@ -30,7 +30,7 @@ const mapDispatchToProps = {
   closeModal,
   fetchTickers,
   payInvoice,
-  setPayReq,
+  setRedirectPayReq,
   sendCoins,
   queryFees,
   queryRoutes,

--- a/renderer/reducers/pay.js
+++ b/renderer/reducers/pay.js
@@ -14,7 +14,7 @@ export const QUERY_ROUTES = 'QUERY_ROUTES'
 export const QUERY_ROUTES_SUCCESS = 'QUERY_ROUTES_SUCCESS'
 export const QUERY_ROUTES_FAILURE = 'QUERY_ROUTES_FAILURE'
 
-export const SET_PAY_REQ = 'SET_PAY_REQ'
+export const SET_REDIRECT_PAY_REQ = 'SET_REDIRECT_PAY_REQ'
 
 // ------------------------------------
 // Actions
@@ -60,19 +60,19 @@ export const queryRoutesFailure = () => dispatch => {
   dispatch({ type: QUERY_ROUTES_FAILURE })
 }
 
-export function setPayReq(payReq) {
+export function setRedirectPayReq(redirectPayReq) {
   return {
-    type: SET_PAY_REQ,
-    payReq,
+    type: SET_REDIRECT_PAY_REQ,
+    redirectPayReq,
   }
 }
 
 export const bitcoinPaymentUri = (event, { address, options: { amount } }) => dispatch => {
-  dispatch(setPayReq({ address, amount }))
+  dispatch(setRedirectPayReq({ address, amount }))
 }
 
-export const lightningPaymentUri = (event, { payReq: address }) => dispatch => {
-  dispatch(setPayReq({ address }))
+export const lightningPaymentUri = (event, { address }) => dispatch => {
+  dispatch(setRedirectPayReq({ address }))
 }
 
 // ------------------------------------
@@ -117,9 +117,9 @@ const ACTION_HANDLERS = {
     queryRoutesError: error,
     routes: [],
   }),
-  [SET_PAY_REQ]: (state, { payReq }) => ({
+  [SET_REDIRECT_PAY_REQ]: (state, { redirectPayReq }) => ({
     ...state,
-    payReq,
+    redirectPayReq,
   }),
 }
 
@@ -134,10 +134,10 @@ const initialState = {
     medium: null,
     slow: null,
   },
-  payReq: null,
   pubKey: null,
   queryFeesError: null,
   queryRoutesError: null,
+  redirectPayReq: null,
   routes: [],
 }
 


### PR DESCRIPTION
## Description:

Clear lightning link payment request after use

## Motivation and Context:

When a `lightning:` payment link is used we set `payment.payReq` in the state and we use this when the Pay form opens to autofill form. This state data is meant to be temporary and should be cleared after use to prevent the possibility of it being used again since the lightning payment link is a one-time action.

There is a bug caused by this in which the payment modal immediately opens again after closing.

## How Has This Been Tested?

1. Click on a lightning payment link
2. Try to close the Pay modal

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
