### PR TITLE
fix(wallet): fix LN fee estimates and add 1 sat buffer to fee limits

### DIFF
--- a/renderer/reducers/pay.js
+++ b/renderer/reducers/pay.js
@@ -98,7 +98,7 @@ export const queryRoutes = (pubKey, amount) => async dispatch => {
   dispatch({ type: QUERY_ROUTES, pubKey })
   try {
     const grpc = await grpcService
-    const routes = await grpc.services.Lightning.queryRoutes({ pub_key: pubKey, amt: amount })
+    const { routes } = await grpc.services.Lightning.queryRoutes({ pub_key: pubKey, amt: amount })
     dispatch({ type: QUERY_ROUTES_SUCCESS, routes })
   } catch (e) {
     dispatch({ type: QUERY_ROUTES_FAILURE })

--- a/utils/crypto.js
+++ b/utils/crypto.js
@@ -181,7 +181,10 @@ export const getMinFee = (routes = []) => {
   if (!routes || !routes.length) {
     return null
   }
-  return routes.reduce((min, b) => Math.min(min, b.total_fees), routes[0].total_fees)
+  const fee = routes.reduce((min, b) => Math.min(min, b.total_fees), routes[0].total_fees)
+
+  // Add one to the fee to add room for accuracy error when using as a fee limit.
+  return fee + 1
 }
 
 /**
@@ -194,7 +197,10 @@ export const getMaxFee = routes => {
   if (!routes || !routes.length) {
     return null
   }
-  return routes.reduce((max, b) => Math.max(max, b.total_fees), routes[0].total_fees)
+  const fee = routes.reduce((max, b) => Math.max(max, b.total_fees), routes[0].total_fees)
+
+  // Add one to the fee to add room for accuracy error when using as a fee limit.
+  return fee + 1
 }
 
 /**


### PR DESCRIPTION
## Description:

Ensure routes extract from queryroutes and add add 1 sat buffer to fee limits

## Motivation and Context:

Route information is not being correctly extracted from `queryroutes`, so ln fee estimations are not working.

Additionally, ensure that the fee limits that we apply are 1 sat larger than estimates returned by query routes. This provides a buffer incase the actual fee is over the estimated sat limit by some msats.

## How Has This Been Tested?

Manually

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
