### PR TITLE
fix: use correct crypto unit names based on network

### DIFF
--- a/renderer/components/UI/CurrencyFieldGroup.js
+++ b/renderer/components/UI/CurrencyFieldGroup.js
@@ -101,6 +101,7 @@ const CurrencyFieldGroup = React.forwardRef(
               ml={2}
               mt={40}
               onChange={handleCryptoCurrencyChange}
+              valueField="name"
             />
           </Flex>
           <Flex justifyContent="center" mt={42} width={1 / 11}>

--- a/renderer/components/UI/Dropdown.js
+++ b/renderer/components/UI/Dropdown.js
@@ -96,7 +96,7 @@ MenuItemText.defaultProps = {
  * MenuItem
  */
 export const MenuItem = withTheme(
-  ({ item, onClick, active, theme, hasParent, hasChildren, ...rest }) => (
+  ({ item, onClick, active, theme, hasParent, hasChildren, valueField, ...rest }) => (
     <MenuItemText key={item.key} onClick={() => onClick(item.key)} {...rest}>
       <Flex alignItems="center" pr={2}>
         {hasParent && (
@@ -109,7 +109,7 @@ export const MenuItem = withTheme(
             {active && <Check height="0.95em" />}
           </Text>
         )}
-        <Text mr={2}>{item.value}</Text>
+        <Text mr={2}>{item[valueField]}</Text>
 
         <Flex alignItems="center" color="gray" justifyContent="flex-end" ml="auto" width="20px">
           {hasChildren && <AngleRight height="8px" />}
@@ -120,7 +120,18 @@ export const MenuItem = withTheme(
 )
 
 const Dropdown = injectIntl(
-  ({ activeKey, intl, items, justify, theme, buttonOpacity, onChange, messageMapper, ...rest }) => {
+  ({
+    activeKey,
+    intl,
+    items,
+    justify,
+    theme,
+    buttonOpacity,
+    onChange,
+    messageMapper,
+    valueField,
+    ...rest
+  }) => {
     // State to track dropdown open state.
     const [isOpen, setIsOpen] = useState(false)
     const toggleMenu = () => setIsOpen(!isOpen)
@@ -133,7 +144,7 @@ const Dropdown = injectIntl(
     let itemsArray = items.map(item => {
       if (typeof item === 'string') {
         return {
-          value: item,
+          [valueField]: item,
           key: item,
         }
       }
@@ -170,7 +181,7 @@ const Dropdown = injectIntl(
                 mr={1}
                 textAlign="left"
               >
-                {selectedItem ? selectedItem.value : activeKey}{' '}
+                {selectedItem ? selectedItem[valueField] : activeKey}{' '}
               </Text>
               <Flex color="gray">
                 {isOpen ? <AngleUp width="0.6em" /> : <AngleDown width="0.6em" />}
@@ -187,6 +198,7 @@ const Dropdown = injectIntl(
                       active={activeKey === item.key}
                       item={item}
                       onClick={() => handleClick(item.key)}
+                      valueField={valueField}
                     />
                   )
                 })}
@@ -199,6 +211,10 @@ const Dropdown = injectIntl(
   }
 )
 
+Dropdown.defaultProps = {
+  valueField: 'value',
+}
+
 Dropdown.propTypes = {
   activeKey: PropTypes.string.isRequired,
   buttonOpacity: PropTypes.number,
@@ -206,6 +222,7 @@ Dropdown.propTypes = {
   justify: PropTypes.string,
   onChange: PropTypes.func,
   theme: PropTypes.object.isRequired,
+  valueField: PropTypes.string,
 }
 
 export default withTheme(Dropdown)

--- a/renderer/containers/UI/CryptoSelector.js
+++ b/renderer/containers/UI/CryptoSelector.js
@@ -5,6 +5,7 @@ import { tickerSelectors, setCryptoUnit } from 'reducers/ticker'
 const mapStateToProps = state => ({
   activeKey: tickerSelectors.cryptoUnit(state),
   items: tickerSelectors.cryptoUnits(state),
+  valueField: 'name',
 })
 
 const mapDispatchToProps = {

--- a/renderer/reducers/ticker.js
+++ b/renderer/reducers/ticker.js
@@ -205,7 +205,7 @@ tickerSelectors.cryptoAddressName = createSelector(
     // assume first entry is as a currency ticker name (e.g BTC, LTC etc)
     const [selectedUnit] = cryptoUnits
     if (selectedUnit) {
-      return selectedUnit.value
+      return selectedUnit.name
     }
     // fallback in case something is very wrong
     return chain
@@ -218,7 +218,7 @@ tickerSelectors.cryptoUnitName = createSelector(
   (unit, cryptoUnits = []) => {
     const selectedUnit = cryptoUnits.find(c => c.key === unit)
     if (selectedUnit) {
-      return selectedUnit.value
+      return selectedUnit.name
     }
     // fallback in case something is very wrong
     return unit


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Currently, when switching between mainnet and testnet wallets at some point wrong units are displayed in the UI (BTC instead of tBTC etc. for the testnet wallets)
<!--- Describe your changes in detail -->


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually. Switch between wallets that use different networks
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes:
Bugfix
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
