### PR TITLE
fix(ui): align amount and crypto unit

### DIFF
--- a/renderer/components/Pay/PaySummaryLightning.js
+++ b/renderer/components/Pay/PaySummaryLightning.js
@@ -132,9 +132,10 @@ class PaySummaryLightning extends React.Component {
         <DataRow
           left={<FormattedMessage {...messages.total} />}
           right={
-            <React.Fragment>
-              <CryptoValue value={amountInSatoshis + maxFee} /> {cryptoUnitName}
-            </React.Fragment>
+            <Flex alignItems="baseline">
+              <CryptoSelector mr={2} />
+              <CryptoValue value={amountInSatoshis + maxFee} />
+            </Flex>
           }
         />
 

--- a/test/unit/components/Pay/__snapshots__/PaySummaryLightning.spec.js.snap
+++ b/test/unit/components/Pay/__snapshots__/PaySummaryLightning.spec.js.snap
@@ -131,13 +131,16 @@ exports[`component.Form.PaySummaryLightning should render correctly 1`] = `
       />
     }
     right={
-      <React.Fragment>
+      <ForwardRef(Styled(styled.div))
+        alignItems="baseline"
+      >
+        <Memo(ConnectFunction)
+          mr={2}
+        />
         <CryptoValue
           value={10000}
         />
-         
-        BTC
-      </React.Fragment>
+      </ForwardRef(Styled(styled.div))>
     }
   />
   <Bar


### PR DESCRIPTION
## Description:

Align amount and crypto unit on LN pay summary page and use crypto unit selector. This is more consistent with the on chain payment summary.

## Motivation and Context:

Fix display glitch and make behaviour more consistent with rest of app.

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):

**Before:**

![image](https://user-images.githubusercontent.com/200251/62969027-3fbcdf80-be04-11e9-9b93-95a242e66cc2.png)

**After:**

![image](https://user-images.githubusercontent.com/200251/62969046-4b100b00-be04-11e9-89d0-21c3b58526e6.png)


## Types of changes:

Fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
