### PR TITLE
fix(channels): ensure csv_delay property is defined before returning it

### DIFF
--- a/renderer/containers/Channels/ChannelCloseDialog.js
+++ b/renderer/containers/Channels/ChannelCloseDialog.js
@@ -11,7 +11,7 @@ const isForceCloseDialog = state => {
 
 const csvDelay = state => {
   const selectedChannel = channelsSelectors.selectedChannel(state)
-  return selectedChannel ? selectedChannel.csv_delay : 0
+  return selectedChannel && selectedChannel.csv_delay ? selectedChannel.csv_delay : 0
 }
 
 const mapStateToProps = state => {


### PR DESCRIPTION
Pretty straightforward change which just makes sure csv_delay property exists in the channel object before returning it.

## Motivation and Context:

Addresses #2692 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
