### PR TITLE
refactor: remove unused 386 lnd build targets

### DIFF
--- a/scripts/lnd-release/.goreleaser.yml
+++ b/scripts/lnd-release/.goreleaser.yml
@@ -6,7 +6,6 @@ builds:
       - windows
     goarch:
       - amd64
-      - '386'
     binary: lnd
     main: ./cmd/lnd
     ldflags:
@@ -20,7 +19,6 @@ builds:
       - windows
     goarch:
       - amd64
-      - '386'
     binary: lncli
     main: ./cmd/lncli
     ldflags:


### PR DESCRIPTION
## Description:

This just updates our lnd build script to remove the 386 targets which we are no longer using.

## Motivation and Context:

Clean up

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
