### PR TITLE
perf: simplify activity list renderer

### DIFF
--- a/renderer/components/Activity/Activity.js
+++ b/renderer/components/Activity/Activity.js
@@ -1,8 +1,8 @@
-import React, { Component } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { space } from 'styled-system'
-import { List, AutoSizer, CellMeasurer, CellMeasurerCache } from 'react-virtualized'
+import { List, AutoSizer } from 'react-virtualized'
 import { FormattedDate, injectIntl, intlShape } from 'react-intl'
 import { Box } from 'rebass'
 import { Bar, Heading, Panel } from 'components/UI'
@@ -11,74 +11,61 @@ import ActivityListItem from './ActivityListItem'
 import ErrorDetailsDialog from './ErrorDetailsDialog'
 import messages from './messages'
 
+const ROW_HEIGHT = 53
+
 const StyledList = styled(List)`
   ${space}
   outline: none;
   padding-left: 12px;
 `
 
-class Activity extends Component {
-  cache = new CellMeasurerCache({
-    fixedWidth: true,
-    minHeight: 52,
-  })
+const Activity = props => {
+  const {
+    isErrorDialogOpen,
+    hideErrorDetailsDialog,
+    errorDialogDetails,
+    currentActivity,
+    showNotification,
+    intl,
+  } = props
 
-  componentDidUpdate() {
-    // update list since item heights might have changed
-    this.updateList()
-  }
-
-  updateList = () => {
-    this.cache.clearAll()
-    this._list && this._list.recomputeRowHeights(0)
-  }
-
-  onListResize = ({ width }) => {
-    // only invalidate row measurement cache if width has actually changed
-    if (this._prevListWidth != width) {
-      this.updateList()
-    }
-    this._prevListWidth = width
-  }
-
-  onErrorDetailsCopy = () => {
-    const { showNotification, intl } = this.props
+  const onErrorDetailsCopy = () => {
     showNotification(intl.formatMessage({ ...messages.error_copied }))
   }
 
-  renderActivityList = () => {
-    let { currentActivity } = this.props
-
-    const renderRow = ({ index, key, style, parent }) => {
+  const renderActivityList = () => {
+    /**
+     * renderRow - renders react virtualized row.
+     *
+     * @param {*} { index, key, style, parent }
+     */
+    // eslint-disable-next-line react/prop-types
+    const renderRow = ({ index, key, style }) => {
       const item = currentActivity[index]
       return (
-        <CellMeasurer key={key} cache={this.cache} columnIndex={0} parent={parent} rowIndex={index}>
-          <div style={style}>
-            {item.title ? (
-              <Box mt={4} pl={4}>
-                <Heading.h4 fontWeight="normal">
-                  <FormattedDate day="2-digit" month="short" value={item.title} year="numeric" />
-                </Heading.h4>
-                <Bar my={1} />
-              </Box>
-            ) : (
-              <ActivityListItem activity={currentActivity[index]} />
-            )}
-          </div>
-        </CellMeasurer>
+        <div key={key} style={style}>
+          {item.title ? (
+            <Box mt={4} pl={4}>
+              <Heading.h4 fontWeight="normal">
+                <FormattedDate day="2-digit" month="short" value={item.title} year="numeric" />
+              </Heading.h4>
+              <Bar my={1} />
+            </Box>
+          ) : (
+            <ActivityListItem activity={currentActivity[index]} />
+          )}
+        </div>
       )
     }
     return (
-      <AutoSizer onResize={this.onListResize}>
+      <AutoSizer>
         {({ width, height }) => {
           return (
             <StyledList
-              ref={ref => (this._list = ref)}
-              deferredMeasurementCache={this.cache}
               height={height}
               pr={4}
               rowCount={currentActivity.length}
-              rowHeight={this.cache.rowHeight}
+              rowHeight={ROW_HEIGHT}
               rowRenderer={renderRow}
               width={width}
             />
@@ -88,28 +75,24 @@ class Activity extends Component {
     )
   }
 
-  render() {
-    const { isErrorDialogOpen, hideErrorDetailsDialog, errorDialogDetails } = this.props
-
-    return (
-      <Panel>
-        <Panel.Header my={3} px={4}>
-          <ActivityActions />
-        </Panel.Header>
-        <Panel.Body>
-          <>
-            {this.renderActivityList()}
-            <ErrorDetailsDialog
-              error={errorDialogDetails}
-              isOpen={isErrorDialogOpen}
-              onClose={hideErrorDetailsDialog}
-              onCopy={this.onErrorDetailsCopy}
-            />
-          </>
-        </Panel.Body>
-      </Panel>
-    )
-  }
+  return (
+    <Panel>
+      <Panel.Header my={3} px={4}>
+        <ActivityActions />
+      </Panel.Header>
+      <Panel.Body>
+        <>
+          {renderActivityList()}
+          <ErrorDetailsDialog
+            error={errorDialogDetails}
+            isOpen={isErrorDialogOpen}
+            onClose={hideErrorDetailsDialog}
+            onCopy={onErrorDetailsCopy}
+          />
+        </>
+      </Panel.Body>
+    </Panel>
+  )
 }
 
 Activity.propTypes = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Simplify the activity list rendering and improve performance.
<!--- Describe your changes in detail -->

## Motivation and Context:
#2584 introduced uniform height for activity items, allowing us to get rid of react-virtualized `CellMeasureer` infrastructure and speed up rendering
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually. 5000 tx node strikes again
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes:
Perf improvement
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
