### PR TITLE
fix(i18n): add missing memo translation

### DIFF
--- a/renderer/components/Activity/PaymentModal/messages.js
+++ b/renderer/components/Activity/PaymentModal/messages.js
@@ -8,4 +8,5 @@ export default defineMessages({
   fee: 'Total fee',
   current_value: 'Current value',
   preimage: 'Payment preimage',
+  memo: 'Memo',
 })

--- a/translations/af-ZA.json
+++ b/translations/af-ZA.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "",
   "components.Activity.PaymentModal.date_sent": "",
   "components.Activity.PaymentModal.fee": "",
+  "components.Activity.PaymentModal.memo": "",
   "components.Activity.PaymentModal.preimage": "",
   "components.Activity.PaymentModal.subtitle": "",
   "components.Activity.PaymentModal.title_sent": "",

--- a/translations/ar-SA.json
+++ b/translations/ar-SA.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "",
   "components.Activity.PaymentModal.date_sent": "",
   "components.Activity.PaymentModal.fee": "",
+  "components.Activity.PaymentModal.memo": "",
   "components.Activity.PaymentModal.preimage": "",
   "components.Activity.PaymentModal.subtitle": "",
   "components.Activity.PaymentModal.title_sent": "",

--- a/translations/bg-BG.json
+++ b/translations/bg-BG.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "",
   "components.Activity.PaymentModal.date_sent": "",
   "components.Activity.PaymentModal.fee": "Такса",
+  "components.Activity.PaymentModal.memo": "Бележка",
   "components.Activity.PaymentModal.preimage": "",
   "components.Activity.PaymentModal.subtitle": "",
   "components.Activity.PaymentModal.title_sent": "",

--- a/translations/ca-ES.json
+++ b/translations/ca-ES.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "",
   "components.Activity.PaymentModal.date_sent": "",
   "components.Activity.PaymentModal.fee": "",
+  "components.Activity.PaymentModal.memo": "",
   "components.Activity.PaymentModal.preimage": "",
   "components.Activity.PaymentModal.subtitle": "",
   "components.Activity.PaymentModal.title_sent": "",

--- a/translations/cs-CZ.json
+++ b/translations/cs-CZ.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "",
   "components.Activity.PaymentModal.date_sent": "",
   "components.Activity.PaymentModal.fee": "Poplatek",
+  "components.Activity.PaymentModal.memo": "Poznámka",
   "components.Activity.PaymentModal.preimage": "",
   "components.Activity.PaymentModal.subtitle": "",
   "components.Activity.PaymentModal.title_sent": "",

--- a/translations/da-DK.json
+++ b/translations/da-DK.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "Nuværende værdi",
   "components.Activity.PaymentModal.date_sent": "Dato sendt",
   "components.Activity.PaymentModal.fee": "Gebyr",
+  "components.Activity.PaymentModal.memo": "Notat",
   "components.Activity.PaymentModal.preimage": "Betalings Preimage",
   "components.Activity.PaymentModal.subtitle": "Lightning Betaling",
   "components.Activity.PaymentModal.title_sent": "Sendt",

--- a/translations/de-DE.json
+++ b/translations/de-DE.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "Aktueller Wert",
   "components.Activity.PaymentModal.date_sent": "Sendedatum",
   "components.Activity.PaymentModal.fee": "Gebühr",
+  "components.Activity.PaymentModal.memo": "Memo",
   "components.Activity.PaymentModal.preimage": "Zahlung Urbild",
   "components.Activity.PaymentModal.subtitle": "Lightning Zahlung",
   "components.Activity.PaymentModal.title_sent": "Gesendet",

--- a/translations/el-GR.json
+++ b/translations/el-GR.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "",
   "components.Activity.PaymentModal.date_sent": "",
   "components.Activity.PaymentModal.fee": "Αμοιβή",
+  "components.Activity.PaymentModal.memo": "Τιμολόγιο",
   "components.Activity.PaymentModal.preimage": "",
   "components.Activity.PaymentModal.subtitle": "",
   "components.Activity.PaymentModal.title_sent": "",

