### PR TITLE
refactor: fix lodash import in generate-icon script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "predev": "npm run build-main",
     "dev": "cross-env HOT=1 npm run start-renderer-dev",
     "extract-messages": "extract-messages -l=af-ZA,ca-ES,de-DE,es-ES,ga-IE,hr-HR,ja-JP,no-NO,pt-PT,sr-SP,uk-UA,zh-TW,ar-SA,cs-CZ,el-GR,fi-FI,he-IL,hu-HU,ko-KR,pl-PL,ro-RO,sv-SE,vi-VN,bg-BG,da-DK,en,fr-FR,hi-IN,it-IT,nl-NL,pt-BR,ru-RU,tr-TR,zh-CN -o translations -d en --flat true renderer/**/messages.js",
-    "fetch-lnd": "node ./scripts/fetch-lnd-for-packaging.js",
+    "fetch-lnd": "node -r @babel/register ./scripts/fetch-lnd-for-packaging.js",
     "generate-icon": "node -r @babel/register ./scripts/genIcons.js",
     "lint-base": "eslint --cache --format=node_modules/eslint-formatter-pretty",
     "lint": "npm run lint-base -- .",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev": "cross-env HOT=1 npm run start-renderer-dev",
     "extract-messages": "extract-messages -l=af-ZA,ca-ES,de-DE,es-ES,ga-IE,hr-HR,ja-JP,no-NO,pt-PT,sr-SP,uk-UA,zh-TW,ar-SA,cs-CZ,el-GR,fi-FI,he-IL,hu-HU,ko-KR,pl-PL,ro-RO,sv-SE,vi-VN,bg-BG,da-DK,en,fr-FR,hi-IN,it-IT,nl-NL,pt-BR,ru-RU,tr-TR,zh-CN -o translations -d en --flat true renderer/**/messages.js",
     "fetch-lnd": "node ./scripts/fetch-lnd-for-packaging.js",
-    "generate-icon": "node ./scripts/genIcons.js",
+    "generate-icon": "node -r @babel/register ./scripts/genIcons.js",
     "lint-base": "eslint --cache --format=node_modules/eslint-formatter-pretty",
     "lint": "npm run lint-base -- .",
     "lint-fix-base": "npm run lint-base -- --fix",

--- a/scripts/fetch-lnd-for-packaging.js
+++ b/scripts/fetch-lnd-for-packaging.js
@@ -1,16 +1,29 @@
-const lndBinary = require('lnd-binary')
+import { install } from 'lnd-binary'
 
-function install(platform, arch, dest) {
+/**
+ * installLnd - Install lnd for a given platform and architecture.
+ *
+ * @param  {string} platform Platform
+ * @param  {string} arch     Architecture
+ * @param  {string} dest     Destination
+ * @returns {Promise} resolves after install is complete
+ */
+function installLnd(platform, arch, dest) {
   process.env.LND_BINARY_PLATFORM = platform
   process.env.LND_BINARY_ARCH = arch
   process.env.LND_BINARY_DIR = dest
 
-  return lndBinary.install()
+  return install()
 }
 
-return install('darwin', 'amd64', 'resources/bin/mac/x64')
-  .then(() => install('darwin', '386', 'resources/bin/mac/ia32'))
-  .then(() => install('windows', 'amd64', 'resources/bin/win/x64'))
-  .then(() => install('windows', '386', 'resources/bin/win/ia32'))
-  .then(() => install('linux', 'amd64', 'resources/bin/linux/x64'))
-  .then(() => install('linux', '386', 'resources/bin/linux/ia32'))
+installLnd('darwin', 'amd64', 'resources/bin/mac/x64')
+  .then(() => installLnd('darwin', '386', 'resources/bin/mac/ia32'))
+  .then(() => installLnd('windows', 'amd64', 'resources/bin/win/x64'))
+  .then(() => installLnd('windows', '386', 'resources/bin/win/ia32'))
+  .then(() => installLnd('linux', 'amd64', 'resources/bin/linux/x64'))
+  .then(() => installLnd('linux', '386', 'resources/bin/linux/ia32'))
+  .catch(e => {
+    // eslint-disable-next-line no-console
+    console.warn(e)
+    process.exit(1)
+  })

--- a/scripts/genIcons.js
+++ b/scripts/genIcons.js
@@ -1,7 +1,6 @@
 import camelCase from 'lodash/camelCase'
-
-const { execSync } = require('child_process')
-const path = require('path')
+import { execSync } from 'child_process'
+import path from 'path'
 
 const OUTPUT_DIR = 'renderer/components/Icon'
 const TMP_DIR = 'icon_gen_temp'
@@ -9,9 +8,9 @@ const TMP_DIR = 'icon_gen_temp'
 const iconPath = process.argv[2] || ''
 
 /**
- * Converts iconPath to pascal case icon name
+ * getIconName - Converts iconPath to pascal case icon name.
  *
- * @returns {string}
+ * @returns {string} Icon name
  */
 function getIconName() {
   const [icon] = path.basename(iconPath).split('.')


### PR DESCRIPTION
## Description:

The `generate-icons` script is broken since switching to lodash subpackage import style. Convert all imports to ES module imports and use babel when running the script.

## Motivation and Context:

The `generate-icon` script is broken since.

## How Has This Been Tested?

run `yarn generate-icon /path/to/icon`

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
