### PR TITLE
fix(lnd): increase autopilot minconfs to 1

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -50,7 +50,7 @@ module.exports = {
       minchansize: 20000,
       maxchansize: 16777215,
       allocation: 0.6,
-      minconfs: 0,
+      minconfs: 1,
       heuristics: {
         externalscore: 0.95,
         preferential: 0.05,

--- a/stories/containers/home.stories.js
+++ b/stories/containers/home.stories.js
@@ -17,7 +17,7 @@ const wallets = [
     autopilotMaxchannels: 5,
     autopilotMaxchansize: 16777215,
     autopilotMinchansize: 20000,
-    autopilotMinconfs: 0,
+    autopilotMinconfs: 1,
     autopilotPrivate: true,
     chain: 'bitcoin',
     network: 'testnet',


### PR DESCRIPTION
## Description:

This prevents spending unconfirmed funds by default. Ref https://github.com/lightningnetwork/lnd/issues/3341

## Motivation and Context:

fix #2591
fix #2531

## How Has This Been Tested?

Manually

## Types of changes:

Fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
