### PR TITLE
feat(ui): add copy button for channel transactions

### DIFF
--- a/renderer/components/Activity/TransactionModal/TransactionModal.js
+++ b/renderer/components/Activity/TransactionModal/TransactionModal.js
@@ -11,8 +11,8 @@ import {
 } from 'react-intl'
 import { Flex } from 'rebass'
 import blockExplorer from '@zap/utils/blockExplorer'
-import { Bar, CopyButton, DataRow, Header, Link, Panel, Span, Text } from 'components/UI'
-import { CryptoSelector, CryptoValue, FiatSelector, FiatValue } from 'containers/UI'
+import { Bar, DataRow, Header, Link, Panel, Span, Text } from 'components/UI'
+import { CopyButton, CryptoSelector, CryptoValue, FiatSelector, FiatValue } from 'containers/UI'
 import { Truncate } from 'components/Util'
 import Onchain from 'components/Icon/Onchain'
 import Padlock from 'components/Icon/Padlock'
@@ -42,26 +42,6 @@ class TransactionModal extends React.PureComponent {
   showTransaction = hash => {
     const { networkInfo } = this.props
     return networkInfo && blockExplorer.showTransaction(networkInfo, hash)
-  }
-
-  notifyOfCopy = value => {
-    const { intl, showNotification } = this.props
-    showNotification(intl.formatMessage({ ...messages.copied_to_clipbpard }, { value }))
-  }
-
-  notifyOfCopyBlock = () => {
-    const { intl } = this.props
-    this.notifyOfCopy(intl.formatMessage({ ...messages.block_id }))
-  }
-
-  notifyOfCopyAddress = () => {
-    const { intl } = this.props
-    this.notifyOfCopy(intl.formatMessage({ ...messages.address }))
-  }
-
-  notifyOfCopyTransaction = () => {
-    const { intl } = this.props
-    this.notifyOfCopy(intl.formatMessage({ ...messages.tx_hash }))
   }
 
   render() {
@@ -145,9 +125,9 @@ class TransactionModal extends React.PureComponent {
                 right={
                   <Flex>
                     <CopyButton
-                      hint={intl.formatMessage({ ...messages.copy_to_clipboard })}
                       mr={2}
-                      onCopy={this.notifyOfCopyAddress}
+                      name={intl.formatMessage({ ...messages.address })}
+                      size="0.7em"
                       value={destAddress}
                     />
                     <Link
@@ -187,9 +167,9 @@ class TransactionModal extends React.PureComponent {
                 <>
                   <Flex>
                     <CopyButton
-                      hint={intl.formatMessage({ ...messages.copy_to_clipboard })}
                       mr={2}
-                      onCopy={this.notifyOfCopyBlock}
+                      name={intl.formatMessage({ ...messages.block_id })}
+                      size="0.7em"
                       value={item.block_hash}
                     />
                     <Link
@@ -231,9 +211,9 @@ class TransactionModal extends React.PureComponent {
             right={
               <Flex>
                 <CopyButton
-                  hint={intl.formatMessage({ ...messages.copy_to_clipboard })}
                   mr={2}
-                  onCopy={this.notifyOfCopyTransaction}
+                  name={intl.formatMessage({ ...messages.tx_hash })}
+                  size="0.7em"
                   value={item.tx_hash}
                 />
                 <Link

--- a/renderer/components/Activity/TransactionModal/messages.js
+++ b/renderer/components/Activity/TransactionModal/messages.js
@@ -16,6 +16,4 @@ export default defineMessages({
   tx_hash: 'Transaction ID',
   block_id: 'Block ID',
   unconfirmed: 'Unconfirmed',
-  copied_to_clipbpard: '{value} has been copied to your clipboard',
-  copy_to_clipboard: 'Copy to clipboard',
 })

--- a/renderer/components/Channels/ChannelData.js
+++ b/renderer/components/Channels/ChannelData.js
@@ -1,19 +1,19 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { FormattedDate, FormattedTime, FormattedMessage } from 'react-intl'
+import { FormattedDate, FormattedTime, FormattedMessage, injectIntl, intlShape } from 'react-intl'
 import styled from 'styled-components'
 import { opacity } from 'styled-system'
-import { Box as BaseBox } from 'rebass'
+import { Box as BaseBox, Flex } from 'rebass'
 import blockExplorer from '@zap/utils/blockExplorer'
 import { Bar, DataRow, Link, Text } from 'components/UI'
 import { Truncate } from 'components/Util'
-import { CryptoValue } from 'containers/UI'
+import { CopyButton, CryptoValue } from 'containers/UI'
 import { CHANNEL_DATA_VIEW_MODE_BASIC, CHANNEL_DATA_VIEW_MODE_FULL } from './constants'
 import messages from './messages'
 
 const Box = styled(BaseBox)(opacity)
 
-const ChannelData = ({ channel, cryptoUnitName, networkInfo, viewMode, ...rest }) => {
+const ChannelData = ({ channel, cryptoUnitName, intl, networkInfo, viewMode, ...rest }) => {
   const {
     channel_point,
     closing_txid,
@@ -35,11 +35,19 @@ const ChannelData = ({ channel, cryptoUnitName, networkInfo, viewMode, ...rest }
         label: <FormattedMessage {...messages.funding_transaction_id_label} />,
         body: <FormattedMessage {...messages.funding_transaction_id_description} />,
         value: (
-          <Link
-            onClick={() => networkInfo && blockExplorer.showTransaction(networkInfo, fundingTxid)}
-          >
-            <Truncate maxlen={25} text={fundingTxid} />
-          </Link>
+          <Flex>
+            <CopyButton
+              mr={2}
+              name={intl.formatMessage({ ...messages.transaction_id })}
+              size="0.7em"
+              value={fundingTxid}
+            />
+            <Link
+              onClick={() => networkInfo && blockExplorer.showTransaction(networkInfo, fundingTxid)}
+            >
+              <Truncate maxlen={25} text={fundingTxid} />
+            </Link>
+          </Flex>
         ),
       }
     },
@@ -64,11 +72,19 @@ const ChannelData = ({ channel, cryptoUnitName, networkInfo, viewMode, ...rest }
       label: <FormattedMessage {...messages.closing_transaction_id_label} />,
       body: <FormattedMessage {...messages.closing_transaction_id_description} />,
       value: (
-        <Link
-          onClick={() => networkInfo && blockExplorer.showTransaction(networkInfo, closing_txid)}
-        >
-          <Truncate maxlen={25} text={closing_txid} />
-        </Link>
+        <Flex>
+          <CopyButton
+            mr={2}
+            name={intl.formatMessage({ ...messages.transaction_id })}
+            size="0.7em"
+            value={closing_txid}
+          />
+          <Link
+            onClick={() => networkInfo && blockExplorer.showTransaction(networkInfo, closing_txid)}
+          >
+            <Truncate maxlen={25} text={closing_txid} />
+          </Link>
+        </Flex>
       ),
     }),
 
@@ -194,6 +210,7 @@ const ChannelData = ({ channel, cryptoUnitName, networkInfo, viewMode, ...rest }
 ChannelData.propTypes = {
   channel: PropTypes.object.isRequired,
   cryptoUnitName: PropTypes.string.isRequired,
+  intl: intlShape.isRequired,
   networkInfo: PropTypes.shape({
     id: PropTypes.string,
     name: PropTypes.string,
@@ -205,4 +222,4 @@ ChannelData.defaultProps = {
   viewMode: CHANNEL_DATA_VIEW_MODE_BASIC,
 }
 
-export default ChannelData
+export default injectIntl(ChannelData)

--- a/renderer/components/Channels/messages.js
+++ b/renderer/components/Channels/messages.js
@@ -41,6 +41,7 @@ export default defineMessages({
   close_button: 'Close Channel',
   force_close_button: 'Force Close Channel',
   unknown: 'Unknown',
+  transaction_id: 'Transaction ID',
   funding_date_label: 'Channel opening date',
   funding_date_description: 'Channel funding transaction date and time.',
   funding_transaction_id_label: 'Funding Transaction',

--- a/renderer/components/UI/CopyButton.js
+++ b/renderer/components/UI/CopyButton.js
@@ -1,10 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { injectIntl, intlShape } from 'react-intl'
 import copy from 'copy-to-clipboard'
 import Button from 'components/UI/Button'
 import Copy from 'components/Icon/Copy'
+import messages from './messages'
 
-const CopyButton = ({ value, hint, onCopy, p, ...rest }) => {
+const CopyButton = ({ value, hint, intl, onCopy, p, size, ...rest }) => {
   const doCopy = () => {
     copy(value)
     if (onCopy) {
@@ -22,7 +24,7 @@ const CopyButton = ({ value, hint, onCopy, p, ...rest }) => {
   return (
     <Button
       className="hint--left"
-      data-hint={hint}
+      data-hint={hint || intl.formatMessage({ ...messages.copy_to_clipboard })}
       onClick={doCopy}
       px={0}
       py={0}
@@ -31,16 +33,22 @@ const CopyButton = ({ value, hint, onCopy, p, ...rest }) => {
       {...paddingProps}
       {...rest}
     >
-      <Copy />
+      <Copy height={size} width={size} />
     </Button>
   )
 }
 
 CopyButton.propTypes = {
   hint: PropTypes.node,
+  intl: intlShape.isRequired,
   onCopy: PropTypes.func,
   p: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  size: PropTypes.string,
   value: PropTypes.string,
 }
 
-export default CopyButton
+CopyButton.defaultProps = {
+  size: '1em',
+}
+
+export default injectIntl(CopyButton)

--- a/renderer/components/UI/messages.js
+++ b/renderer/components/UI/messages.js
@@ -4,6 +4,7 @@ import { defineMessages } from 'react-intl'
 export default defineMessages({
   amount: 'Amount',
   calculating: 'calculating',
+  copy_to_clipboard: 'Copy to clipboard',
   expires: 'Expires',
   expired: 'Expired',
   fee: 'Fee',

--- a/renderer/containers/UI/CopyButton.js
+++ b/renderer/containers/UI/CopyButton.js
@@ -1,0 +1,41 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { injectIntl, intlShape } from 'react-intl'
+import { connect } from 'react-redux'
+import CopyButton from 'components/UI/CopyButton'
+import { showNotification } from 'reducers/notification'
+import messages from './messages'
+
+const WrappedCopyButton = ({ intl, onCopy, name, showNotification, value, ...rest }) => {
+  const notifyOfCopy = () => {
+    showNotification(intl.formatMessage({ ...messages.copied_to_clipbpard }, { name }))
+  }
+
+  const handleCopy = () => {
+    notifyOfCopy()
+    if (onCopy) {
+      onCopy(value)
+    }
+  }
+
+  return <CopyButton onCopy={handleCopy} value={value} {...rest} />
+}
+
+WrappedCopyButton.propTypes = {
+  intl: intlShape.isRequired,
+  name: PropTypes.string.isRequired,
+  onCopy: PropTypes.func,
+  showNotification: PropTypes.func.isRequired,
+  value: PropTypes.string.isRequired,
+}
+
+const mapDispatchToProps = {
+  showNotification,
+}
+
+const ConnectedCopyButton = connect(
+  null,
+  mapDispatchToProps
+)(WrappedCopyButton)
+
+export default injectIntl(ConnectedCopyButton)

--- a/renderer/containers/UI/index.js
+++ b/renderer/containers/UI/index.js
@@ -1,3 +1,4 @@
+export CopyButton from './CopyButton'
 export CurrencyFieldGroup from './CurrencyFieldGroup'
 export CryptoSelector from './CryptoSelector'
 export CryptoValue from './CryptoValue'

--- a/renderer/containers/UI/messages.js
+++ b/renderer/containers/UI/messages.js
@@ -1,0 +1,5 @@
+import { defineMessages } from 'react-intl'
+
+export default defineMessages({
+  copied_to_clipbpard: '{name} has been copied to your clipboard',
+})

--- a/translations/af-ZA.json
+++ b/translations/af-ZA.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "",
   "components.Activity.TransactionModal.block_height": "",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "",
   "components.Channels.total_sent_description": "",
   "components.Channels.total_sent_label": "",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "",
   "components.Channels.transaction_speed_medium": "",
   "components.Channels.transaction_speed_slow": "",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "",
   "components.UI.amount": "",
   "components.UI.calculating": "",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "",
   "components.UI.expires": "",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "",
   "components.Wallet.request": "",
   "components.Wallet.sending_tx": "",
-  "components.Wallet.transaction_success": ""
+  "components.Wallet.transaction_success": "",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/ar-SA.json
+++ b/translations/ar-SA.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "",
   "components.Activity.TransactionModal.block_height": "",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "",
   "components.Channels.total_sent_description": "",
   "components.Channels.total_sent_label": "",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "",
   "components.Channels.transaction_speed_medium": "",
   "components.Channels.transaction_speed_slow": "",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "",
   "components.UI.amount": "",
   "components.UI.calculating": "",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "",
   "components.UI.expires": "",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "",
   "components.Wallet.request": "",
   "components.Wallet.sending_tx": "",
-  "components.Wallet.transaction_success": ""
+  "components.Wallet.transaction_success": "",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/bg-BG.json
+++ b/translations/bg-BG.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "",
   "components.Activity.TransactionModal.block_height": "",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "Такса",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "",
   "components.Channels.total_sent_description": "",
   "components.Channels.total_sent_label": "",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "",
   "components.Channels.transaction_speed_medium": "",
   "components.Channels.transaction_speed_slow": "",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "Изчакване за връзки…",
   "components.UI.amount": "",
   "components.UI.calculating": "",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "",
   "components.UI.expires": "",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "Успешно изпратено плащане",
   "components.Wallet.request": "Заяви",
   "components.Wallet.sending_tx": "Изпращане на вашата транзакция…",
-  "components.Wallet.transaction_success": "Успешно изпратена транзакция"
+  "components.Wallet.transaction_success": "Успешно изпратена транзакция",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/ca-ES.json
+++ b/translations/ca-ES.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "",
   "components.Activity.TransactionModal.block_height": "",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "",
   "components.Channels.total_sent_description": "",
   "components.Channels.total_sent_label": "",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "",
   "components.Channels.transaction_speed_medium": "",
   "components.Channels.transaction_speed_slow": "",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "",
   "components.UI.amount": "",
   "components.UI.calculating": "",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "",
   "components.UI.expires": "",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "",
   "components.Wallet.request": "",
   "components.Wallet.sending_tx": "",
-  "components.Wallet.transaction_success": ""
+  "components.Wallet.transaction_success": "",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/cs-CZ.json
+++ b/translations/cs-CZ.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "",
   "components.Activity.TransactionModal.block_height": "",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "Poplatek",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "",
   "components.Channels.total_sent_description": "",
   "components.Channels.total_sent_label": "",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "",
   "components.Channels.transaction_speed_medium": "",
   "components.Channels.transaction_speed_slow": "",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "Čekání na peery…",
   "components.UI.amount": "",
   "components.UI.calculating": "",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "",
   "components.UI.expires": "",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "Platba úspěšně odeslána",
   "components.Wallet.request": "Vyžádat",
   "components.Wallet.sending_tx": "Probíhá odesílání vaší transakce…",
-  "components.Wallet.transaction_success": "Transakce úspěšně odeslána"
+  "components.Wallet.transaction_success": "Transakce úspěšně odeslána",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/da-DK.json
+++ b/translations/da-DK.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "Beløb",
   "components.Activity.TransactionModal.block_height": "Bekræftet i blok {height}",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "Nuværende værdi",
   "components.Activity.TransactionModal.date_confirmed": "Bekræftelses dato",
   "components.Activity.TransactionModal.fee": "Gebyr",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "",
   "components.Channels.total_sent_description": "",
   "components.Channels.total_sent_label": "",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "",
   "components.Channels.transaction_speed_medium": "",
   "components.Channels.transaction_speed_slow": "",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "Venter på peers…",
   "components.UI.amount": "Beløb",
   "components.UI.calculating": "",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "Udløbet",
   "components.UI.expires": "Udløber",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "Succesfuldt sendt betaling",
   "components.Wallet.request": "Anmodning",
   "components.Wallet.sending_tx": "Sender din betaling…",
-  "components.Wallet.transaction_success": "Succesfuldt sendt transaktion"
+  "components.Wallet.transaction_success": "Succesfuldt sendt transaktion",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/de-DE.json
+++ b/translations/de-DE.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "Betrag",
   "components.Activity.TransactionModal.block_height": "Im Block {height} bestätigt",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "Aktueller Wert",
   "components.Activity.TransactionModal.date_confirmed": "Bestätigungsdatum",
   "components.Activity.TransactionModal.fee": "Gebühr",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "Insgesamt erhaltenes Geld",
   "components.Channels.total_sent_description": "Der Gesamtwert, den Sie innerhalb dieses Kanals gesendet haben.",
   "components.Channels.total_sent_label": "Insgesamt gesendetes Geld",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "Schnell",
   "components.Channels.transaction_speed_medium": "Mittel",
   "components.Channels.transaction_speed_slow": "Langsam",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "Warte auf Verbindungen…",
   "components.UI.amount": "Betrag",
   "components.UI.calculating": "berechne",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "Abgelaufen",
   "components.UI.expires": "Endet",
   "components.UI.fee": "Gebühr",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "Zahlung erfolgreich gesendet",
   "components.Wallet.request": "Anfrage",
   "components.Wallet.sending_tx": "Sende deine Transaktion…",
-  "components.Wallet.transaction_success": "Transaktion erfolgreich gesendet"
+  "components.Wallet.transaction_success": "Transaktion erfolgreich gesendet",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/el-GR.json
+++ b/translations/el-GR.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "",
   "components.Activity.TransactionModal.block_height": "",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "Αμοιβή",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "",
   "components.Channels.total_sent_description": "",
   "components.Channels.total_sent_label": "",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "",
   "components.Channels.transaction_speed_medium": "",
   "components.Channels.transaction_speed_slow": "",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "Αναμονή για συνομηλίκους…",
   "components.UI.amount": "",
   "components.UI.calculating": "",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "",
   "components.UI.expires": "",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "Η πληρωμή έγινε με επιτυχία",
   "components.Wallet.request": "Αίτηση πληρωμής",
   "components.Wallet.sending_tx": "Αποστολή της συναλλαγής σας…",
-  "components.Wallet.transaction_success": "Η συναλλαγή στάλθηκε με επιτυχία"
+  "components.Wallet.transaction_success": "Η συναλλαγή στάλθηκε με επιτυχία",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "Amount",
   "components.Activity.TransactionModal.block_height": "Confirmed in block {height}",
   "components.Activity.TransactionModal.block_id": "Block ID",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "{value} has been copied to your clipboard",
-  "components.Activity.TransactionModal.copy_to_clipboard": "Copy to clipboard",
   "components.Activity.TransactionModal.current_value": "Current value",
   "components.Activity.TransactionModal.date_confirmed": "Date of confirmation",
   "components.Activity.TransactionModal.fee": "Total fee",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "Total Money Received",
   "components.Channels.total_sent_description": "The total value you've sent within this channel.",
   "components.Channels.total_sent_label": "Total Money Sent",
+  "components.Channels.transaction_id": "Transaction ID",
   "components.Channels.transaction_speed_fast": "Fast",
   "components.Channels.transaction_speed_medium": "Medium",
   "components.Channels.transaction_speed_slow": "Slow",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "Waiting for peers…",
   "components.UI.amount": "Amount",
   "components.UI.calculating": "calculating",
+  "components.UI.copy_to_clipboard": "Copy to clipboard",
   "components.UI.expired": "Expired",
   "components.UI.expires": "Expires",
   "components.UI.fee": "Fee",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "Successfully sent payment",
   "components.Wallet.request": "Request",
   "components.Wallet.sending_tx": "Sending your transaction…",
-  "components.Wallet.transaction_success": "Successfully sent transaction"
+  "components.Wallet.transaction_success": "Successfully sent transaction",
+  "containers.UI.copied_to_clipbpard": "{name} has been copied to your clipboard"
 }

--- a/translations/es-ES.json
+++ b/translations/es-ES.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "Cantidad",
   "components.Activity.TransactionModal.block_height": "Confirmado en bloque {height}",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "Valor actual",
   "components.Activity.TransactionModal.date_confirmed": "Fecha de confirmación",
   "components.Activity.TransactionModal.fee": "Comisión",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "Monto recibido",
   "components.Channels.total_sent_description": "El monto total que has enviado en este canal.",
   "components.Channels.total_sent_label": "Monto total enviado",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "Rápido",
   "components.Channels.transaction_speed_medium": "Mediano",
   "components.Channels.transaction_speed_slow": "Lento",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "Esperando por los pares…",
   "components.UI.amount": "Monto",
   "components.UI.calculating": "calculando",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "Expirado",
   "components.UI.expires": "Expira",
   "components.UI.fee": "Tarifa",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "Pago enviado correctamente",
   "components.Wallet.request": "Solicitar",
   "components.Wallet.sending_tx": "Enviando tu transacción…",
-  "components.Wallet.transaction_success": "Transacción enviada correctamente"
+  "components.Wallet.transaction_success": "Transacción enviada correctamente",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/fi-FI.json
+++ b/translations/fi-FI.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "",
   "components.Activity.TransactionModal.block_height": "",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "",
   "components.Channels.total_sent_description": "",
   "components.Channels.total_sent_label": "",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "",
   "components.Channels.transaction_speed_medium": "",
   "components.Channels.transaction_speed_slow": "",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "",
   "components.UI.amount": "",
   "components.UI.calculating": "",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "",
   "components.UI.expires": "",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "",
   "components.Wallet.request": "",
   "components.Wallet.sending_tx": "",
-  "components.Wallet.transaction_success": ""
+  "components.Wallet.transaction_success": "",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/fr-FR.json
+++ b/translations/fr-FR.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "Montant",
   "components.Activity.TransactionModal.block_height": "Confirmée dans le bloc {height}",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "Valeur courante",
   "components.Activity.TransactionModal.date_confirmed": "Date de la confirmation",
   "components.Activity.TransactionModal.fee": "Frais totaux",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "Montant reçu au total",
   "components.Channels.total_sent_description": "La valeur totale que vous avez envoyé dance ce canal.",
   "components.Channels.total_sent_label": "Montant envoyé au total",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "Rapide",
   "components.Channels.transaction_speed_medium": "Moyenne",
   "components.Channels.transaction_speed_slow": "Lente",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "En attente de paires…",
   "components.UI.amount": "Montant",
   "components.UI.calculating": "calculation",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "Expiré",
   "components.UI.expires": "Expire",
   "components.UI.fee": "Frais",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "Paiement envoyé avec succès",
   "components.Wallet.request": "Demande",
   "components.Wallet.sending_tx": "Envoi de votre transaction…",
-  "components.Wallet.transaction_success": "Transaction effectuée avec succès"
+  "components.Wallet.transaction_success": "Transaction effectuée avec succès",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/ga-IE.json
+++ b/translations/ga-IE.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "Méid",
   "components.Activity.TransactionModal.block_height": "Deimhnithe i bloc {height}",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "Luach reatha",
   "components.Activity.TransactionModal.date_confirmed": "Dáta an daingnithe",
   "components.Activity.TransactionModal.fee": "Táille",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "",
   "components.Channels.total_sent_description": "",
   "components.Channels.total_sent_label": "",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "",
   "components.Channels.transaction_speed_medium": "",
   "components.Channels.transaction_speed_slow": "",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "Ag fanacht le nasc…",
   "components.UI.amount": "Méid",
   "components.UI.calculating": "",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "Deireadh",
   "components.UI.expires": "Deireadh",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "D'éirigh leis an íocaíocht a sheoladh",
   "components.Wallet.request": "Iarratas",
   "components.Wallet.sending_tx": "Ag seoladh d'idirbhearta…",
-  "components.Wallet.transaction_success": "D'éirigh leis an idirbheart a sheoladh"
+  "components.Wallet.transaction_success": "D'éirigh leis an idirbheart a sheoladh",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/he-IL.json
+++ b/translations/he-IL.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "",
   "components.Activity.TransactionModal.block_height": "",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "עמלה",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "",
   "components.Channels.total_sent_description": "",
   "components.Channels.total_sent_label": "",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "",
   "components.Channels.transaction_speed_medium": "",
   "components.Channels.transaction_speed_slow": "",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "",
   "components.UI.amount": "",
   "components.UI.calculating": "",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "",
   "components.UI.expires": "",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "",
   "components.Wallet.request": "",
   "components.Wallet.sending_tx": "",
-  "components.Wallet.transaction_success": ""
+  "components.Wallet.transaction_success": "",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/hi-IN.json
+++ b/translations/hi-IN.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "",
   "components.Activity.TransactionModal.block_height": "",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "",
   "components.Channels.total_sent_description": "",
   "components.Channels.total_sent_label": "",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "",
   "components.Channels.transaction_speed_medium": "",
   "components.Channels.transaction_speed_slow": "",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "",
   "components.UI.amount": "",
   "components.UI.calculating": "",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "",
   "components.UI.expires": "",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "",
   "components.Wallet.request": "",
   "components.Wallet.sending_tx": "",
-  "components.Wallet.transaction_success": ""
+  "components.Wallet.transaction_success": "",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/hr-HR.json
+++ b/translations/hr-HR.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "Iznos",
   "components.Activity.TransactionModal.block_height": "Potvrđena u bloku {height}",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "Trenutna vrijednost",
   "components.Activity.TransactionModal.date_confirmed": "Datum potvrde",
   "components.Activity.TransactionModal.fee": "Naknada",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "Ukupan novac primljen",
   "components.Channels.total_sent_description": "Ukupna vrijednost koju ste poslali unutar ovog kanala.",
   "components.Channels.total_sent_label": "Ukupno novac poslan",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "Brzo",
   "components.Channels.transaction_speed_medium": "Srednje",
   "components.Channels.transaction_speed_slow": "Sporo",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "Čekanje na kolege...",
   "components.UI.amount": "Iznos",
   "components.UI.calculating": "izračunavanje",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "Isteklo",
   "components.UI.expires": "Ističe",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "Uspješno poslana plaćanja",
   "components.Wallet.request": "Zahtjev",
   "components.Wallet.sending_tx": "Slanje vaše transakcije...",
-  "components.Wallet.transaction_success": "Uspješno poslane transakcije"
+  "components.Wallet.transaction_success": "Uspješno poslane transakcije",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/hu-HU.json
+++ b/translations/hu-HU.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "",
   "components.Activity.TransactionModal.block_height": "",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "",
   "components.Channels.total_sent_description": "",
   "components.Channels.total_sent_label": "",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "",
   "components.Channels.transaction_speed_medium": "",
   "components.Channels.transaction_speed_slow": "",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "",
   "components.UI.amount": "",
   "components.UI.calculating": "",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "",
   "components.UI.expires": "",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "",
   "components.Wallet.request": "",
   "components.Wallet.sending_tx": "",
-  "components.Wallet.transaction_success": ""
+  "components.Wallet.transaction_success": "",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/it-IT.json
+++ b/translations/it-IT.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "Importo",
   "components.Activity.TransactionModal.block_height": "Confermato nel blocco {height}",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "Valore attuale",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "Commissione",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "",
   "components.Channels.total_sent_description": "",
   "components.Channels.total_sent_label": "",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "",
   "components.Channels.transaction_speed_medium": "",
   "components.Channels.transaction_speed_slow": "",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "",
   "components.UI.amount": "",
   "components.UI.calculating": "",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "",
   "components.UI.expires": "",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "",
   "components.Wallet.request": "",
   "components.Wallet.sending_tx": "",
-  "components.Wallet.transaction_success": ""
+  "components.Wallet.transaction_success": "",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/ja-JP.json
+++ b/translations/ja-JP.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "数量",
   "components.Activity.TransactionModal.block_height": "ブロック（高さ）で確認済み",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "現在値",
   "components.Activity.TransactionModal.date_confirmed": "確認の日付",
   "components.Activity.TransactionModal.fee": "フィー",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "",
   "components.Channels.total_sent_description": "",
   "components.Channels.total_sent_label": "",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "",
   "components.Channels.transaction_speed_medium": "",
   "components.Channels.transaction_speed_slow": "",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "仲間を待っています…",
   "components.UI.amount": "",
   "components.UI.calculating": "",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "",
   "components.UI.expires": "",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "正常に支払いを送信",
   "components.Wallet.request": "要求",
   "components.Wallet.sending_tx": "あなたのトランザクションを送信しています…",
-  "components.Wallet.transaction_success": "正常にトランザクションを送信"
+  "components.Wallet.transaction_success": "正常にトランザクションを送信",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/ko-KR.json
+++ b/translations/ko-KR.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "",
   "components.Activity.TransactionModal.block_height": "",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "",
   "components.Channels.total_sent_description": "",
   "components.Channels.total_sent_label": "",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "",
   "components.Channels.transaction_speed_medium": "",
   "components.Channels.transaction_speed_slow": "",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "",
   "components.UI.amount": "",
   "components.UI.calculating": "",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "",
   "components.UI.expires": "",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "",
   "components.Wallet.request": "",
   "components.Wallet.sending_tx": "",
-  "components.Wallet.transaction_success": ""
+  "components.Wallet.transaction_success": "",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/nl-NL.json
+++ b/translations/nl-NL.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "",
   "components.Activity.TransactionModal.block_height": "",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "Vergoeding",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "",
   "components.Channels.total_sent_description": "",
   "components.Channels.total_sent_label": "",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "",
   "components.Channels.transaction_speed_medium": "",
   "components.Channels.transaction_speed_slow": "",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "Wachten op verbindingen…",
   "components.UI.amount": "",
   "components.UI.calculating": "",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "",
   "components.UI.expires": "",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "Betaling verzonden",
   "components.Wallet.request": "Verzoek",
   "components.Wallet.sending_tx": "Bezig met verzenden…",
-  "components.Wallet.transaction_success": "Transactie verzonden"
+  "components.Wallet.transaction_success": "Transactie verzonden",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/no-NO.json
+++ b/translations/no-NO.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "",
   "components.Activity.TransactionModal.block_height": "",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "",
   "components.Channels.total_sent_description": "",
   "components.Channels.total_sent_label": "",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "",
   "components.Channels.transaction_speed_medium": "",
   "components.Channels.transaction_speed_slow": "",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "",
   "components.UI.amount": "",
   "components.UI.calculating": "",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "",
   "components.UI.expires": "",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "",
   "components.Wallet.request": "",
   "components.Wallet.sending_tx": "",
-  "components.Wallet.transaction_success": ""
+  "components.Wallet.transaction_success": "",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/pl-PL.json
+++ b/translations/pl-PL.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "",
   "components.Activity.TransactionModal.block_height": "",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "Fee",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "",
   "components.Channels.total_sent_description": "",
   "components.Channels.total_sent_label": "",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "",
   "components.Channels.transaction_speed_medium": "",
   "components.Channels.transaction_speed_slow": "",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "",
   "components.UI.amount": "",
   "components.UI.calculating": "",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "",
   "components.UI.expires": "",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "",
   "components.Wallet.request": "",
   "components.Wallet.sending_tx": "",
-  "components.Wallet.transaction_success": ""
+  "components.Wallet.transaction_success": "",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/pt-BR.json
+++ b/translations/pt-BR.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "",
   "components.Activity.TransactionModal.block_height": "",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "Taxa",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "",
   "components.Channels.total_sent_description": "",
   "components.Channels.total_sent_label": "",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "",
   "components.Channels.transaction_speed_medium": "",
   "components.Channels.transaction_speed_slow": "",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "Esperando por seus pares…",
   "components.UI.amount": "",
   "components.UI.calculating": "",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "",
   "components.UI.expires": "",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "Pagamento enviado com sucesso",
   "components.Wallet.request": "Solicitar",
   "components.Wallet.sending_tx": "Enviando sua transação…",
-  "components.Wallet.transaction_success": "Transação enviada com sucesso"
+  "components.Wallet.transaction_success": "Transação enviada com sucesso",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/pt-PT.json
+++ b/translations/pt-PT.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "",
   "components.Activity.TransactionModal.block_height": "",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "",
   "components.Channels.total_sent_description": "",
   "components.Channels.total_sent_label": "",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "",
   "components.Channels.transaction_speed_medium": "",
   "components.Channels.transaction_speed_slow": "",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "",
   "components.UI.amount": "",
   "components.UI.calculating": "",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "",
   "components.UI.expires": "",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "",
   "components.Wallet.request": "",
   "components.Wallet.sending_tx": "",
-  "components.Wallet.transaction_success": ""
+  "components.Wallet.transaction_success": "",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/ro-RO.json
+++ b/translations/ro-RO.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "",
   "components.Activity.TransactionModal.block_height": "",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "Taxa",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "",
   "components.Channels.total_sent_description": "",
   "components.Channels.total_sent_label": "",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "",
   "components.Channels.transaction_speed_medium": "",
   "components.Channels.transaction_speed_slow": "",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "Asteptam conexiunea cu peers...",
   "components.UI.amount": "",
   "components.UI.calculating": "",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "",
   "components.UI.expires": "",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "Plata a fost trimisa cu succes",
   "components.Wallet.request": "Cerere",
   "components.Wallet.sending_tx": "Trimitem tranzactia…",
-  "components.Wallet.transaction_success": "Tranzactia a fost trimisa cu succes"
+  "components.Wallet.transaction_success": "Tranzactia a fost trimisa cu succes",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/ru-RU.json
+++ b/translations/ru-RU.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "",
   "components.Activity.TransactionModal.block_height": "",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "Комиссия",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "",
   "components.Channels.total_sent_description": "",
   "components.Channels.total_sent_label": "",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "",
   "components.Channels.transaction_speed_medium": "",
   "components.Channels.transaction_speed_slow": "",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "Ожидание подключений…",
   "components.UI.amount": "",
   "components.UI.calculating": "",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "",
   "components.UI.expires": "",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "Платеж успешно отправлен",
   "components.Wallet.request": "Запрос",
   "components.Wallet.sending_tx": "Отправка вашей транзакции…",
-  "components.Wallet.transaction_success": "Транзакция успешно отправлена"
+  "components.Wallet.transaction_success": "Транзакция успешно отправлена",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/sr-SP.json
+++ b/translations/sr-SP.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "",
   "components.Activity.TransactionModal.block_height": "",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "",
   "components.Channels.total_sent_description": "",
   "components.Channels.total_sent_label": "",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "",
   "components.Channels.transaction_speed_medium": "",
   "components.Channels.transaction_speed_slow": "",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "",
   "components.UI.amount": "",
   "components.UI.calculating": "",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "",
   "components.UI.expires": "",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "",
   "components.Wallet.request": "",
   "components.Wallet.sending_tx": "",
-  "components.Wallet.transaction_success": ""
+  "components.Wallet.transaction_success": "",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/sv-SE.json
+++ b/translations/sv-SE.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "",
   "components.Activity.TransactionModal.block_height": "",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "Avgift",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "",
   "components.Channels.total_sent_description": "",
   "components.Channels.total_sent_label": "",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "",
   "components.Channels.transaction_speed_medium": "",
   "components.Channels.transaction_speed_slow": "",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "Väntar på peers…",
   "components.UI.amount": "",
   "components.UI.calculating": "",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "",
   "components.UI.expires": "",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "Betalning framgångsrikt skickad",
   "components.Wallet.request": "Begäran",
   "components.Wallet.sending_tx": "Skickar din transaktion…",
-  "components.Wallet.transaction_success": "Framgångsrikt skickad transaktion"
+  "components.Wallet.transaction_success": "Framgångsrikt skickad transaktion",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/tr-TR.json
+++ b/translations/tr-TR.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "",
   "components.Activity.TransactionModal.block_height": "",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "Ücret",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "",
   "components.Channels.total_sent_description": "",
   "components.Channels.total_sent_label": "",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "",
   "components.Channels.transaction_speed_medium": "",
   "components.Channels.transaction_speed_slow": "",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "Eş bağlantıları için bekleniyor…",
   "components.UI.amount": "",
   "components.UI.calculating": "",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "",
   "components.UI.expires": "",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "Ödeme başarıyla gönderildi",
   "components.Wallet.request": "İste",
   "components.Wallet.sending_tx": "İşlem gönderiliyor…",
-  "components.Wallet.transaction_success": "İşlem başarıyla gönderildi"
+  "components.Wallet.transaction_success": "İşlem başarıyla gönderildi",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/uk-UA.json
+++ b/translations/uk-UA.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "",
   "components.Activity.TransactionModal.block_height": "",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "Плата",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "",
   "components.Channels.total_sent_description": "",
   "components.Channels.total_sent_label": "",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "",
   "components.Channels.transaction_speed_medium": "",
   "components.Channels.transaction_speed_slow": "",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "Очікуємо підключення…",
   "components.UI.amount": "",
   "components.UI.calculating": "",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "",
   "components.UI.expires": "",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "Оплата успішно відправлена",
   "components.Wallet.request": "Запит",
   "components.Wallet.sending_tx": "Відправка транзакції…",
-  "components.Wallet.transaction_success": "Транзакція успішно відправлена"
+  "components.Wallet.transaction_success": "Транзакція успішно відправлена",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/vi-VN.json
+++ b/translations/vi-VN.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "",
   "components.Activity.TransactionModal.block_height": "",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "",
   "components.Channels.total_sent_description": "",
   "components.Channels.total_sent_label": "",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "",
   "components.Channels.transaction_speed_medium": "",
   "components.Channels.transaction_speed_slow": "",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "",
   "components.UI.amount": "",
   "components.UI.calculating": "",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "",
   "components.UI.expires": "",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "",
   "components.Wallet.request": "",
   "components.Wallet.sending_tx": "",
-  "components.Wallet.transaction_success": ""
+  "components.Wallet.transaction_success": "",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/zh-CN.json
+++ b/translations/zh-CN.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "数量",
   "components.Activity.TransactionModal.block_height": "已在块 {height} 中确认",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "确认日期",
   "components.Activity.TransactionModal.fee": "矿工费",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "",
   "components.Channels.total_sent_description": "",
   "components.Channels.total_sent_label": "",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "",
   "components.Channels.transaction_speed_medium": "",
   "components.Channels.transaction_speed_slow": "",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "等待peer..。",
   "components.UI.amount": "",
   "components.UI.calculating": "",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "",
   "components.UI.expires": "",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "成功发送付款",
   "components.Wallet.request": "请求",
   "components.Wallet.sending_tx": "正在发送您的交易..。",
-  "components.Wallet.transaction_success": "成功发送交易"
+  "components.Wallet.transaction_success": "成功发送交易",
+  "containers.UI.copied_to_clipbpard": ""
 }

--- a/translations/zh-TW.json
+++ b/translations/zh-TW.json
@@ -58,8 +58,6 @@
   "components.Activity.TransactionModal.amount": "",
   "components.Activity.TransactionModal.block_height": "",
   "components.Activity.TransactionModal.block_id": "",
-  "components.Activity.TransactionModal.copied_to_clipbpard": "",
-  "components.Activity.TransactionModal.copy_to_clipboard": "",
   "components.Activity.TransactionModal.current_value": "",
   "components.Activity.TransactionModal.date_confirmed": "",
   "components.Activity.TransactionModal.fee": "矿工费",
@@ -191,6 +189,7 @@
   "components.Channels.total_received_label": "",
   "components.Channels.total_sent_description": "",
   "components.Channels.total_sent_label": "",
+  "components.Channels.transaction_id": "",
   "components.Channels.transaction_speed_fast": "",
   "components.Channels.transaction_speed_medium": "",
   "components.Channels.transaction_speed_slow": "",
@@ -482,6 +481,7 @@
   "components.Syncing.waiting_for_peers": "等待peer..。",
   "components.UI.amount": "",
   "components.UI.calculating": "",
+  "components.UI.copy_to_clipboard": "",
   "components.UI.expired": "",
   "components.UI.expires": "",
   "components.UI.fee": "",
@@ -514,5 +514,6 @@
   "components.Wallet.payment_success": "成功发送付款",
   "components.Wallet.request": "请求",
   "components.Wallet.sending_tx": "正在发送您的交易..。",
-  "components.Wallet.transaction_success": "成功发送交易"
+  "components.Wallet.transaction_success": "成功发送交易",
+  "containers.UI.copied_to_clipbpard": ""
 }


### PR DESCRIPTION
## Description:

Add copy button for channel transactions

## Motivation and Context:

We recently added buttons to allow easy copying of transaction ids into the transaction modal. This 
pr extends that to also add these buttons to the Channel detail view.

It also refactors the related code so as to reduce some code duplication.

## How Has This Been Tested?

Manually

## Types of changes:

Enhancement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
