### PR TITLE
fix(ui): add top padding to autopay modal

### DIFF
--- a/renderer/containers/ModalStack.js
+++ b/renderer/containers/ModalStack.js
@@ -39,7 +39,7 @@ const ModalContent = ({ type, closeModal }) => {
 
     case 'AUTOPAY':
       return (
-        <Modal onClose={closeModal} p={4}>
+        <Modal onClose={closeModal} pt={4}>
           <Autopay width={1} />
         </Modal>
       )


### PR DESCRIPTION
## Description:

Add top and bottom padding to autopay modal

## Motivation and Context:

This fixes a display issue with the Autopay screen in which the scrollbars were wrongly positioned.

## How Has This Been Tested?

Enable autopay feature and verify page padding looks ok

## Types of changes:

UI Fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
