### PR TITLE
chore: allow overriding state props in sb components

### DIFF
--- a/.storybook/patchedReactRedux.js
+++ b/.storybook/patchedReactRedux.js
@@ -1,0 +1,33 @@
+export {
+  Provider,
+  connectAdvanced,
+  ReactReduxContext,
+  batch,
+  useDispatch,
+  useSelector,
+  useStore,
+  shallowEqual,
+} from '../node_modules/react-redux' // full import path to avoid circular dep
+import { connect as originalConnect } from '../node_modules/react-redux'
+
+function defaultMergeProps(stateProps, dispatchProps, ownProps) {
+  return { ...stateProps, ...dispatchProps, ...ownProps }
+}
+
+/**
+ * connect - Patches redux connect function to use `defaultMergeProps` that prioritizes `ownProps` over `stateProps`.
+ *
+ * @param {*} mapStateToProps mapStateToProps
+ * @param {*} mapDispatchToProps mapDispatchToProps
+ * @param {*} [mergeProps=defaultMergeProps] mergeProps
+ * @param {*} rest options
+ * @returns {*}
+ */
+export function connect(
+  mapStateToProps,
+  mapDispatchToProps,
+  mergeProps = defaultMergeProps,
+  ...rest
+) {
+  return originalConnect(mapStateToProps, mapDispatchToProps, mergeProps, ...rest)
+}

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,12 +1,20 @@
 require('@babel/register')
 const baseConfig = require('../webpack/webpack.config.base')
+const path = require('path')
+
+const createResolveConfig = config => {
+  const resolveConfig = {
+    ...config.resolve,
+    ...baseConfig.default.resolve,
+  }
+  resolveConfig.alias['react-redux'] = path.resolve(__dirname, './patchedReactRedux')
+  return resolveConfig
+}
 
 module.exports = ({ config }) => ({
   ...config,
-  resolve: {
-    ...config.resolve,
-    ...baseConfig.default.resolve,
-  },
+  resolve: createResolveConfig(config),
+
   module: {
     ...config.module,
     rules: [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
This PR monkey patches `react-redux` connect to use `defaultMergeProps`  that prioritizes `ownProps` over `stateProps`
<!--- Describe your changes in detail -->

## Motivation and Context:
Simplify sb testing by allowing to mock redux actions
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
`yarn storybook`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes:
Devops
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
