### PR TITLE
fix(docs): change npm to yarn in advanced usage docs

### DIFF
--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -14,7 +14,7 @@
 
 To compile the Zap wallet, you will need:
 
-- **[Node.js version >= 8](https://nodejs.org)** and **[npm version >= 5](https://www.npmjs.com)**
+- **[Node.js version >= 12](https://nodejs.org)** and **[npm version >= 5](https://www.npmjs.com)**
 - **[yarn](https://yarnpkg.com/lang/en/docs/install/)**
 
 ### Downloading Zap
@@ -53,8 +53,8 @@ To setup your own `lnd` for use with Zap please follow the instructions on the [
 To test that everything has been installed correctly:
 
 ```bash
-npm run build
-npm run test
+yarn build
+yarn test
 ```
 
 ### Running
@@ -62,7 +62,7 @@ npm run test
 To run Zap in development mode:
 
 ```bash
-npm run dev
+yarn && yarn dev
 ```
 
 ### Linting
@@ -70,7 +70,7 @@ npm run dev
 To check linting:
 
 ```bash
-npm run lint
+yarn lint
 ```
 
 ### Debugging


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:

Update `Advanced Usage` docs to use `yarn` instead of `npm`

## Motivation and Context:

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes:

- changed usage of `npm` to `yarn`
- updated node version to `>= 12`

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have reviewed and updated the documentation accordingly.
- [ ] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [ ] My commits have been squashed into a concise set of changes.
