### PR TITLE
fix(ui): make sure connection string visibility toggle is respected

### DIFF
--- a/renderer/components/Form/Input.js
+++ b/renderer/components/Form/Input.js
@@ -77,8 +77,6 @@ const Input = ({
       <Flex alignItems="center">
         {type === 'search' && <SearchIcon width={iconSize} />}
         <StyledInput
-          {...otherProps}
-          ref={forwardedRef}
           disabled={isDisabled}
           fieldState={fieldState}
           maxLength={maxLength}
@@ -113,6 +111,8 @@ const Input = ({
           theme={theme}
           type={type}
           value={getValue()}
+          {...otherProps}
+          ref={forwardedRef}
         />
         {children}
       </Flex>

--- a/renderer/components/Form/TextArea.js
+++ b/renderer/components/Form/TextArea.js
@@ -61,8 +61,6 @@ const TextArea = ({
         </InputLabel>
       )}
       <StyledTextArea
-        {...otherProps}
-        ref={forwardedRef}
         disabled={isDisabled}
         fieldState={fieldState}
         name={field}
@@ -93,6 +91,8 @@ const TextArea = ({
         required={isRequired}
         theme={theme}
         value={getValue()}
+        {...otherProps}
+        ref={forwardedRef}
       />
       {description && (
         <Text color="gray" fontSize="s" mt={1}>


### PR DESCRIPTION
Looks like there was a change during a recent refactor where the `{...otherProps}` piece was moved from the bottom to the top which broke the connection string component. This PR fixes it but I can guarantee it doesn't break something else if that change of moving `{...otherProps}` was intentional and if some other components are relying on this.

## Motivation and Context:

fix #2785

## How Has This Been Tested?

Manually

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
