### PR TITLE
fix(wallet): properly validate msat invoices

### DIFF
--- a/renderer/components/UI/LightningInvoiceInput.js
+++ b/renderer/components/UI/LightningInvoiceInput.js
@@ -48,7 +48,7 @@ class LightningInvoiceInput extends React.Component {
       if (invoiceIsLn) {
         try {
           const invoice = decodePayReq(value)
-          if (!invoice || (!invoice.satoshis || !invoice.millisatoshis)) {
+          if (!invoice || (!invoice.satoshis && !invoice.millisatoshis)) {
             throw new Error('Invalid invoice')
           }
         } catch (e) {


### PR DESCRIPTION
## Description:

properly validate msat invoices

## Motivation and Context:

Invoices that only contain an msat amount are not validating in the pay form

## How Has This Been Tested?

Create an invoice on the blockstream store and try to pay it.

## Types of changes:

Fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
