### PR TITLE
fix(app): disable app downgrade feature

### DIFF
--- a/electron/updater.js
+++ b/electron/updater.js
@@ -59,8 +59,8 @@ class ZapUpdater {
   configure(settings) {
     Object.assign(this.settings, settings)
 
-    autoUpdater.allowDowngrade = false
     autoUpdater.channel = this.settings.channel
+    autoUpdater.allowDowngrade = false
   }
 
   /**


### PR DESCRIPTION
## Description:

Ensure that we set electron-updater `allowDowngrade=false` after setting the update channel, since `autoUpdater.channel` is a setter which explicitly sets `allowDowngrade=true`.

See https://github.com/electron-userland/electron-builder/blob/v20.41.0/packages/electron-updater/src/AppUpdater.ts#L73-L91

## Motivation and Context:

If you try to run a yet unreleased version of the app, it constantly tries to download the previous version of the app.

## How Has This Been Tested?

Manually

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
