### PR TITLE
fix: ensure timeout is cleared asap in promiseTimeout

### DIFF
--- a/utils/promiseTimeout.js
+++ b/utils/promiseTimeout.js
@@ -3,19 +3,20 @@
  *
  * @param {number} ms Timeout (ms)
  * @param {Promise} promise Promise to timeout
+ * @param {string} message messaged passed to the reject promise
  * @returns {Promise} Promise that rejects in <ms> milliseconds
  */
-const promiseTimeout = function(ms, promise) {
+export default function(ms, promise, message = 'Timed out') {
   // Create a promise that rejects in <ms> milliseconds
-  let timeout = new Promise((resolve, reject) => {
-    let id = setTimeout(() => {
-      clearTimeout(id)
-      reject(`Timed out.`)
-    }, ms)
+  let timerId
+
+  const timeout = new Promise((resolve, reject) => {
+    timerId = setTimeout(() => reject(new Error(message)), ms)
   })
-
+  const clearTimer = value => {
+    timerId && clearTimeout(timerId)
+    return value
+  }
   // Returns a race between our timeout and the passed in promise
-  return Promise.race([promise, timeout])
+  return Promise.race([promise, timeout]).then(clearTimer, clearTimer)
 }
-
-export default promiseTimeout


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Fixes corner case with `promiseTimeout` which prevents node.js process from exiting because of hanging timeout. This PR ensures timeout is cleared as soon as promise race resolves
<!--- Describe your changes in detail -->


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes:
Bugfix
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
