### PR TITLE
fix(grpc): activate Lightning grpc after init wallet

### DIFF
--- a/services/grpc/grpc.js
+++ b/services/grpc/grpc.js
@@ -14,6 +14,9 @@ import lightningSubscriptions from './lightning.subscriptions'
 const GRPC_WALLET_UNLOCKER_SERVICE_ACTIVE = 'GRPC_WALLET_UNLOCKER_SERVICE_ACTIVE'
 const GRPC_LIGHTNING_SERVICE_ACTIVE = 'GRPC_LIGHTNING_SERVICE_ACTIVE'
 
+// Timeout for WalletUnlocker actions.
+const WALLET_UNLOCKER_TIMEOUT = 1000 * 60
+
 /**
  * LND gRPC wrapper.
  * @extends EventEmitter
@@ -83,13 +86,12 @@ class ZapGrpc extends EventEmitter {
    */
   async unlock(password) {
     try {
-      const TIMEOUT = 1000 * 60
       const { grpc } = this
       await promiseTimeout(
-        TIMEOUT,
+        WALLET_UNLOCKER_TIMEOUT,
         grpc.services.WalletUnlocker.unlockWallet({ wallet_password: Buffer.from(password) })
       )
-      return await promiseTimeout(TIMEOUT, grpc.activateLightning())
+      return await promiseTimeout(WALLET_UNLOCKER_TIMEOUT, grpc.activateLightning())
     } catch (e) {
       grpcLog.debug(`Error when trying to connect to LND grpc: %o`, e)
       throw e
@@ -104,10 +106,12 @@ class ZapGrpc extends EventEmitter {
    */
   async initWallet(payload) {
     try {
-      const TIMEOUT = 1000 * 60
       const { grpc } = this
-      await promiseTimeout(TIMEOUT, grpc.services.WalletUnlocker.initWallet(payload))
-      return await promiseTimeout(TIMEOUT, grpc.activateLightning())
+      await promiseTimeout(
+        WALLET_UNLOCKER_TIMEOUT,
+        grpc.services.WalletUnlocker.initWallet(payload)
+      )
+      return await promiseTimeout(WALLET_UNLOCKER_TIMEOUT, grpc.activateLightning())
     } catch (e) {
       grpcLog.debug(`Error when trying to create wallet: %o`, e)
       throw e

--- a/services/grpc/grpc.js
+++ b/services/grpc/grpc.js
@@ -71,9 +71,16 @@ class ZapGrpc extends EventEmitter {
       this.subscribeAll()
     })
 
-    return this.grpc.connect(options)
     // Connect the service.
+    return this.grpc.connect(options)
   }
+
+  /**
+   * unlock - Unlock gRPC service.
+   *
+   * @param {string} password Password
+   * @returns {Promise} Promise that resolves after unlocking a wallet and connecting to the Lightning interface.
+   */
   async unlock(password) {
     try {
       const TIMEOUT = 1000 * 60
@@ -85,6 +92,24 @@ class ZapGrpc extends EventEmitter {
       return await promiseTimeout(TIMEOUT, grpc.activateLightning())
     } catch (e) {
       grpcLog.debug(`Error when trying to connect to LND grpc: %o`, e)
+      throw e
+    }
+  }
+
+  /**
+   * initWallet - Create / Restore wallet.
+   *
+   * @param {object} payload Payload
+   * @returns {Promise} Promise that resolves after creating wallet and connecting to the Lightning interface.
+   */
+  async initWallet(payload) {
+    try {
+      const TIMEOUT = 1000 * 60
+      const { grpc } = this
+      await promiseTimeout(TIMEOUT, grpc.services.WalletUnlocker.initWallet(payload))
+      return await promiseTimeout(TIMEOUT, grpc.activateLightning())
+    } catch (e) {
+      grpcLog.debug(`Error when trying to create wallet: %o`, e)
       throw e
     }
   }


### PR DESCRIPTION
## Description:

Following a recent update to the node-lnd-grpc package `activateLightning` must now be manually called after creating a new wallet.

Update our createWallet action to properly handle this.

## Motivation and Context:

Fix bug where wallet hangs on `creating wallet` indefinitely after successfully creating a new wallet.

## How Has This Been Tested?

Manually

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
