### PR TITLE
fix(wallet): use selector for sending payments

### DIFF
--- a/renderer/reducers/activity.js
+++ b/renderer/reducers/activity.js
@@ -352,7 +352,7 @@ activitySelectors.activityModalItem = createSelector(
 
 const allActivity = createSelector(
   searchTextSelector,
-  paymentsSendingSelector,
+  paymentsSending,
   transactionsSendingSelector,
   paymentsSelector,
   transactionsSelector,

--- a/renderer/reducers/payment.js
+++ b/renderer/reducers/payment.js
@@ -57,6 +57,7 @@ export const sendPayment = data => dispatch => {
 
   const payment = {
     ...data,
+    type: 'payment',
     status: 'sending',
     creation_date: Math.round(new Date() / 1000),
     payment_hash: paymentHashTag.data,


### PR DESCRIPTION
## Description:

Use selector for sending payments

## Motivation and Context:

Entries in sendingPayments state are not suitable for direct display. We use a selector to decorate them with additional/missing information but that selector was not being used.

## How Has This Been Tested?

Manually - make a ln payment and verify app doesn't crash after clicking send

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
