### PR TITLE
build: remove .deb linux target

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ Once you have the .exe file downloaded, simply **double click** on the file.
 
 ### Linux
 
-Once you have the .AppImage file extracted, you can either **double click** the file or by running in the cli:
+Once you have the .AppImage file downloaded you must [make the file executable](https://docs.appimage.org/user-guide/run-appimages.html).
+
+Once executible you can run either **double click** the file or run via the cli:
 
 ```bash
 ./file.AppImage

--- a/README.md
+++ b/README.md
@@ -56,36 +56,6 @@ Once you have the .exe file downloaded, simply **double click** on the file.
 
 ### Linux
 
-Once you have the .zip file downloaded, simply **double click** the file to unzip or run the following command:
-
-```bash
-unzip file.zip
-```
-
-You have the option to either install Zap through the [.deb](#.deb-file) or [.AppImage](#.appimage-file) files.
-
-#### .deb File
-
-Once you have the .deb file extracted, you can install Zap by **double clicking** on the file or through the `dpkg` command:
-
-```bash
-sudo dpkg -i file.deb
-```
-
-If this is your first time installing zap, you may have some unmet dependencies. This can be resolved with the following command:
-
-```bash
-sudo apt-get -f install
-```
-
-To run Zap you can either navigate through the GUI or run the following command:
-
-```bash
-zap-desktop
-```
-
-#### .AppImage File
-
 Once you have the .AppImage file extracted, you can either **double click** the file or by running in the cli:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -150,13 +150,6 @@
       "icon": "resources/linux",
       "target": [
         {
-          "target": "deb",
-          "arch": [
-            "x64",
-            "ia32"
-          ]
-        },
-        {
           "target": "AppImage",
           "arch": [
             "x64",
@@ -168,7 +161,6 @@
         "Comment": "Zap - Lightning wallet",
         "Icon": "zap",
         "Name": "Zap",
-        "Path": "/opt/zap",
         "StartupNotify": "true",
         "Terminal": "false",
         "Type": "Application",


### PR DESCRIPTION
## Description:

Remove .deb linux target

## Motivation and Context:

Currently we distribute both a `.deb` file and a `.AppImage` file for linux. This is unnecessary and there are a couple of issues with this:

1) AppImage is already supported on Debian based distributions, so we are offering a redundant choice to users.
2) AppImage is supported in many more places than `.deb` files (in addition to all the places where .deb files run) so the .deb offers nothing over and above the AppImage
3) Linux users have 4 downloadable assets to choose from on our releases. It bloats the releases page and makes it look intimidating. There is no reason for users to choose - they can just run the AppImage file.
4) Increased maintenance effort to test both .deb and .AppImage releases.
5) Increased build times to build multiple linux targets.


## How Has This Been Tested?

`yarn build --linux`

## Types of changes:

Build system

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
