### PR TITLE
fix(launchpad): ensure full form reset on cancel

### DIFF
--- a/renderer/components/Home/WalletLauncher.js
+++ b/renderer/components/Home/WalletLauncher.js
@@ -287,24 +287,8 @@ class WalletLauncher extends React.Component {
   }
 
   resetForm = () => {
-    const { wallet } = this.props
     const { formApi } = this
-    // for remote wallets manually reset cert, macaroon and host since they are derived from
-    // lndconnect uri
-    const resetValues =
-      wallet.type === 'local'
-        ? wallet
-        : Object.assign({}, { ...parseLndConnectURI(wallet.lndconnectUri) }, wallet)
-
-    formApi.setValues(walletToFormFormat(resetValues))
-
-    // reset errors
-    if (formApi.getTouched('lndconnectUri')) {
-      formApi.setTouched('lndconnectUri', false)
-    }
-    if (formApi.getError('lndconnectUri')) {
-      formApi.setError('lndconnectUri', undefined)
-    }
+    formApi.reset()
   }
 
   setFormApi = formApi => {


### PR DESCRIPTION
## Description:

Use Informed formApi.reset to do the wallet settings form reset.

## Motivation and Context:

This resolves an issue in which the cancel action bar button was not working when editing a field that was initially empty.

## How Has This Been Tested?

Test all kinds of different scenarios of clicking the cancel button when editing wallet settings on the launchpad.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
