### PR TITLE
fix(settings): ensure number fields use number type

### DIFF
--- a/renderer/components/UI/IntegerInput.js
+++ b/renderer/components/UI/IntegerInput.js
@@ -20,13 +20,14 @@ const isNumericRegex = /^\d+$/
 const isNumeric = value => isNumericRegex.test(value)
 
 /**
- * stripLeadingZero - Strip leading zeros.
+ * convertToNumber - Convert value to number.
  *
- * @param  {number|string} value Value
- * @returns {string} Number as string with leading zeros removed
+ * @param  {string} value Value
+ * @returns {number} Value as number
  */
-const stripLeadingZero = value => {
-  return value && String(value).replace(/^0+(?=\d)/, '')
+const convertToNumber = value => {
+  const valueAsNumber = Number(value)
+  return Number.isNaN(valueAsNumber) ? undefined : valueAsNumber
 }
 
 /**
@@ -122,7 +123,7 @@ class WrappedIntegerInputAsField extends React.Component {
     return (
       <IntegerInputAsField
         {...this.props}
-        mask={stripLeadingZero}
+        mask={convertToNumber}
         onKeyDown={preventNonNumeric}
         onPaste={preventNonNumericOnPaste}
         validate={this.validate}


### PR DESCRIPTION
## Description:

This PR fixes two issues with the settings form:

1) After creating a new wallet and navigating to the preferences page and clicking the wallet tab the action bar shows up even though there are no changes.

2) conf targets are being saved as strings instead of numbers and this causes a prop-type error when they are used on the payment form

## How Has This Been Tested?

Manually

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
