### PR TITLE
fix(wallet): use decorated selector for transactions sending

### DIFF
--- a/renderer/reducers/activity.js
+++ b/renderer/reducers/activity.js
@@ -353,7 +353,7 @@ activitySelectors.activityModalItem = createSelector(
 const allActivity = createSelector(
   searchTextSelector,
   paymentsSending,
-  transactionsSendingSelector,
+  transactionsSending,
   paymentsSelector,
   transactionsSelector,
   invoicesSelector,

--- a/renderer/reducers/transaction.js
+++ b/renderer/reducers/transaction.js
@@ -42,6 +42,7 @@ export function getTransactions() {
 
 export function sendTransaction(data) {
   const transaction = Object.assign({}, data, {
+    type: 'transaction',
     status: 'sending',
     timestamp: Math.round(new Date() / 1000),
   })


### PR DESCRIPTION
## Description:

Ensure we use decorated selector for transactions sending in the activity list. Fixes issue similar to https://github.com/LN-Zap/zap-desktop/pull/2458

## Motivation and Context:

App crashes after sending onchain payment

## How Has This Been Tested?

Make on-chain payment

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
