### PR TITLE
fix(autopay): correctly apply blue theme overrides

### DIFF
--- a/renderer/components/Autopay/Autopay.js
+++ b/renderer/components/Autopay/Autopay.js
@@ -12,7 +12,7 @@ import AutopayActions from './AutopayActions'
 import messages from './messages'
 
 const customiseTheme = theme => {
-  return createThemeVariant('autopilot', {
+  return createThemeVariant('autopay', {
     colors: {
       ...theme.colors,
       lightningOrange: palette.superBlue,

--- a/renderer/components/Autopay/Autopay.js
+++ b/renderer/components/Autopay/Autopay.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { ThemeProvider } from 'styled-components'
-import { Panel, Heading } from 'components/UI'
 import { FormattedMessage } from 'react-intl'
+import { Panel, Heading } from 'components/UI'
 import AutopayList from 'containers/Autopay/AutopayList'
 import AutopayMerchantList from 'containers/Autopay/AutopayMerchantList'
 import AutopayCreateModal from 'containers/Autopay/AutopayCreateModal'
@@ -13,8 +13,10 @@ import messages from './messages'
 
 const customiseTheme = theme => {
   return createThemeVariant('autopilot', {
-    ...theme.colors,
-    lightningOrange: palette.superBlue,
+    colors: {
+      ...theme.colors,
+      lightningOrange: palette.superBlue,
+    },
   })
 }
 


### PR DESCRIPTION
## Description:

Correctly apply blue theme overrides

## Motivation and Context:

App crashes when trying to access autopay feature.

## How Has This Been Tested?

Enable autopay feature and try to navigate to that part of the wallet ui.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
