### PR TITLE
fix(ui): adjust sizes of launchpad inputs

### DIFF
--- a/renderer/components/Home/WalletSettingsFormLocal.js
+++ b/renderer/components/Home/WalletSettingsFormLocal.js
@@ -78,7 +78,7 @@ class WalletSettingsFormLocal extends React.Component {
                   ...messages.wallet_settings_name_placeholder,
                 })}
                 textAlign="right"
-                width={1}
+                width={250}
               />
             }
           />
@@ -106,7 +106,7 @@ class WalletSettingsFormLocal extends React.Component {
                   ...messages.wallet_settings_alias_placeholder,
                 })}
                 textAlign="right"
-                width={1}
+                width={250}
               />
             }
           />

--- a/renderer/components/Home/WalletSettingsFormRemote.js
+++ b/renderer/components/Home/WalletSettingsFormRemote.js
@@ -78,7 +78,7 @@ const WalletSettingsFormRemote = ({
                     ...messages.hostname_title,
                   })}
                   textAlign="right"
-                  width={300}
+                  width={250}
                 />
               }
             />
@@ -91,7 +91,7 @@ const WalletSettingsFormRemote = ({
                 />
               }
               py={2}
-              right={<OpenDialogInput field="cert" initialValue={cert} name="cert" width={300} />}
+              right={<OpenDialogInput field="cert" initialValue={cert} name="cert" width={250} />}
             />
             <DataRow
               left={
@@ -107,7 +107,7 @@ const WalletSettingsFormRemote = ({
                   field="macaroon"
                   initialValue={macaroon}
                   name="macaroon"
-                  width={300}
+                  width={250}
                 />
               }
             />
@@ -141,7 +141,7 @@ const WalletSettingsFormRemote = ({
                 ...messages.wallet_settings_name_placeholder,
               })}
               textAlign="right"
-              width={300}
+              width={250}
             />
           }
         />

--- a/renderer/components/Home/WalletSettingsFormRemote.js
+++ b/renderer/components/Home/WalletSettingsFormRemote.js
@@ -52,6 +52,7 @@ const WalletSettingsFormRemote = ({
             placeholder={intl.formatMessage({
               ...messages.connection_string,
             })}
+            rows={6}
             validateOnBlur
             validateOnChange
           />

--- a/renderer/components/UI/LndConnectionStringEditor.js
+++ b/renderer/components/UI/LndConnectionStringEditor.js
@@ -27,10 +27,10 @@ function LndConnectionStringEditor({ formApi, field, hideStringMessage, ...rest 
   return (
     <Box>
       <LndConnectionStringInput
+        rows={10}
         {...rest}
         field={field}
         isReadOnly={isDisabled}
-        rows={12}
         value={getValue(isDisabled)}
       />
       <Flex alignItems="center" justifyContent="space-between" mt={3}>


### PR DESCRIPTION
## Description:

Adjust sizes of launchpad inputs.

## Motivation and Context:

Input sizes a bit wonky and inconsistent.

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):

**Before:**

![image](https://user-images.githubusercontent.com/200251/59796517-007b8200-92de-11e9-8c15-10cc94e30237.png)
**After:**

![image](https://user-images.githubusercontent.com/200251/59796599-2acd3f80-92de-11e9-9535-f42c09e53d22.png)

## Types of changes:

UI fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
