### PR TITLE
fix(ui): ensure sidebar/main sizes respected

### DIFF
--- a/renderer/components/UI/MainContent.js
+++ b/renderer/components/UI/MainContent.js
@@ -14,8 +14,8 @@ const MainContent = props => (
       height: 100%;
       overflow-y: overlay;
       overflow-x: hidden;
+      flex: 1;
     `}
-    width={1}
     {...props}
   />
 )

--- a/renderer/components/UI/Modal.js
+++ b/renderer/components/UI/Modal.js
@@ -20,7 +20,7 @@ const ModalHeader = styled(Flex)`
   top: 0;
   left: 0;
   right: 0;
-  z-index: 1;
+  z-index: 2;
   pointer-events: none;
 `
 

--- a/renderer/components/UI/Sidebar.js
+++ b/renderer/components/UI/Sidebar.js
@@ -5,6 +5,7 @@ import { Flex } from 'rebass'
 const SidebarBox = styled(Flex)`
   overflow: hidden;
   box-shadow: 0 2px 24px 0 rgba(0, 0, 0, 0.5);
+  z-index: 1;
 `
 
 const Sidebar = ({ ...props }) => (

--- a/renderer/components/UI/Sidebar.js
+++ b/renderer/components/UI/Sidebar.js
@@ -14,13 +14,13 @@ const Sidebar = ({ ...props }) => (
     bg="primaryColor"
     color="primaryText"
     flexDirection="column"
-    width={3 / 12}
+    width={4 / 12}
     {...props}
   />
 )
 
-Sidebar.small = props => <Sidebar {...props} width={4 / 16} />
-Sidebar.medium = props => <Sidebar {...props} width={5 / 16} />
+Sidebar.small = props => <Sidebar {...props} width={3 / 16} />
+Sidebar.medium = props => <Sidebar {...props} width={4 / 16} />
 Sidebar.large = props => <Sidebar {...props} width={6 / 16} />
 
 Sidebar.small.displayName = 'Sidebar Small'

--- a/test/unit/components/UI/__snapshots__/MainContent.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/MainContent.spec.js.snap
@@ -3,14 +3,15 @@
 exports[`component.UI.MainContent should render correctly 1`] = `
 .c0 {
   box-sizing: border-box;
-  width: 100%;
   height: 100%;
   overflow-y: overlay;
   overflow-x: hidden;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 }
 
 <article
   className="c0"
-  width={1}
 />
 `;

--- a/test/unit/components/UI/__snapshots__/Modal.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Modal.spec.js.snap
@@ -54,7 +54,7 @@ exports[`component.UI.Modal should render correctly 1`] = `
   top: 0;
   left: 0;
   right: 0;
-  z-index: 1;
+  z-index: 2;
   pointer-events: none;
 }
 

--- a/test/unit/components/UI/__snapshots__/Sidebar.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Sidebar.spec.js.snap
@@ -15,6 +15,7 @@ exports[`component.UI.Sidebar should render correctly 1`] = `
   flex-direction: column;
   overflow: hidden;
   box-shadow: 0 2px 24px 0 rgba(0,0,0,0.5);
+  z-index: 1;
 }
 
 <aside

--- a/test/unit/components/UI/__snapshots__/Sidebar.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Sidebar.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`component.UI.Sidebar should render correctly 1`] = `
 .c0 {
   box-sizing: border-box;
-  width: 25%;
+  width: 33.33333333333333%;
   color: primaryText;
   background-color: primaryColor;
   display: -webkit-box;
@@ -21,6 +21,6 @@ exports[`component.UI.Sidebar should render correctly 1`] = `
 <aside
   className="c0"
   color="primaryText"
-  width={0.25}
+  width={0.3333333333333333}
 />
 `;


### PR DESCRIPTION
## Description:

Ensure sidebar/main sizes respected

## Motivation and Context:

This fixes a glitch in the `Sidebar` & `MainContent` components which manifests when trying to position a sidebar on the right side of the main content area or when trying to use sidebars with different widths. Previously, with the sidebar positioned on the right it would display over the top of the modal close button. Also, sidebar width was not being properly applied.

## How Has This Been Tested?

Manually

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
