### PR TITLE
fix(ui): make sure QR code is centered perfectly

### DIFF
--- a/renderer/components/UI/QRCode.js
+++ b/renderer/components/UI/QRCode.js
@@ -57,9 +57,11 @@ const BottomRight = styled(CornerCard)`
 const CodeWrapper = styled(Box)`
   border-style: solid;
   border-color: white;
+  display: inline-flex;
   position: absolute;
-  top: calc(10% - 2px);
-  left: calc(10% - 2px);
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   filter: ${props => (props.isObfuscated ? 'blur(3px)' : 'none')};
   transition: ${props => (props.isObfuscated ? 'none' : 'all 0.5s ease')};
 `
@@ -80,9 +82,6 @@ const Code = styled(QRCode)`
   border-style: solid;
   border-color: white;
   border-width: 8px;
-  position: absolute;
-  top: calc(10% - 2px);
-  left: calc(10% - 2px);
 `
 
 /**

--- a/test/unit/components/UI/__snapshots__/QRCode.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/QRCode.spec.js.snap
@@ -92,9 +92,16 @@ exports[`component.UI.QRCode should render correctly 1`] = `
   box-sizing: border-box;
   border-style: solid;
   border-color: white;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   position: absolute;
-  top: calc(10% - 2px);
-  left: calc(10% - 2px);
+  top: 50%;
+  left: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
   -webkit-filter: none;
   filter: none;
   -webkit-transition: all 0.5s ease;
@@ -122,9 +129,6 @@ exports[`component.UI.QRCode should render correctly 1`] = `
   border-style: solid;
   border-color: white;
   border-width: 8px;
-  position: absolute;
-  top: calc(10% - 2px);
-  left: calc(10% - 2px);
 }
 
 <div


### PR DESCRIPTION
Made sure QR code is always centered perfectly using some CSS magic.

## Motivation and Context:

Fixes #2700

## How Has This Been Tested?

Manually and unit tests.

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
