### PR TITLE
fix(ui): ensure lndconnect string is trimmed

### DIFF
--- a/renderer/components/Onboarding/Steps/ConnectionConfirm.js
+++ b/renderer/components/Onboarding/Steps/ConnectionConfirm.js
@@ -46,7 +46,7 @@ class ConnectionConfirm extends React.Component {
       connectionString,
       startLnd,
     } = this.props
-
+    connectionString = connectionString && connectionString.trim()
     // If we have a hostname, assume we are using the custom form in which host, cer and macaroon paths are supplied.
     if (connectionHost) {
       return startLnd({
@@ -123,11 +123,12 @@ class ConnectionConfirm extends React.Component {
     }
     // Otherwise, if we have a connection uri, parse the host details from that.
     else if (connectionString) {
-      if (connectionString.startsWith('lndconnect:')) {
-        const { host } = decode(connectionString)
+      const conString = connectionString.trim()
+      if (conString.startsWith('lndconnect:')) {
+        const { host } = decode(conString)
         hostname = host
       } else {
-        const { host } = parseConnectionString(connectionString)
+        const { host } = parseConnectionString(conString)
         hostname = host
       }
     }

--- a/renderer/components/UI/LndConnectionStringInput.js
+++ b/renderer/components/UI/LndConnectionStringInput.js
@@ -5,6 +5,8 @@ import { isValidLndConnectUri, isValidBtcPayConfig } from '@zap/utils/connection
 import TextArea from './TextArea'
 import messages from './messages'
 
+const mask = value => value && value.trim()
+
 /**
  * @render react
  * @name LndConnectionStringInput
@@ -58,6 +60,7 @@ class LndConnectionStringInput extends React.Component {
           word-break: break-all;
         `}
         initialValue={initialValue}
+        mask={mask}
         placeholder={intl.formatMessage({ ...messages.lnd_connection_string_placeholder })}
         {...rest}
         spellCheck="false"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Prevent app from crashing when using a valid LND connect with leading or trailing spaces
<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes:
Bugfix
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
