### PR TITLE
fix(onboarding): show recover wallet passphrase form

### DIFF
--- a/package.json
+++ b/package.json
@@ -330,7 +330,7 @@
     "informed": "2.11.7",
     "is-electron-renderer": "2.0.1",
     "jstimezonedetect": "1.0.6",
-    "lnd-grpc": "0.3.0-beta.3",
+    "lnd-grpc": "0.3.0-beta.5",
     "lndconnect": "0.2.7",
     "lodash": "4.17.14",
     "node-fetch": "2.6.0",

--- a/renderer/components/Onboarding/Steps/WalletRecover.js
+++ b/renderer/components/Onboarding/Steps/WalletRecover.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { FormattedMessage, intlShape, injectIntl } from 'react-intl'
-import { Bar, Form, Header, Message, Input, Spinner, Text } from 'components/UI'
+import { Bar, Form, Header, Input, Spinner, Text } from 'components/UI'
 import ErrorDialog from './components/ErrorDialog'
 import messages from './messages'
 
@@ -131,16 +131,15 @@ class WalletRecover extends React.Component {
                       willAutoFocus
                     />
                   ) : (
-                    <Message variant="error">{createWalletError}</Message>
+                    <ErrorDialog
+                      error={createWalletError}
+                      isOpen={Boolean(createWalletError)}
+                      isRestoreMode
+                      onClose={this.resetOnboarding}
+                    />
                   )}
                 </>
               )}
-              <ErrorDialog
-                error={createWalletError}
-                isOpen={Boolean(createWalletError)}
-                isRestoreMode
-                onClose={this.resetOnboarding}
-              />
             </>
           )
         }}

--- a/services/grpc/grpc.js
+++ b/services/grpc/grpc.js
@@ -98,7 +98,7 @@ class ZapGrpc extends EventEmitter {
       )
       return await promiseTimeout(WALLET_UNLOCKER_TIMEOUT, grpc.activateLightning())
     } catch (e) {
-      grpcLog.debug(`Error when trying to connect to LND grpc: %o`, e)
+      grpcLog.error(`Error when trying to connect to LND grpc: %o`, e)
       throw e
     }
   }
@@ -118,7 +118,7 @@ class ZapGrpc extends EventEmitter {
       )
       return await promiseTimeout(WALLET_UNLOCKER_TIMEOUT, grpc.activateLightning())
     } catch (e) {
-      grpcLog.debug(`Error when trying to create wallet: %o`, e)
+      grpcLog.error(`Error when trying to create wallet: %o`, e)
       throw e
     }
   }

--- a/utils/promiseTimeout.js
+++ b/utils/promiseTimeout.js
@@ -18,5 +18,5 @@ export default function(ms, promise, message = 'Timed out') {
     return value
   }
   // Returns a race between our timeout and the passed in promise
-  return Promise.race([promise, timeout]).then(clearTimer, clearTimer)
+  return Promise.race([promise, timeout]).finally(clearTimer)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3755,7 +3755,7 @@ babel-plugin-styled-components@1.10.6, "babel-plugin-styled-components@>= 1":
     "@babel/helper-annotate-as-pure" "^7.0.0"
     "@babel/helper-module-imports" "^7.0.0"
     babel-plugin-syntax-jsx "^6.18.0"
-    lodash "^4.17.10"
+    lodash "^4.17.11"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -10660,16 +10660,16 @@ lnd-binary@0.3.11:
     "true-case-path" "^2.0.0"
     unzip-stream "^0.3.0"
 
-lnd-grpc@0.3.0-beta.3:
-  version "0.3.0-beta.3"
-  resolved "https://registry.yarnpkg.com/lnd-grpc/-/lnd-grpc-0.3.0-beta.3.tgz#2238e0f08307efb482f95eb9217b560b1d362e85"
-  integrity sha512-1Zefsal6ddqGcuLJJ7i4Zsx2D7ddvBtCmH47wlGbmmB9HDXfJqtLC9fWwP6Z3sr44fDPD/J39jcbrSxqcxTW2Q==
+lnd-grpc@0.3.0-beta.5:
+  version "0.3.0-beta.5"
+  resolved "https://registry.yarnpkg.com/lnd-grpc/-/lnd-grpc-0.3.0-beta.5.tgz#0f83f7ea769990ca40f36c7fee82358db33a413b"
+  integrity sha512-d0EW16KKg2why0BS1FO6btJ9phvFgBEgJBBOgVjNBFJWzGfDIPUfnw+emyzqttRyplSm1nT7GOzlNb4j68+Amw==
   dependencies:
     "@grpc/grpc-js" "0.5.2"
     "@ln-zap/proto-loader" "0.5.1"
     debug "4.1.1"
     javascript-state-machine "3.1.0"
-    lndconnect "0.2.8"
+    lndconnect "0.2.9"
     lodash.defaultsdeep "4.6.1"
     semver "6.3.0"
     untildify "4.0.0"
@@ -10685,10 +10685,10 @@ lndconnect@0.2.7:
     strict-uri-encode "^2.0.0"
     untildify "^4.0.0"
 
-lndconnect@0.2.8:
-  version "0.2.8"
-  resolved "https://registry.yarnpkg.com/lndconnect/-/lndconnect-0.2.8.tgz#d0b64f3ecdb4981f4a0fe3584050849cf1ebb6e0"
-  integrity sha512-Im/PTTBodHf+debwxXESIAcVjRwfFhi2ZLvVwuqrG8jyzfll6JWoQ3uYwSG1MILeY7cuC3gLBuPM6kNGaN9drg==
+lndconnect@0.2.9:
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/lndconnect/-/lndconnect-0.2.9.tgz#82cae8a2d07ea3a03315fb3085096d838f15477c"
+  integrity sha512-kw4A63wg9yygfM3xQZcvSbLLoK0ZGfFLyiCDMJOy5P5Pq6e76sJLDgy9WODqdTg69elK7xwthp806xOjJLdhVw==
   dependencies:
     base64url "^3.0.1"
     decode-uri-component "^0.2.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:

When recovering a wallet wallet ensure that we show the passphrase form in the case that that there is an error due to a missing or invalid passphrase. Show an error dialog incase of all other errors.

## Motivation and Context:

Unable to recover encrypted wallet

## How Has This Been Tested?

Try recovering this encrypted wallet:

```
1. abstract   2. solution   3. ramp     4. repeat
5. sentence   6. soup       7. quick    8. trend
9. nation    10. cute      11. bridge  12. note
13. ritual    14. century   15. game    16. sponsor
17. sea       18. impact    19. game    20. wrist
21. follow    22. rail      23. lemon   24. curious

password: password
passphrase: passphrase
```

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
