### PR TITLE
fix(ui): disable delete wallet button in launching state

### DIFF
--- a/renderer/components/Home/WalletLauncher.js
+++ b/renderer/components/Home/WalletLauncher.js
@@ -425,7 +425,13 @@ class WalletLauncher extends React.Component {
               <Bar my={2} />
 
               <Flex justifyContent="center" my={4}>
-                <Button onClick={this.handleDelete} size="small" type="button" variant="danger">
+                <Button
+                  isDisabled={isStartingLnd || isNeutrinoRunning}
+                  onClick={this.handleDelete}
+                  size="small"
+                  type="button"
+                  variant="danger"
+                >
                   <FormattedMessage {...messages.delete_wallet_button_text} />
                 </Button>
               </Flex>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Not only it doesn't make sense to delete wallet while it's launching, but it doing so can cause weird bugs. This PR makes `delete wallet` button to be disabled while the wallet is in the launching state
<!--- Describe your changes in detail -->


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes:
Bugfix/Enhancement
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
