### PR TITLE
fix: ensure app is focused after menu interaction on windows/linux

### DIFF
--- a/electron/menuBuilder.js
+++ b/electron/menuBuilder.js
@@ -31,6 +31,30 @@ const buildAboutMenu = () => {
   }
 }
 
+/**
+ * interceptMethod - Alters the `template` to inject `handler` call into `method`.
+ *
+ * @param {Array} template menu template
+ * @param {string} method method to intercept
+ * @param {Function} handler  extract method to be called alongside with the original `method`
+ * @returns {object} updated menu template
+ */
+function interceptMethod(template, method, handler) {
+  return template.map(({ submenu, ...rest }) => {
+    return {
+      ...rest,
+      submenu: submenu.map(item => {
+        const { [method]: wrappedMethod } = item
+        item[method] = () => {
+          wrappedMethod && wrappedMethod()
+          handler()
+        }
+        return item
+      }),
+    }
+  })
+}
+
 export default class ZapMenuBuilder {
   constructor(mainWindow) {
     this.mainWindow = mainWindow
@@ -46,11 +70,14 @@ export default class ZapMenuBuilder {
     if (os.platform() === 'darwin') {
       template = this.buildDarwinTemplate()
     } else {
-      template = this.buildDefaultTemplate()
+      // add global `click` interceptor that re-focuses
+      // Web app after menu is closed
+      template = interceptMethod(this.buildDefaultTemplate(), 'click', () =>
+        this.mainWindow.webContents.focus()
+      )
     }
 
     this.setupInputTemplate()
-
     const menu = Menu.buildFromTemplate(template)
     Menu.setApplicationMenu(menu)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
After interacting with the application menu (for example, clicking `Preferences` item) React app loses focus which prevents it from receiving keyboard events and as a result causes issues like keyboard shortcuts not working. This PR adds a global application menu `click` handler that ensures React is focused after `click` handlers
<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes:
Bugfix
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
