### PR TITLE
feat(activity): improve search

### DIFF
--- a/renderer/reducers/activity.js
+++ b/renderer/reducers/activity.js
@@ -70,8 +70,8 @@ const months = [
  * @returns {boolean} Boolean indicating if the prop was found and contains the search string
  */
 const propMatches = function(prop) {
-  const { item, searchTextSelector } = this
-  return item[prop] && item[prop].includes(searchTextSelector)
+  const { item, searchTextSelector = '' } = this
+  return item[prop] && item[prop].toLowerCase().includes(searchTextSelector)
 }
 
 /**

--- a/renderer/reducers/activity.js
+++ b/renderer/reducers/activity.js
@@ -159,13 +159,14 @@ const applySearch = (data, searchTextSelector) => {
       'payment_request',
       'dest_node_pubkey',
       'dest_node_alias',
+      'memo',
     ].some(propMatches, { item, searchTextSelector })
 
     // Check every destination address.
     const hasAddressMatch =
       item.dest_addresses && item.dest_addresses.find(addr => addr.includes(searchTextSelector))
 
-    // Include the item if at least one search critera matches.
+    // Include the item if at least one search criteria matches.
     return hasPropMatch || hasAddressMatch
   })
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Though the activity search was improved recently we can still do better.
The PR adds the following improvements:

1. Makes search case-insensitive
2. Allows search by memo field
3. Allows search by type field (invoice, payment etc)
4. Allows search by date
5. Delivers perf optimization of the search process

A little more on search by date.
Currently, we don't have an ability to filter activity by date range, which is quite a common use case.
This PR instead adds search by date.
The current implementation has some limitations though. The biggest one is that it currently has no intl support because search is performed against a raw dataset and date localization happens at the UI level. This can be addressed by future PR since it requires some more refactoring.

<!--- Describe your changes in detail -->


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
For instance type `may` or `2019` to search by date
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes:
Enhancement
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
