### PR TITLE
refactor: use danger variant for delete wallet button

### DIFF
--- a/renderer/components/Home/WalletLauncher.js
+++ b/renderer/components/Home/WalletLauncher.js
@@ -435,7 +435,7 @@ class WalletLauncher extends React.Component {
               <Bar my={2} />
 
               <Flex justifyContent="center" my={4}>
-                <Button onClick={this.handleDelete} size="small" type="button">
+                <Button onClick={this.handleDelete} size="small" type="button" variant="danger">
                   <FormattedMessage {...messages.delete_wallet_button_text} />
                 </Button>
               </Flex>


### PR DESCRIPTION
## Description:

Alert user to the fact that the probably don't want to click on the delete button by using the danger (red) button variant.

## Motivation and Context:

Using red for destructive actions is a fairly typical design pattern and we already do this in the delete wallet modal for example.

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):

**Before:**
![image](https://user-images.githubusercontent.com/200251/59749713-d85c3680-927d-11e9-9e8e-923d761b1e6b.png)

**After:**
![image](https://user-images.githubusercontent.com/200251/59749619-b2cf2d00-927d-11e9-9e3e-321e3262197a.png)

## Types of changes:

<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have reviewed and updated the documentation accordingly.
- [ ] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [ ] My commits have been squashed into a concise set of changes.
