### PR TITLE
fix(ui): use primary colour for dialog buttons

### DIFF
--- a/renderer/components/UI/CloseButton.js
+++ b/renderer/components/UI/CloseButton.js
@@ -10,8 +10,8 @@ const CloseButtonWrapper = styled(Box)`
   cursor: pointer;
   color: ${themeGet('colors.primaryText')};
   opacity: 0.6;
-  &:hover: {
-    opacity: 1;
+  &:hover {
+    color: ${themeGet('colors.lightningOrange')};
   }
 `
 

--- a/renderer/themes/util.js
+++ b/renderer/themes/util.js
@@ -15,7 +15,7 @@ const createThemeVariant = (name, colors) => {
     },
     primary: {
       backgroundImage: `linear-gradient(to left,
-        ${colors.superBlue}, ${tint(0.2, colors.lightningOrange)})`,
+        ${colors.lightningOrange}, ${tint(0.2, colors.lightningOrange)})`,
       color: colors.white,
     },
     secondary: {

--- a/test/unit/components/UI/__snapshots__/Modal.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Modal.spec.js.snap
@@ -21,10 +21,6 @@ exports[`component.UI.Modal should render correctly 1`] = `
   opacity: 0.6;
 }
 
-.c4:hover: {
-  opacity: 1;
-}
-
 .c5 {
   box-sizing: border-box;
   color: primaryText;


### PR DESCRIPTION
## Description:

- use primary colour for primary button
- use primary colour for close button

## Motivation and Context:

Fix funky looking dialog button (seen when lnd crashes)

## How Has This Been Tested?

Storybook

## Screenshots (if appropriate):

**Before:**

![image](https://user-images.githubusercontent.com/200251/59600472-8a222880-9101-11e9-9f75-3b5419b3de79.png)

**After:**

![image](https://user-images.githubusercontent.com/200251/59600329-2861be80-9101-11e9-9cfa-485b7090769a.png)


## Types of changes:

UI fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
