### PR TITLE
refactor: stop using deprecated lnd props

### DIFF
--- a/renderer/components/Activity/ActivityListItem.js
+++ b/renderer/components/Activity/ActivityListItem.js
@@ -42,7 +42,7 @@ const ActivityListItem = ({ activity, ...rest }) => {
       <Text color="gray" mr={10} textAlign="center" width={24}>
         <ActivityIcon activity={activity} />
       </Text>
-      <Box css={activity.sending ? null : { cursor: 'pointer' }} width={1}>
+      <Box css={activity.isSending ? null : { cursor: 'pointer' }} width={1}>
         <ListItem {...listItemProps} />
       </Box>
     </Flex>

--- a/renderer/components/Activity/PaymentModal/PaymentModal.js
+++ b/renderer/components/Activity/PaymentModal/PaymentModal.js
@@ -32,7 +32,7 @@ export default class PaymentModal extends React.PureComponent {
             right={
               <Flex alignItems="center">
                 <CryptoSelector mr={2} />
-                <CryptoValue fontSize="xxl" value={item.value} />
+                <CryptoValue fontSize="xxl" value={item.value_sat} />
               </Flex>
             }
           />
@@ -44,7 +44,7 @@ export default class PaymentModal extends React.PureComponent {
             right={
               <Flex alignItems="center">
                 <FiatSelector mr={2} />
-                <FiatValue value={item.value} />
+                <FiatValue value={item.value_sat} />
               </Flex>
             }
           />

--- a/renderer/containers/Activity/Payment.js
+++ b/renderer/containers/Activity/Payment.js
@@ -1,7 +1,6 @@
 import { connect } from 'react-redux'
 import { tickerSelectors } from 'reducers/ticker'
 import { showActivityModal } from 'reducers/activity'
-import { networkSelectors } from 'reducers/network'
 
 import Payment from 'components/Activity/Payment'
 
@@ -11,7 +10,6 @@ const mapDispatchToProps = {
 
 const mapStateToProps = state => ({
   cryptoUnitName: tickerSelectors.cryptoUnitName(state),
-  nodes: networkSelectors.nodes(state),
 })
 
 export default connect(

--- a/renderer/reducers/activity.js
+++ b/renderer/reducers/activity.js
@@ -1,5 +1,4 @@
 import { createSelector } from 'reselect'
-import { decodePayReq } from '@zap/utils/crypto'
 import { openModal, closeModal } from './modal'
 import { fetchDescribeNetwork } from './network'
 import { fetchTransactions, transactionsSelectors } from './transaction'
@@ -260,7 +259,7 @@ const filtersSelector = state => state.activity.filters
 const searchTextSelector = state => state.activity.searchText
 const modalItemTypeSelector = state => state.activity.modal.itemType
 const modalItemIdSelector = state => state.activity.modal.itemId
-const paymentsSelector = state => paymentSelectors.decoratedPaymentsSelector(state)
+const paymentsSelector = state => paymentSelectors.payments(state)
 const paymentsSendingSelector = state => paymentSelectors.paymentsSending(state)
 const invoicesSelector = state => invoiceSelectors.invoices(state)
 const transactionsSelector = state => transactionsSelectors.decoratedTransactionsSelector(state)
@@ -269,29 +268,6 @@ const transactionsSendingSelector = state => transactionsSelectors.transactionsS
 activitySelectors.filter = filterSelector
 activitySelectors.filters = filtersSelector
 activitySelectors.searchText = searchTextSelector
-
-/**
- * Map sending payments to something that looks like normal payments.
- */
-const paymentsSending = createSelector(
-  paymentsSendingSelector,
-  paymentsSending => {
-    const payments = paymentsSending.map(payment => {
-      const invoice = decodePayReq(payment.paymentRequest)
-      return {
-        type: 'payment',
-        creation_date: payment.creation_date,
-        value: payment.amt,
-        path: [invoice.payeeNodeKey],
-        payment_hash: invoice.tags.find(t => t.tagName === 'payment_hash').data,
-        sending: true,
-        status: payment.status,
-        error: payment.error,
-      }
-    })
-    return payments
-  }
-)
 
 /**
  * Map sending transactions to something that looks like normal transactions.
@@ -343,7 +319,7 @@ const addDate = entry => {
 
 // pre-search compound activity list
 const allActivityRaw = createSelector(
-  paymentsSending,
+  paymentsSendingSelector,
   transactionsSending,
   paymentsSelector,
   transactionsSelector,
@@ -371,7 +347,7 @@ const allActivity = createSelector(
 
 const sentActivity = createSelector(
   searchTextSelector,
-  paymentsSending,
+  paymentsSendingSelector,
   transactionsSending,
   paymentsSelector,
   transactionsSelector,
@@ -413,7 +389,7 @@ const receivedActivity = createSelector(
 
 const pendingActivity = createSelector(
   searchTextSelector,
-  paymentsSending,
+  paymentsSendingSelector,
   transactionsSending,
   transactionsSelector,
   invoicesSelector,

--- a/renderer/reducers/activity.js
+++ b/renderer/reducers/activity.js
@@ -262,7 +262,7 @@ const modalItemIdSelector = state => state.activity.modal.itemId
 const paymentsSelector = state => paymentSelectors.payments(state)
 const paymentsSendingSelector = state => paymentSelectors.paymentsSending(state)
 const invoicesSelector = state => invoiceSelectors.invoices(state)
-const transactionsSelector = state => transactionsSelectors.decoratedTransactionsSelector(state)
+const transactionsSelector = state => transactionsSelectors.transactions(state)
 const transactionsSendingSelector = state => transactionsSelectors.transactionsSending(state)
 
 activitySelectors.filter = filterSelector

--- a/renderer/reducers/utils.js
+++ b/renderer/reducers/utils.js
@@ -83,7 +83,7 @@ export const getLoadingMessage = (state, location = {}) => {
  * such as funding  tx timestamp
  */
 export const decoratedSelectedChannel = createSelector(
-  transactionsSelectors.rawTransactionsSelector,
+  transactionsSelectors.transactions,
   channelsSelectors.selectedChannel,
   (transactions, channelData) => {
     if (channelData && channelData.channel_point) {


### PR DESCRIPTION
## Description:

Old versions of lnd provided a `payment.value` prop that had the payment value. In 0.5.1 this was replaced with `.value_sat` and `.value_msat`.The old `payment.value` prop is still supported but marked as deprecated.

## Motivation and Context:

Stop using deprecated lnd payment props to future proof things.

## How Has This Been Tested?

Make payments
Open existing payments
Verify payments sending functionality works correctly
Verify payments look correct on the activity list and in the payment modal

## Types of changes:

Refactor

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
