### PR TITLE
fix(ui): separate version/commit on profile pane

### DIFF
--- a/renderer/components/Profile/ProfilePaneNodeInfo/ProfilePaneNodeInfo.js
+++ b/renderer/components/Profile/ProfilePaneNodeInfo/ProfilePaneNodeInfo.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { FormattedMessage, injectIntl, intlShape } from 'react-intl'
+import { clean } from 'semver'
 import { Box } from 'rebass'
 import { Bar, CopyBox, DataRow, QRCode, Text } from 'components/UI'
 import messages from './messages'
@@ -25,10 +26,11 @@ function backupMethodMessageMapper(provider, intl) {
 const ProfilePaneNodeInfo = ({
   intl,
   activeWalletSettings,
+  commitString,
   nodeUriOrPubkey,
-  lndVersion,
   showNotification,
   backupProvider,
+  versionString,
   ...rest
 }) => {
   const notifyOfCopy = () =>
@@ -72,7 +74,16 @@ const ProfilePaneNodeInfo = ({
           </Text>
         }
         py={2}
-        right={lndVersion}
+        right={
+          <>
+            <Text>{versionString}</Text>
+            {commitString && clean(commitString) !== versionString && (
+              <Text color="grey" fontSize="s">
+                {commitString}
+              </Text>
+            )}
+          </>
+        }
       />
       {backupProvider && (
         <DataRow
@@ -92,10 +103,11 @@ const ProfilePaneNodeInfo = ({
 ProfilePaneNodeInfo.propTypes = {
   activeWalletSettings: PropTypes.object.isRequired,
   backupProvider: PropTypes.string,
+  commitString: PropTypes.string,
   intl: intlShape.isRequired,
-  lndVersion: PropTypes.string,
   nodeUriOrPubkey: PropTypes.string.isRequired,
   showNotification: PropTypes.func.isRequired,
+  versionString: PropTypes.string.isRequired,
 }
 
 export default injectIntl(ProfilePaneNodeInfo)

--- a/renderer/containers/Profile/ProfilePaneNodeInfo.js
+++ b/renderer/containers/Profile/ProfilePaneNodeInfo.js
@@ -8,7 +8,8 @@ import ProfilePaneNodeInfo from 'components/Profile/ProfilePaneNodeInfo'
 const mapStateToProps = state => ({
   activeWalletSettings: walletSelectors.activeWalletSettings(state),
   nodeUriOrPubkey: infoSelectors.nodeUriOrPubkey(state),
-  lndVersion: infoSelectors.lndVersion(state),
+  versionString: infoSelectors.versionString(state),
+  commitString: infoSelectors.commitString(state),
   backupProvider: backupSelectors.providerSelector(state),
 })
 

--- a/renderer/reducers/info.js
+++ b/renderer/reducers/info.js
@@ -185,9 +185,27 @@ infoSelectors.infoLoading = state => state.info.infoLoading
 infoSelectors.infoLoaded = state => state.info.infoLoaded
 infoSelectors.hasSynced = state => state.info.hasSynced
 infoSelectors.isSyncedToChain = state => get(state, 'info.data.synced_to_chain', false)
-infoSelectors.lndVersion = state => get(state, 'info.data.version')
+infoSelectors.version = state => get(state, 'info.data.version')
 infoSelectors.identityPubkey = state => get(state, 'info.data.identity_pubkey')
 infoSelectors.nodeUri = state => get(state, 'info.data.uris[0]')
+
+// Extract the version string from the version.
+infoSelectors.versionString = createSelector(
+  infoSelectors.version,
+  version => version && version.split(' ')[0]
+)
+
+// Extract the commit string from the version.
+infoSelectors.commitString = createSelector(
+  infoSelectors.version,
+  version => {
+    if (!version) {
+      return
+    }
+    const commitString = version.split(' ')[1]
+    return commitString ? commitString.replace('commit=', '') : undefined
+  }
+)
 
 // Get the node pubkey. If not set, try to extract it from the node uri.
 infoSelectors.nodePubkey = createSelector(

--- a/services/grpc/lightning.methods.js
+++ b/services/grpc/lightning.methods.js
@@ -16,8 +16,8 @@ async function getInfo(payload = {}) {
   logGrpcCmd('Lightning.getInfo', payload)
   const infoData = await promisifiedCall(this.service, this.service.getInfo, payload)
 
-  // Add semver info into info so that we can use it to customise functionality based on active version.
-  infoData.semver = this.version
+  // Add grpc proto version into info so that it can be used by the client.
+  infoData.grpcProtoVersion = this.version
 
   // In older versions `chain` was a simple string and there was a separate boolean to indicate the network.
   // Convert it to the current format for consistency.


### PR DESCRIPTION
# Description:

Split the version string out from the commit identifier and display over two lines with the commit identifier in a smaller lighter font.

## Motivation and Context:

When connected to a node that is running a custom lnd build the lnd version string as reported by `getInfo` is quite long since it contains the version string and commit identifier.

This causes a display glitch on the node profile page when viewed at the default window size.

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):

**Before:**

![image](https://user-images.githubusercontent.com/200251/60300930-6300fd80-9930-11e9-90f0-7f4a5610b853.png)

**After:**

![image](https://user-images.githubusercontent.com/200251/60300903-51b7f100-9930-11e9-897d-37ceae993cdb.png)

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