--- a/translations/en.json
+++ b/translations/en.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "Current value",
   "components.Activity.PaymentModal.date_sent": "Date sent",
   "components.Activity.PaymentModal.fee": "Total fee",
+  "components.Activity.PaymentModal.memo": "Memo",
   "components.Activity.PaymentModal.preimage": "Payment preimage",
   "components.Activity.PaymentModal.subtitle": "Lightning Payment",
   "components.Activity.PaymentModal.title_sent": "Sent",

--- a/translations/es-ES.json
+++ b/translations/es-ES.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "Valor actual",
   "components.Activity.PaymentModal.date_sent": "Fecha enviado",
   "components.Activity.PaymentModal.fee": "Comisión",
+  "components.Activity.PaymentModal.memo": "Memorándum",
   "components.Activity.PaymentModal.preimage": "Preimagen de Pago",
   "components.Activity.PaymentModal.subtitle": "Pago de Lightning",
   "components.Activity.PaymentModal.title_sent": "Enviado",

--- a/translations/fi-FI.json
+++ b/translations/fi-FI.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "",
   "components.Activity.PaymentModal.date_sent": "",
   "components.Activity.PaymentModal.fee": "",
+  "components.Activity.PaymentModal.memo": "",
   "components.Activity.PaymentModal.preimage": "",
   "components.Activity.PaymentModal.subtitle": "",
   "components.Activity.PaymentModal.title_sent": "",

--- a/translations/fr-FR.json
+++ b/translations/fr-FR.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "",
   "components.Activity.PaymentModal.date_sent": "Date d'envoi",
   "components.Activity.PaymentModal.fee": "Frais",
+  "components.Activity.PaymentModal.memo": "Note",
   "components.Activity.PaymentModal.preimage": "",
   "components.Activity.PaymentModal.subtitle": "Paiements Lightning",
   "components.Activity.PaymentModal.title_sent": "Envoyé",

--- a/translations/ga-IE.json
+++ b/translations/ga-IE.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "Luach reatha",
   "components.Activity.PaymentModal.date_sent": "Dáta a seoladh",
   "components.Activity.PaymentModal.fee": "Táille",
+  "components.Activity.PaymentModal.memo": "Meabhrán",
   "components.Activity.PaymentModal.preimage": "Preimage Íocaíochta",
   "components.Activity.PaymentModal.subtitle": "Íocaíocht Lightning",
   "components.Activity.PaymentModal.title_sent": "Seolta",

--- a/translations/he-IL.json
+++ b/translations/he-IL.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "",
   "components.Activity.PaymentModal.date_sent": "",
   "components.Activity.PaymentModal.fee": "עמלה",
+  "components.Activity.PaymentModal.memo": "תזכיר",
   "components.Activity.PaymentModal.preimage": "",
   "components.Activity.PaymentModal.subtitle": "",
   "components.Activity.PaymentModal.title_sent": "",

--- a/translations/hi-IN.json
+++ b/translations/hi-IN.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "",
   "components.Activity.PaymentModal.date_sent": "",
   "components.Activity.PaymentModal.fee": "",
+  "components.Activity.PaymentModal.memo": "",
   "components.Activity.PaymentModal.preimage": "",
   "components.Activity.PaymentModal.subtitle": "",
   "components.Activity.PaymentModal.title_sent": "",

--- a/translations/hr-HR.json
+++ b/translations/hr-HR.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "Trenutna vrijednost",
   "components.Activity.PaymentModal.date_sent": "Datum slanja",
   "components.Activity.PaymentModal.fee": "Naknada",
+  "components.Activity.PaymentModal.memo": "Bilješka",
   "components.Activity.PaymentModal.preimage": "Skica plaćanja",
   "components.Activity.PaymentModal.subtitle": "LN plaćanje",
   "components.Activity.PaymentModal.title_sent": "Poslano",

--- a/translations/hu-HU.json
+++ b/translations/hu-HU.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "",
   "components.Activity.PaymentModal.date_sent": "",
   "components.Activity.PaymentModal.fee": "",
