### PR TITLE
fix(ui): ensure active wallet is set early

### DIFF
--- a/renderer/reducers/lnd.js
+++ b/renderer/reducers/lnd.js
@@ -274,8 +274,6 @@ export const stopLnd = () => async (dispatch, getState) => {
  * (lnd wallet is connected and unlocked)
  */
 export const setLightningGrpcActive = () => async (dispatch, getState) => {
-  dispatch({ type: LND_LIGHTNING_GRPC_ACTIVE })
-
   // Fetch key info from lnd as early as possible.
   dispatch(fetchInfo())
   dispatch(fetchBalance())
@@ -292,6 +290,8 @@ export const setLightningGrpcActive = () => async (dispatch, getState) => {
   }
 
   await dispatch(setActiveWallet(walletId))
+
+  dispatch({ type: LND_LIGHTNING_GRPC_ACTIVE })
 }
 
 /**


### PR DESCRIPTION
## Description:

In order to effectively render the wallet we must know which wallet is being rendered (which wallet is the active wallet). This chance ensures that we set the current active wallet before registering that the lnd gRPC Lightning interface has been successfully connected to, since this is the trigger that use for redirecting between the onboarding process and the wallet screen.

## Motivation and Context:

Random crash when connecting to 

```
Uncaught TypeError: Cannot read property 'type' of undefined
    at SettingsMenu (SettingsMenu.js?addf:82)
    at renderWithHooks (react-dom.development.js:12939)
    at mountIndeterminateComponent (react-dom.development.js:15021)
    at beginWork (react-dom.development.js:15626)
    at performUnitOfWork (react-dom.development.js:19313)
    at workLoop (react-dom.development.js:19353)
```

## How Has This Been Tested?

Conceptually the change should work, however it's hard to test as can not recreate issue. But, have verified that this change doesn't break anything and that the app works as it did prior to the change.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
