### PR TITLE
fix(ui): remove gaps in pay/request form help text

### DIFF
--- a/renderer/components/Pay/Pay.js
+++ b/renderer/components/Pay/Pay.js
@@ -434,14 +434,12 @@ class Pay extends React.Component {
           show &&
           (styles => (
             <animated.div style={styles}>
-              <Box mb={4}>
-                <Text textAlign="justify">
-                  <FormattedMessage
-                    {...messages.description}
-                    values={{ chain: chainName, ticker: cryptoUnitName }}
-                  />
-                </Text>
-              </Box>
+              <Text mb={4}>
+                <FormattedMessage
+                  {...messages.description}
+                  values={{ chain: chainName, ticker: cryptoUnitName }}
+                />
+              </Text>
             </animated.div>
           ))
         }

--- a/renderer/components/Request/Request.js
+++ b/renderer/components/Request/Request.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Box, Flex } from 'rebass'
+import { Flex } from 'rebass'
 import { FormattedMessage, injectIntl, intlShape } from 'react-intl'
 import {
   Bar,
@@ -125,14 +125,12 @@ class Request extends React.Component {
   renderHelpText = () => {
     const { chainName, cryptoUnitName } = this.props
     return (
-      <Box mb={4}>
-        <Text textAlign="justify">
-          <FormattedMessage
-            {...messages.description}
-            values={{ chain: chainName, ticker: cryptoUnitName }}
-          />
-        </Text>
-      </Box>
+      <Text mb={4}>
+        <FormattedMessage
+          {...messages.description}
+          values={{ chain: chainName, ticker: cryptoUnitName }}
+        />
+      </Text>
     )
   }
 


### PR DESCRIPTION
## Description:

Left align help text in Pay and Request forms in order to prevent strange looking gaps in the text at certain screen sizes.

## Motivation and Context:

fix #2655

## How Has This Been Tested?

Manually

## Types of changes:

UI Fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
