### PR TITLE
fix(ui): improve channel list hamburger icon

### DIFF
--- a/icons/layout-list.svg
+++ b/icons/layout-list.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-    <g fill="currentColor" fill-rule="evenodd" stroke="currentColor">
-        <path d="M.5.5h15v1H.5zM.5 5.5h15v1H.5zM.5 10.5h15v1H.5zM.5 15.5h15v1H.5z"/>
-    </g>
+  <g fill="currentColor" fill-rule="evenodd" stroke="currentColor">
+    <path d="M.5.5h15v1H.5v-1zm0 4.672h15v1H.5v-1zm0 4.668h15v1H.5v-1zm0 4.672h15v1H.5v-1z"/>
+  </g>
 </svg>

--- a/renderer/components/Icon/LayoutList.js
+++ b/renderer/components/Icon/LayoutList.js
@@ -3,7 +3,7 @@ import React from 'react'
 const SvgLayoutList = props => (
   <svg height="1em" viewBox="0 0 16 16" width="1em" {...props}>
     <path
-      d="M.5.5h15v1H.5zm0 5h15v1H.5zm0 5h15v1H.5zm0 5h15v1H.5z"
+      d="M.5.5h15v1H.5v-1zm0 4.672h15v1H.5v-1zm0 4.668h15v1H.5v-1zm0 4.672h15v1H.5v-1z"
       fill="currentColor"
       fillRule="evenodd"
       stroke="currentColor"


### PR DESCRIPTION
## Description:

Ensure that the hamburger icon is not cut off at the bottom.

## Motivation and Context:

fix #2656

## How Has This Been Tested?

Manually

## Screenshots:

**Before:**

![image](https://user-images.githubusercontent.com/200251/62206127-0195d980-b389-11e9-8a50-8542be1bd2e3.png)

**After:**

![image](https://user-images.githubusercontent.com/200251/62206092-ee830980-b388-11e9-9db4-059e73277925.png)


## Types of changes:

UI fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