+  "components.Activity.PaymentModal.memo": "",
   "components.Activity.PaymentModal.preimage": "",
   "components.Activity.PaymentModal.subtitle": "",
   "components.Activity.PaymentModal.title_sent": "",

--- a/translations/it-IT.json
+++ b/translations/it-IT.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "Valore attuale",
   "components.Activity.PaymentModal.date_sent": "",
   "components.Activity.PaymentModal.fee": "Commissione",
+  "components.Activity.PaymentModal.memo": "Note",
   "components.Activity.PaymentModal.preimage": "",
   "components.Activity.PaymentModal.subtitle": "Pagamento Lightning",
   "components.Activity.PaymentModal.title_sent": "",

--- a/translations/ja-JP.json
+++ b/translations/ja-JP.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "現在値",
   "components.Activity.PaymentModal.date_sent": "送信日",
   "components.Activity.PaymentModal.fee": "フィー",
+  "components.Activity.PaymentModal.memo": "メモ",
   "components.Activity.PaymentModal.preimage": "支払いプレイメージ",
   "components.Activity.PaymentModal.subtitle": "ライトニングペイメンツ",
   "components.Activity.PaymentModal.title_sent": "送信した",

--- a/translations/ko-KR.json
+++ b/translations/ko-KR.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "",
   "components.Activity.PaymentModal.date_sent": "",
   "components.Activity.PaymentModal.fee": "",
+  "components.Activity.PaymentModal.memo": "",
   "components.Activity.PaymentModal.preimage": "",
   "components.Activity.PaymentModal.subtitle": "",
   "components.Activity.PaymentModal.title_sent": "",

--- a/translations/nl-NL.json
+++ b/translations/nl-NL.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "",
   "components.Activity.PaymentModal.date_sent": "",
   "components.Activity.PaymentModal.fee": "Vergoeding",
+  "components.Activity.PaymentModal.memo": "",
   "components.Activity.PaymentModal.preimage": "",
   "components.Activity.PaymentModal.subtitle": "",
   "components.Activity.PaymentModal.title_sent": "",

--- a/translations/no-NO.json
+++ b/translations/no-NO.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "",
   "components.Activity.PaymentModal.date_sent": "",
   "components.Activity.PaymentModal.fee": "",
+  "components.Activity.PaymentModal.memo": "",
   "components.Activity.PaymentModal.preimage": "",
   "components.Activity.PaymentModal.subtitle": "",
   "components.Activity.PaymentModal.title_sent": "",

--- a/translations/pl-PL.json
+++ b/translations/pl-PL.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "",
   "components.Activity.PaymentModal.date_sent": "",
   "components.Activity.PaymentModal.fee": "$1",
+  "components.Activity.PaymentModal.memo": "Notatka",
   "components.Activity.PaymentModal.preimage": "",
   "components.Activity.PaymentModal.subtitle": "",
   "components.Activity.PaymentModal.title_sent": "",

--- a/translations/pt-BR.json
+++ b/translations/pt-BR.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "",
   "components.Activity.PaymentModal.date_sent": "",
   "components.Activity.PaymentModal.fee": "Taxa",
+  "components.Activity.PaymentModal.memo": "",
   "components.Activity.PaymentModal.preimage": "",
   "components.Activity.PaymentModal.subtitle": "",
   "components.Activity.PaymentModal.title_sent": "",

--- a/translations/pt-PT.json
+++ b/translations/pt-PT.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "",
   "components.Activity.PaymentModal.date_sent": "",
   "components.Activity.PaymentModal.fee": "",
+  "components.Activity.PaymentModal.memo": "",
   "components.Activity.PaymentModal.preimage": "",
   "components.Activity.PaymentModal.subtitle": "",
   "components.Activity.PaymentModal.title_sent": "",

--- a/translations/ro-RO.json
+++ b/translations/ro-RO.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "",
   "components.Activity.PaymentModal.date_sent": "",
   "components.Activity.PaymentModal.fee": "Taxa",
