### PR TITLE
feat(ui): add autosuggest for seed recovery

### DIFF
--- a/renderer/components/Onboarding/Steps/Recover.js
+++ b/renderer/components/Onboarding/Steps/Recover.js
@@ -1,90 +1,29 @@
-/* eslint-disable react/no-multi-comp */
-
-import React from 'react'
+import React, { useRef } from 'react'
 import PropTypes from 'prop-types'
-import { compose } from 'redux'
-import { withFormApi } from 'informed'
+import range from 'lodash/range'
 import { FormattedMessage, injectIntl } from 'react-intl'
-import bip39 from 'bip39-en'
 import { Flex } from 'rebass/styled-components'
+import SeedWordInput from './components/SeedWordInput'
 import { intlShape } from '@zap/i18n'
 import parseSeed from '@zap/utils/parseSeed'
 import { Bar, Header } from 'components/UI'
-import { Form, Input, Label } from 'components/Form'
+import { Form } from 'components/Form'
 import messages from './messages'
 
-class SeedWord extends React.Component {
-  static propTypes = {
-    index: PropTypes.number.isRequired,
-    intl: intlShape.isRequired,
-    onPaste: PropTypes.func,
-    word: PropTypes.string,
-  }
+const getInputKey = idx => `word${idx}`
 
-  /**
-   * mask - Masks the value with a trimmed version.
-   *
-   * @param  {string} value Value to check
-   * @returns {string}       Trimmed string
-   */
-  mask = value => (value ? value.trim() : value)
+const Recover = ({ wizardApi, wizardState, setSeed, intl, ...rest }) => {
+  const formApiRef = useRef(null)
 
-  /**
-   * validate - Check if a word is included in the bip39 word list.
-   *
-   * @param  {string} value     Value to check
-   * @returns {string|undefined} undefined if word is in bip39 word list. The string 'incorrect' otherwise.
-   */
-  validate = value => {
-    return !value || !bip39.includes(value) ? 'incorrect' : undefined
-  }
-
-  render() {
-    const { index, intl, onPaste, word } = this.props
-    return (
-      <Flex key={`word${index}`} alignItems="center" as="li" justifyContent="flex-start" my={1}>
-        <Label htmlFor={`word${index}`} mb={0} width={35}>
-          {index}
-        </Label>
-        <Input
-          field={`word${index}`}
-          hasMessage={false}
-          initialValue={word}
-          mask={this.mask}
-          onPaste={onPaste}
-          placeholder={intl.formatMessage({ ...messages.word_placeholder })}
-          validate={this.validate}
-          validateOnChange
-          variant="thin"
-          willAutoFocus={index === 1}
-        />
-      </Flex>
-    )
-  }
-}
-
-const SeedWordWithIntl = compose(
-  withFormApi,
-  injectIntl
-)(SeedWord)
-
-class Recover extends React.Component {
-  static propTypes = {
-    intl: intlShape.isRequired,
-    seed: PropTypes.array.isRequired,
-    setSeed: PropTypes.func.isRequired,
-    wizardApi: PropTypes.object,
-    wizardState: PropTypes.object,
-  }
-
-  static defaultProps = {
-    wizardApi: {},
-    wizardState: {},
-  }
-
-  handleSubmit = values => {
-    const { setSeed } = this.props
+  const handleSubmit = values => {
     setSeed(Object.values(values))
+  }
+
+  const setFormApiFieldValue = (index, word) => {
+    const fieldKey = getInputKey(index + 1)
+    const formApi = formApiRef.current
+    formApi.setValue(fieldKey, word)
+    formApi.setTouched(fieldKey, true)
   }
 
   /**
@@ -92,82 +31,87 @@ class Recover extends React.Component {
    *
    * @param  {Event} event onPaste event
    */
-  handlePaste = event => {
+  const handlePaste = event => {
     const seedWords = parseSeed(event.clipboardData.getData('text'))
     if (seedWords.length === 24) {
       event.preventDefault()
       seedWords.forEach((word, index) => {
-        this.formApi.setValue(`word${index + 1}`, word)
-        this.formApi.setTouched(`word${index + 1}`, true)
+        setFormApiFieldValue(index, word)
       })
     }
   }
 
-  setFormApi = formApi => {
-    this.formApi = formApi
-  }
+  const { getApi, onChange, onSubmit, onSubmitFailure } = wizardApi
+  const { currentItem } = wizardState
+  const indexes = range(24)
 
-  render() {
-    const { wizardApi, wizardState, seed, setSeed, intl, ...rest } = this.props
-    const { getApi, onChange, onSubmit, onSubmitFailure } = wizardApi
-    const { currentItem } = wizardState
-    const indexes = Array.from(Array(24).keys())
+  return (
+    <Form
+      {...rest}
+      getApi={formApi => {
+        formApiRef.current = formApi
+        if (getApi) {
+          getApi(formApi)
+        }
+      }}
+      onChange={
+        onChange &&
+        (formState => {
+          onChange(formState, currentItem)
+        })
+      }
+      onSubmit={values => {
+        handleSubmit(values)
+        if (onSubmit) {
+          onSubmit(values)
+        }
+      }}
+      onSubmitFailure={onSubmitFailure}
+    >
+      <Header
+        subtitle={<FormattedMessage {...messages.import_description} />}
+        title={<FormattedMessage {...messages.import_title} />}
+      />
 
-    return (
-      <Form
-        {...rest}
-        getApi={formApi => {
-          this.setFormApi(formApi)
-          if (getApi) {
-            getApi(formApi)
-          }
-        }}
-        onChange={onChange && (formState => onChange(formState, currentItem))}
-        onSubmit={values => {
-          this.handleSubmit(values)
-          if (onSubmit) {
-            onSubmit(values)
-          }
-        }}
-        onSubmitFailure={onSubmitFailure}
-      >
-        <Header
-          subtitle={<FormattedMessage {...messages.import_description} />}
-          title={<FormattedMessage {...messages.import_title} />}
-        />
+      <Bar my={4} />
 
-        <Bar my={4} />
-
-        <Flex justifyContent="space-between">
-          <Flex as="ul" flexDirection="column" mr={2}>
-            {indexes.slice(0, 6).map(word => (
-              <SeedWordWithIntl
-                key={word + 1}
-                index={word + 1}
-                onPaste={word === 0 ? this.handlePaste : null}
-                word={seed[word]}
+      <Flex justifyContent="space-between">
+        {[[0, 6], [6, 12], [12, 18], [18, 24]].map((slice, sliceIndex) => (
+          <Flex
+            key={sliceIndex}
+            as="ul"
+            flexDirection="column"
+            ml={sliceIndex > 0 ? 2 : 0}
+            mr={sliceIndex < 3 ? 2 : 0}
+          >
+            {indexes.slice(...slice).map(index => (
+              <SeedWordInput
+                key={index + 1}
+                index={index + 1}
+                onPaste={index === 0 ? handlePaste : null}
+                placeholder={intl.formatMessage({ ...messages.word_placeholder })}
+                setFormApiFieldValue={word => {
+                  setFormApiFieldValue(index, word)
+                }}
               />
             ))}
           </Flex>
-          <Flex as="ul" flexDirection="column" mx={2}>
-            {indexes.slice(6, 12).map(word => (
-              <SeedWordWithIntl key={word + 1} index={word + 1} word={seed[word]} />
-            ))}
-          </Flex>
-          <Flex as="ul" flexDirection="column" mx={2}>
-            {indexes.slice(12, 18).map(word => (
-              <SeedWordWithIntl key={word + 1} index={word + 1} word={seed[word]} />
-            ))}
-          </Flex>
-          <Flex as="ul" flexDirection="column" ml={2}>
-            {indexes.slice(18, 24).map(word => (
-              <SeedWordWithIntl key={word + 1} index={word + 1} word={seed[word]} />
-            ))}
-          </Flex>
-        </Flex>
-      </Form>
-    )
-  }
+        ))}
+      </Flex>
+    </Form>
+  )
+}
+
+Recover.propTypes = {
+  intl: intlShape.isRequired,
+  setSeed: PropTypes.func.isRequired,
+  wizardApi: PropTypes.object,
+  wizardState: PropTypes.object,
+}
+
+Recover.defaultProps = {
+  wizardApi: {},
+  wizardState: {},
 }
 
 export default injectIntl(Recover)

--- a/renderer/components/Onboarding/Steps/components/SeedWordInput.js
+++ b/renderer/components/Onboarding/Steps/components/SeedWordInput.js
@@ -1,0 +1,111 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Downshift from 'downshift'
+import bip39 from 'bip39-en'
+import { Box, Flex } from 'rebass/styled-components'
+import { useFieldApi } from 'informed'
+import { useMaxScreenHeight } from 'hooks'
+import SeedWordList from './SeedWordList'
+import { Input, Label } from 'components/Form'
+
+const SeedWordInput = ({ index, onPaste, placeholder, setFormApiFieldValue }) => {
+  const inputKey = `word${index}`
+  const fieldApi = useFieldApi(inputKey)
+  const [measuredRef, maxHeight] = useMaxScreenHeight(300)
+  const height = Math.max(maxHeight, 100)
+
+  /**
+   * mask - Masks the value with a trimmed version.
+   *
+   * @param {string} value Value to check
+   * @returns {string} Trimmed string
+   */
+  const mask = value => (value ? value.trim() : value)
+
+  /**
+   * validate - Check if a word is included in the bip39 word list.
+   *
+   * @param {string} value Value to check
+   * @returns {string|undefined} undefined if word is in bip39 word list. The string 'incorrect' otherwise
+   */
+  const validate = value => {
+    return bip39.includes(value) ? undefined : 'incorrect'
+  }
+
+  /**
+   * getValue - Get the current field value.
+   *
+   * @returns {string} Current field value
+   */
+  const getValue = () => {
+    return fieldApi.getValue() || ''
+  }
+
+  /**
+   * onChange - Set the current field value.
+   *
+   * @param {Event} event onChange event
+   */
+  const onChange = event => {
+    fieldApi.setValue(event.target.value)
+  }
+
+  return (
+    <Downshift onSelect={setFormApiFieldValue}>
+      {({
+        getInputProps,
+        getItemProps,
+        getMenuProps,
+        getRootProps,
+        isOpen,
+        inputValue,
+        highlightedIndex,
+      }) => (
+        <Box sx={{ position: 'relative' }} {...getRootProps()}>
+          <Flex alignItems="center" as="li" justifyContent="flex-start" my={1}>
+            <Label htmlFor={inputKey} mb={0} width={35}>
+              {index}
+            </Label>
+            <Input
+              {...getInputProps({
+                field: inputKey,
+                hasMessage: false,
+                highlightOnValid: true,
+                onChange,
+                mask,
+                onPaste,
+                placeholder,
+                validate,
+                validateOnChange: true,
+                value: getValue(),
+                variant: 'thin',
+                willAutoFocus: index === 1,
+              })}
+            />
+          </Flex>
+          {isOpen && inputValue && (
+            <SeedWordList
+              {...{
+                getMenuProps,
+                highlightedIndex,
+                getItemProps,
+                inputValue,
+              }}
+              ref={measuredRef}
+              maxHeight={height}
+            />
+          )}
+        </Box>
+      )}
+    </Downshift>
+  )
+}
+
+SeedWordInput.propTypes = {
+  index: PropTypes.number.isRequired,
+  onPaste: PropTypes.func,
+  placeholder: PropTypes.string.isRequired,
+  setFormApiFieldValue: PropTypes.func.isRequired,
+}
+
+export default SeedWordInput

--- a/renderer/components/Onboarding/Steps/components/SeedWordList.js
+++ b/renderer/components/Onboarding/Steps/components/SeedWordList.js
@@ -1,0 +1,111 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import bip39 from 'bip39-en'
+import { Box, Flex } from 'rebass/styled-components'
+import { Text } from 'components/UI'
+
+/**
+ * Create a mapping of first letter to words in BIP 39 list so
+ * we don't have to filter through the whole array when looking up values
+ * every time
+ */
+const bip39WordMap = bip39.reduce((bip39WordMap, word) => {
+  const [firstLetter] = word
+  if (!bip39WordMap[firstLetter]) {
+    bip39WordMap[firstLetter] = []
+  }
+
+  bip39WordMap[firstLetter].push(word)
+
+  return bip39WordMap
+}, {})
+
+const StyledOptionList = React.forwardRef((props, ref) => (
+  <Box
+    ref={ref}
+    as="ul"
+    bg="secondaryColor"
+    maxHeight={300}
+    mt={1}
+    p={0}
+    sx={{
+      position: 'absolute',
+      zIndex: 2,
+      overflowY: 'auto',
+      overflowX: 'hidden',
+      outline: 0,
+      transition: 'opacity 0.1s ease',
+      borderRadius: 's',
+      boxShadow: 's',
+    }}
+    width={1}
+    {...props}
+  />
+))
+StyledOptionList.displayName = 'StyledOptionList'
+
+const SeedWordList = React.forwardRef(
+  ({ highlightedIndex, getItemProps, getMenuProps, inputValue, ...rest }, ref) => {
+    // Don't show suggestions if user didn't input anything
+    if (!inputValue) {
+      return null
+    }
+
+    // Get the wordlist we can suggest
+    const [firstLetter] = inputValue
+    const suggestions = bip39WordMap[firstLetter]
+    if (!suggestions) {
+      return null
+    }
+
+    // Get the words that match the input
+    const wordList = suggestions.filter(word => word.indexOf(inputValue) === 0)
+
+    // Input doesn't match anything, show nothing
+    if (!wordList.length) {
+      return null
+    }
+
+    // We have one suugestion only and it matches the input exactly.
+    // No point to annoy the user by showing exactly the same thing so
+    // we don't show this single suggestion.
+    if (wordList.length === 1 && wordList[0] === inputValue) {
+      return null
+    }
+
+    return (
+      <StyledOptionList {...getMenuProps(rest, { suppressRefError: true })} ref={ref}>
+        {wordList.map((item, index) => (
+          <Flex
+            {...getItemProps({
+              index,
+              item,
+            })}
+            key={item}
+            alignItems="center"
+            as="li"
+            bg={highlightedIndex === index ? 'primaryColor' : null}
+            p={2}
+            sx={{
+              outline: 'none',
+              cursor: 'pointer',
+            }}
+          >
+            <Text>{item}</Text>
+          </Flex>
+        ))}
+      </StyledOptionList>
+    )
+  }
+)
+
+SeedWordList.displayName = 'SeedWordList'
+
+SeedWordList.propTypes = {
+  getItemProps: PropTypes.func.isRequired,
+  getMenuProps: PropTypes.func.isRequired,
+  highlightedIndex: PropTypes.number,
+  inputValue: PropTypes.string.isRequired,
+}
+
+export default SeedWordList

--- a/renderer/containers/Onboarding/Steps/Recover.js
+++ b/renderer/containers/Onboarding/Steps/Recover.js
@@ -2,15 +2,11 @@ import { connect } from 'react-redux'
 import { Recover } from 'components/Onboarding/Steps'
 import { setSeed } from 'reducers/onboarding'
 
-const mapStateToProps = state => ({
-  seed: state.onboarding.seed,
-})
-
 const mapDispatchToProps = {
   setSeed,
 }
 
 export default connect(
-  mapStateToProps,
+  null,
   mapDispatchToProps
 )(Recover)

--- a/test/e2e/onboarding-import.spec.js
+++ b/test/e2e/onboarding-import.spec.js
@@ -1,4 +1,5 @@
 import { waitForReact } from 'testcafe-react-selectors'
+import range from 'lodash/range'
 import {
   getBaseUrl,
   getUserDataDir,
@@ -64,8 +65,8 @@ test('should import a wallet from an existing seed', async t => {
     .click(onboarding.nextButton)
 
   // Fill in the seed form.
-  Array.from(Array(24).keys()).forEach(async index => {
-    await t.typeText(onboarding.seedWordInputs[index], seed[index], { paste: true })
+  range(24).forEach(async index => {
+    await t.typeText(onboarding.seedWordInputs[index], seed[index]).pressKey('tab')
   })
 
   // Submit the seed.

--- a/test/e2e/pages/onboarding.js
+++ b/test/e2e/pages/onboarding.js
@@ -1,4 +1,5 @@
 import { ReactSelector } from 'testcafe-react-selectors'
+import range from 'lodash/range'
 
 class ConnectionTypeOption {
   constructor(key) {
@@ -26,9 +27,7 @@ class SeedWordAtIndex {
 class Onboarding {
   constructor() {
     this.seedWordInputs = []
-    Array.from(Array(24).keys()).forEach(async index => {
-      this.seedWordInputs.push(new SeedWordAtIndex(index).input)
-    })
+    range(24).forEach(index => this.seedWordInputs.push(new SeedWordAtIndex(index).input))
   }
 
   // Controls


### PR DESCRIPTION
## Description:

Add autosuggest functionality when on the seed recovery screen. Words are shown in a list below the input as user starts typing the word. Words can be selected from the suggestion list either by clicking on them or through the keyboard.

## Motivation and Context:

Address #2765

## How Has This Been Tested?

Manually

## Types of changes:

New feature: autosuggest seed words from BIP 39 when recovering your seed.

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
