### PR TITLE
fix: electron shutdown flow on win and linux

### DIFF
--- a/electron/controller.js
+++ b/electron/controller.js
@@ -79,6 +79,13 @@ class ZapController {
     // Send a message to the renderer process telling it to to gracefully shutdown. We register a success callback with
     // it so that we can complete the termination and quit electon once the app has been fully shutdown.
     ipcMain.on('terminateAppSuccess', () => app.quit())
+
+    ipcMain.on('terminateAppFailed', (event, e) => {
+      mainLog.info('terminateAppFailed: %o', e)
+      this.killAllSpawnedProcesses()
+      app.quit()
+    })
+
     this.sendMessage('terminateApp')
   }
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -270,15 +270,26 @@ app.on('ready', async () => {
   // When the window is closed, just hide it unless we are force closing.
   mainWindow.on('close', event => {
     mainLog.trace('mainWindow.close')
-    if (os.platform() === 'darwin' && !mainWindow.forceClose) {
-      event.preventDefault()
-      if (mainWindow.isFullScreen()) {
-        mainWindow.once('leave-full-screen', () => {
+    // On Mac, when the user closes the window we just want to hide it so that they can open from the dock later.
+    if (os.platform() === 'darwin') {
+      if (!mainWindow.forceClose) {
+        event.preventDefault()
+        if (mainWindow.isFullScreen()) {
+          mainWindow.once('leave-full-screen', () => {
+            mainWindow.hide()
+          })
+          mainWindow.setFullScreen(false)
+        } else {
           mainWindow.hide()
-        })
-        mainWindow.setFullScreen(false)
-      } else {
+        }
+      }
+    }
+    // On Windows/Linux, we quit the app when the window is closed.
+    else {
+      if (!mainWindow.forceClose) {
+        event.preventDefault()
         mainWindow.hide()
+        app.quit()
       }
     }
   })

--- a/renderer/reducers/app.js
+++ b/renderer/reducers/app.js
@@ -100,10 +100,14 @@ export const initApp = (event, options = {}) => async (dispatch, getState) => {
  * IPC handler for 'terminateApp' message
  */
 export const terminateApp = () => async dispatch => {
-  dispatch({ type: TERMINATE_APP })
-  await dispatch(stopLnd())
-  dispatch({ type: TERMINATE_APP_SUCCESS })
-  dispatch(send('terminateAppSuccess'))
+  try {
+    dispatch({ type: TERMINATE_APP })
+    await dispatch(stopLnd())
+    dispatch({ type: TERMINATE_APP_SUCCESS })
+    dispatch(send('terminateAppSuccess'))
+  } catch (e) {
+    dispatch(send('terminateAppFailed', e))
+  }
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Correctly shutdowns the app on Windows and Linux. Previously renderer window was closing before having a chance to respond to `terminateApp` IPC event causing `electron` process to become stuck.
<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes:
Bugfix
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