+  "components.Activity.PaymentModal.memo": "Notificare",
   "components.Activity.PaymentModal.preimage": "",
   "components.Activity.PaymentModal.subtitle": "",
   "components.Activity.PaymentModal.title_sent": "",

--- a/translations/ru-RU.json
+++ b/translations/ru-RU.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "",
   "components.Activity.PaymentModal.date_sent": "",
   "components.Activity.PaymentModal.fee": "Комиссия",
+  "components.Activity.PaymentModal.memo": "Памятка",
   "components.Activity.PaymentModal.preimage": "",
   "components.Activity.PaymentModal.subtitle": "",
   "components.Activity.PaymentModal.title_sent": "",

--- a/translations/sr-SP.json
+++ b/translations/sr-SP.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "",
   "components.Activity.PaymentModal.date_sent": "",
   "components.Activity.PaymentModal.fee": "",
+  "components.Activity.PaymentModal.memo": "",
   "components.Activity.PaymentModal.preimage": "",
   "components.Activity.PaymentModal.subtitle": "",
   "components.Activity.PaymentModal.title_sent": "",

--- a/translations/sv-SE.json
+++ b/translations/sv-SE.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "",
   "components.Activity.PaymentModal.date_sent": "",
   "components.Activity.PaymentModal.fee": "Avgift",
+  "components.Activity.PaymentModal.memo": "",
   "components.Activity.PaymentModal.preimage": "",
   "components.Activity.PaymentModal.subtitle": "",
   "components.Activity.PaymentModal.title_sent": "",

--- a/translations/tr-TR.json
+++ b/translations/tr-TR.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "",
   "components.Activity.PaymentModal.date_sent": "",
   "components.Activity.PaymentModal.fee": "Ücret",
+  "components.Activity.PaymentModal.memo": "Kısa Not",
   "components.Activity.PaymentModal.preimage": "",
   "components.Activity.PaymentModal.subtitle": "",
   "components.Activity.PaymentModal.title_sent": "",

--- a/translations/uk-UA.json
+++ b/translations/uk-UA.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "",
   "components.Activity.PaymentModal.date_sent": "",
   "components.Activity.PaymentModal.fee": "Плата",
+  "components.Activity.PaymentModal.memo": "Пам''ятка",
   "components.Activity.PaymentModal.preimage": "",
   "components.Activity.PaymentModal.subtitle": "",
   "components.Activity.PaymentModal.title_sent": "",

--- a/translations/vi-VN.json
+++ b/translations/vi-VN.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "",
   "components.Activity.PaymentModal.date_sent": "",
   "components.Activity.PaymentModal.fee": "",
+  "components.Activity.PaymentModal.memo": "",
   "components.Activity.PaymentModal.preimage": "",
   "components.Activity.PaymentModal.subtitle": "",
   "components.Activity.PaymentModal.title_sent": "",

--- a/translations/zh-CN.json
+++ b/translations/zh-CN.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "",
   "components.Activity.PaymentModal.date_sent": "发送日期",
   "components.Activity.PaymentModal.fee": "矿工费",
+  "components.Activity.PaymentModal.memo": "备注",
   "components.Activity.PaymentModal.preimage": "",
   "components.Activity.PaymentModal.subtitle": "闪电网络支付",
   "components.Activity.PaymentModal.title_sent": "已发送",

--- a/translations/zh-TW.json
+++ b/translations/zh-TW.json
@@ -35,6 +35,7 @@
   "components.Activity.PaymentModal.current_value": "",
   "components.Activity.PaymentModal.date_sent": "",
   "components.Activity.PaymentModal.fee": "矿工费",
+  "components.Activity.PaymentModal.memo": "备注",
   "components.Activity.PaymentModal.preimage": "",
   "components.Activity.PaymentModal.subtitle": "",
   "components.Activity.PaymentModal.title_sent": "",


### PR DESCRIPTION
## Description:

Add missing memo translation

## Motivation and Context:

Prevent app crash when trying to click on a lightning payment from the activity list.

## How Has This Been Tested?

Manually

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
