### PR TITLE
fix(walet): ensure fallback when ticker provider is unavailable

### DIFF
--- a/renderer/components/Settings/SettingsFieldsWallet.js
+++ b/renderer/components/Settings/SettingsFieldsWallet.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import map from 'lodash/map'
 import get from 'lodash/get'
 import { Bar, DataRow, Select } from 'components/UI'
-import { getSupportedProviders } from '@zap/utils/fiat/rateProvider'
+import { getSupportedProviders } from '@zap/utils/rateProvider'
 import { FieldLabel, NumberField } from './SettingsFieldHelpers'
 import messages from './messages'
 

--- a/renderer/reducers/ticker.js
+++ b/renderer/reducers/ticker.js
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect'
 import get from 'lodash/get'
 import { currencies, getDefaultCurrency } from '@zap/i18n'
-import { requestTickerWithFallback } from '@zap/utils/fiat/rateProvider'
+import { requestTickerWithFallback } from '@zap/utils/rateProvider'
 import { infoSelectors } from './info'
 import { putConfig, settingsSelectors } from './settings'
 // ------------------------------------

--- a/test/unit/utils/rateProvider.spec.js
+++ b/test/unit/utils/rateProvider.spec.js
@@ -1,0 +1,35 @@
+/* eslint-disable import/named */
+import { requestTickerWithFallback, requestTicker } from '@zap/utils/rateProvider'
+
+// Mock the requestTicker method so that it:
+// - errros the first time
+// - returns no data the second time
+// - succeeds the third time
+jest.mock('@zap/utils/rateProvider/requestTicker', () =>
+  jest
+    .fn()
+    .mockImplementationOnce(async () => new Error('Some error'))
+    .mockImplementationOnce(async () => ({}))
+    .mockImplementationOnce(async () => ({ USD: [] }))
+)
+
+// Mock `getSupportedProviders.
+jest.mock('@zap/utils/rateProvider/providers', () => ({
+  getSupportedProviders: jest
+    .fn()
+    .mockReturnValue({ coinbase: {}, bitstamp: {}, kraken: {}, bitfinex: {} }),
+}))
+
+describe('requestTickerWithFallback', () => {
+  test(`request tickets from fallback providers`, async () => {
+    const provider = 'coinbase'
+    const coin = 'BTC'
+    const currency = 'USD'
+    await requestTickerWithFallback(provider, coin, currency)
+
+    expect(requestTicker).toHaveBeenCalledTimes(3)
+    expect(requestTicker).toHaveBeenNthCalledWith(1, provider, coin, currency)
+    expect(requestTicker).toHaveBeenNthCalledWith(2, 'bitstamp', coin, currency)
+    expect(requestTicker).toHaveBeenNthCalledWith(3, 'kraken', coin, currency)
+  })
+})

