### PR TITLE
fix(ui): add CopyButton to preimage in Payment modal

### DIFF
--- a/renderer/components/Activity/PaymentModal/PaymentModal.js
+++ b/renderer/components/Activity/PaymentModal/PaymentModal.js
@@ -1,20 +1,21 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { FormattedDate, FormattedTime, FormattedMessage } from 'react-intl'
+import { FormattedDate, FormattedTime, FormattedMessage, injectIntl, intlShape } from 'react-intl'
 import { Flex } from 'rebass'
 import { Bar, DataRow, Header, Panel, Text } from 'components/UI'
-import { CryptoSelector, CryptoValue, FiatSelector, FiatValue } from 'containers/UI'
+import { CopyButton, CryptoSelector, CryptoValue, FiatSelector, FiatValue } from 'containers/UI'
 import { Truncate } from 'components/Util'
 import Lightning from 'components/Icon/Lightning'
 import messages from './messages'
 
-export default class PaymentModal extends React.PureComponent {
+class PaymentModal extends React.PureComponent {
   static propTypes = {
+    intl: intlShape.isRequired,
     item: PropTypes.object.isRequired,
   }
 
   render() {
-    const { item, ...rest } = this.props
+    const { item, intl, ...rest } = this.props
     return (
       <Panel {...rest}>
         <Panel.Header>
@@ -75,9 +76,17 @@ export default class PaymentModal extends React.PureComponent {
           <DataRow
             left={<FormattedMessage {...messages.preimage} />}
             right={
-              <Text className="hint--bottom-left" data-hint={item.payment_preimage}>
-                <Truncate text={item.payment_preimage} />
-              </Text>
+              <Flex>
+                <CopyButton
+                  mr={2}
+                  name={intl.formatMessage({ ...messages.preimage })}
+                  size="0.7em"
+                  value={item.payment_preimage}
+                />
+                <Text className="hint--bottom-left" data-hint={item.payment_preimage}>
+                  <Truncate text={item.payment_preimage} />
+                </Text>
+              </Flex>
             }
           />
         </Panel.Body>
@@ -85,3 +94,5 @@ export default class PaymentModal extends React.PureComponent {
     )
   }
 }
+
+export default injectIntl(PaymentModal)

--- a/renderer/components/Activity/PaymentModal/messages.js
+++ b/renderer/components/Activity/PaymentModal/messages.js
@@ -7,5 +7,5 @@ export default defineMessages({
   date_sent: 'Date sent',
   fee: 'Total fee',
   current_value: 'Current value',
-  preimage: 'Payment Preimage',
+  preimage: 'Payment preimage',
 })

--- a/translations/da-DK.json
+++ b/translations/da-DK.json
@@ -35,7 +35,7 @@
   "components.Activity.PaymentModal.current_value": "Nuværende værdi",
   "components.Activity.PaymentModal.date_sent": "Dato sendt",
   "components.Activity.PaymentModal.fee": "Gebyr",
-  "components.Activity.PaymentModal.preimage": "Betalings Preimage",
+  "components.Activity.PaymentModal.preimage": "Betalings preimage",
   "components.Activity.PaymentModal.subtitle": "Lightning Betaling",
   "components.Activity.PaymentModal.title_sent": "Sendt",
   "components.Activity.Transaction.amount": "Transaktions beløb",

--- a/translations/en.json
+++ b/translations/en.json
@@ -35,7 +35,7 @@
   "components.Activity.PaymentModal.current_value": "Current value",
   "components.Activity.PaymentModal.date_sent": "Date sent",
   "components.Activity.PaymentModal.fee": "Total fee",
-  "components.Activity.PaymentModal.preimage": "Payment Preimage",
+  "components.Activity.PaymentModal.preimage": "Payment preimage",
   "components.Activity.PaymentModal.subtitle": "Lightning Payment",
   "components.Activity.PaymentModal.title_sent": "Sent",
   "components.Activity.Transaction.amount": "Transaction amount",

--- a/translations/es-ES.json
+++ b/translations/es-ES.json
@@ -35,7 +35,7 @@
   "components.Activity.PaymentModal.current_value": "Valor actual",
   "components.Activity.PaymentModal.date_sent": "Fecha enviado",
   "components.Activity.PaymentModal.fee": "Comisión",
-  "components.Activity.PaymentModal.preimage": "Preimagen de Pago",
+  "components.Activity.PaymentModal.preimage": "Preimagen de pago",
   "components.Activity.PaymentModal.subtitle": "Pago de Lightning",
   "components.Activity.PaymentModal.title_sent": "Enviado",
   "components.Activity.Transaction.amount": "Monto",

--- a/translations/ga-IE.json
+++ b/translations/ga-IE.json
@@ -35,7 +35,7 @@
   "components.Activity.PaymentModal.current_value": "Luach reatha",
   "components.Activity.PaymentModal.date_sent": "Dáta a seoladh",
   "components.Activity.PaymentModal.fee": "Táille",
-  "components.Activity.PaymentModal.preimage": "Preimage Íocaíochta",
+  "components.Activity.PaymentModal.preimage": "Preimage íocaíochta",
   "components.Activity.PaymentModal.subtitle": "Íocaíocht Lightning",
   "components.Activity.PaymentModal.title_sent": "Seolta",
   "components.Activity.Transaction.amount": "Méid na hidirbhearta",


### PR DESCRIPTION
## Description:

Add CopyButton to preimage in Payment modal

## Motivation and Context:

fix #2490

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/200251/59979357-31fa9300-95e7-11e9-99b5-37538657bc4e.png)

## Types of changes:

Enhancement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
