### PR TITLE
chore: add rebass to restricted imports rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,17 @@ module.exports = {
   rules: {
     camelcase: 0,
     curly: ['error', 'all'],
+    'no-restricted-imports': [
+      'error',
+      {
+        paths: [
+          {
+            name: 'rebass',
+            message: 'Please use rebass/styled-components instead.',
+          },
+        ],
+      },
+    ],
     'comma-dangle': ['error', 'always-multiline'],
     // 'prettier/prettier': 0,
     'react/boolean-prop-naming': ['error', { rule: '^(is|has|will|(.*)On)[A-Z]([A-Za-z0-9]?)+' }],
@@ -42,7 +53,6 @@ module.exports = {
     'react/require-default-props': 0,
     'react/sort-prop-types': 'error',
     'react/style-prop-object': 0,
-    // 'sort-imports': 'error',
     'import/no-extraneous-dependencies': 0,
     'import/prefer-default-export': 0,
     'import/order': [

--- a/renderer/components/Form/InputContainer.js
+++ b/renderer/components/Form/InputContainer.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { withTheme } from 'styled-components'
 import { themeGet } from '@styled-system/theme-get'
-import { Flex } from 'rebass'
+import { Flex } from 'rebass/styled-components'
 
 const InputContainer = withTheme(({ isDisabled, isReadOnly, ...rest }) => {
   const extraStyles = {}

--- a/renderer/components/UI/CenteredContent.js
+++ b/renderer/components/UI/CenteredContent.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Flex } from 'rebass'
+import { Flex } from 'rebass/styled-components'
 
 const CenteredContent = props => (
   <Flex


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Importing components from `rebass` directly causes all sorts of issues. This lint rule enforces usage of `rebass/styled-components` instead
<!--- Describe your changes in detail -->


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
`yarn lint`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes:
ESLint rule update
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