--- a/utils/fiat/rateProvider.js
+++ b/utils/fiat/rateProvider.js
@@ -2,10 +2,10 @@ import axios from 'axios'
 import pickBy from 'lodash/pickBy'
 
 /**
- * coindeskParser - parser CoindDesk ticker data.
+ * coindeskParser - Parses CoindDesk ticker data.
  *
- * @param {*} data
- * @returns
+ * @param {object} data Ticker data
+ * @returns {object} Price data from Coinbase
  */
 function coindeskParser(data) {
   const { bpi } = data
@@ -16,11 +16,11 @@ function coindeskParser(data) {
 }
 
 /**
- * bitstampParser - parser Bitstamp ticker data.
+ * bitstampParser - Parses Bitstamp ticker data.
  *
- * @param {string} currency
- * @param {object} data
- * @returns {object}
+ * @param {string} currency Currency name
+ * @param {object} data Ticker data
+ * @returns {object} Price data from Bitstamp
  */
 function bitstampParser(currency, data) {
   return {
@@ -29,11 +29,11 @@ function bitstampParser(currency, data) {
 }
 
 /**
- * krakenParser - parser Kraken ticker data.
+ * krakenParser - Parses Kraken ticker data.
  *
- * @param {string} currency
- * @param {object} data
- * @returns {object}
+ * @param {string} currency Currency name
+ * @param {object} data Ticker data
+ * @returns {object} Price data from Kraken
  */
 function krakenParser(currency, data) {
   const tickerData = data.data.result
@@ -46,11 +46,11 @@ function krakenParser(currency, data) {
 }
 
 /**
- * bitfinexParser - parser Bitfinex ticker data.
+ * bitfinexParser - Parses Bitfinex ticker data.
  *
- * @param {string} currency
- * @param {object} data
- * @returns {object}
+ * @param {string} currency Currency name
+ * @param {object} data Ticker data
+ * @returns {object} Price data from Bitfinex
  */
 function bitfinexParser(currency, data) {
   return {
@@ -59,10 +59,11 @@ function bitfinexParser(currency, data) {
 }
 
 /**
- * createConfig - creates provider config for the specified `coin` and `currency`.
+ * createConfig - Creates provider config for the specified `coin` and `currency`.
  *
- * @export
- * @returns {object}
+ * @param {('BTC'|'LTC')} coin Crypto currency of interest
+ * @param {string} currency Fiat currency of interest
+ * @returns {object} Config object
  */
 function createConfig(coin, currency) {
   const scheme =
@@ -125,12 +126,12 @@ function createConfig(coin, currency) {
 }
 
 /**
- * requestTicker - returns ticker for the specified `coin` and `currency` using `provider`.
+ * requestTicker - Returns ticker for the specified `coin` and `currency` using `provider`.
  *
- * @param {string} provider
- * @param {('BTC'|'LTC')} coin
- * @param {string} currency  fiat currency of interest
- * @returns {Promise} promise that resolves to {[currency]:rate} Object. Or empty object
+ * @param {string} provider Provider of interest
+ * @param {('BTC'|'LTC')} coin Crypto currency of interest
+ * @param {string} currency  Fiat currency of interest
+ * @returns {Promise} Promise that resolves to {[currency]:rate} Object. Or empty object
  * if something went wrong
  */
 export async function requestTicker(provider, coin, currency) {
@@ -148,28 +149,26 @@ export async function requestTicker(provider, coin, currency) {
 }
 
 /**
- * getSupportedProviders - get list of supported providers  for the specified `coin` and `currency`
+ * getSupportedProviders - Get list of supported providers for the specified `coin` and `currency`
  * if called with undefined `coin` and/or `currency` - returns all enabled providers.
  *
- * @export
- * @param {('BTC'|'LTC')} coin
- * @param {string} currency - fiat currency of interest
- * @returns {Array<string>} list of supported rate providers
+ * @param {('BTC'|'LTC')} coin Crypto currency of interest
+ * @param {string} currency Fiat currency of interest
+ * @returns {object} Details of supported rate providers
  */
 export function getSupportedProviders(coin, currency) {
   return createConfig(coin, currency)
 }
 
 /**
- * requestTickerWithFallback - returns ticker for the specified `coin` and `currency` using `provider`
+ * requestTickerWithFallback - Returns ticker for the specified `coin` and `currency` using `provider`
  * falls back to `fallback` if operation was unsuccessful.
  *
- * @param {string} provider
- * @param {('BTC'|'LTC')} coin
- * @param {string} currency - fiat currency of interest
- * @param {string} fallback - fallback provider name
- * @returns {Promise} promise that resolves to {[currency]:rate} Object. Or empty object
- * if something went wrong
+ * @param {string} provider Provider of interest
+ * @param {('BTC'|'LTC')} coin Crypto currency of interest
+ * @param {string} currency Fiat currency of interest
+ * @param {string} fallback Fallback provider name
+ * @returns {Promise} Promise that resolves to {[currency]:rate} Object. Or empty object if something went wrong
  */
 export async function requestTickerWithFallback(provider, coin, currency, fallback = 'coinbase') {
   const result = await requestTicker(provider, coin, currency)

--- a/utils/rateProvider/index.js
+++ b/utils/rateProvider/index.js
@@ -1,0 +1,3 @@
+export { createConfig, getSupportedProviders } from './providers'
+export requestTicker from './requestTicker'
+export requestTickerWithFallback from './requestTickerWithFallback'

--- a/utils/rateProvider/requestTicker.js
+++ b/utils/rateProvider/requestTicker.js
@@ -1,0 +1,29 @@
+import axios from 'axios'
+import { mainLog } from '@zap/utils/log'
+import { createConfig } from './providers'
+
+/**
+ * requestTicker - Returns ticker for the specified `coin` and `currency` using `provider`.
+ *
+ * @param {string} provider Provider of interest
+ * @param {('BTC'|'LTC')} coin Crypto currency of interest
+ * @param {string} currency  Fiat currency of interest
+ * @returns {Promise} Promise that resolves to {[currency]:rate} Object. Or empty object
+ * if something went wrong
+ */
+async function requestTicker(provider, coin, currency) {
+  mainLog.info('Fetching %s/%s ticker from %s', coin, currency, provider)
+  const config = createConfig(coin, currency)
+  const { apiUrl, parser } = config[provider] || {}
+
+  if (!(apiUrl && parser)) {
+    return {}
+  }
+
+  return await axios
+    .get(apiUrl)
+    .then(parser)
+    .catch(() => ({}))
+}
+
+export default requestTicker

--- a/utils/rateProvider/requestTickerWithFallback.js
+++ b/utils/rateProvider/requestTickerWithFallback.js
@@ -1,0 +1,37 @@
+import uniq from 'lodash/uniq'
+import { mainLog } from '@zap/utils/log'
+import { getSupportedProviders } from './providers'
+import requestTicker from './requestTicker'
+/**
+ * requestTickerWithFallback - Returns ticker for the specified `coin` and `currency` using `provider`
+ * falls back to `fallback` if operation was unsuccessful.
+ *
+ * @param {string} provider Provider of interest
+ * @param {('BTC'|'LTC')} coin Crypto currency of interest
+ * @param {string} currency Fiat currency of interest
+ * @returns {Promise} Promise that resolves to {[currency]:rate} Object. Or empty object if something went wrong
+ */
+async function requestTickerWithFallback(provider, coin, currency) {
+  const fallbackProviders = Object.keys(getSupportedProviders(coin, currency))
+  const allProviders = uniq([provider].concat(fallbackProviders))
+
+  // Try each provider sequentially until we get a result.
+  let result = {}
+  for (const currentProvider of allProviders) {
+    try {
+      // Attempt to fetch the ticker data.
+      result = await requestTicker(currentProvider, coin, currency)
+      // If we got the result we were looking for abort early.
+      if (result[currency]) {
+        break
+      }
+      throw new Error('No data')
+    } catch (e) {
+      mainLog.warn('Unable to fetch %s/%s ticker from %s: %o', coin, currency, currentProvider, e)
+    }
+  }
+
+  return result
+}
+
+export default requestTickerWithFallback


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:

Always use fallback providers when fetching ticker data.

## Motivation and Context:

fix #1783

## How Has This Been Tested?

Manually

## Types of changes:

Enhancement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
