### PR TITLE
fix(slack): update slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,4 +115,4 @@ This project is open source under the MIT license, which means you have full acc
 
 [issues]: https://github.com/LN-Zap/zap-desktop/issues
 [releases]: https://github.com/LN-Zap/zap-desktop/releases
-[slack]: https://join.slack.com/t/zaphq/shared_invite/enQtMzgyNDA2NDI2Nzg0LTQwZWQ2ZWEzOWFhMjRiNWZkZWMwYTA4MzA5NzhjMDNhNTM5YzliNDA4MmZkZWZkZTFmODM4ODJkYzU3YmI3ZmI
+[slack]: https://join.slack.com/t/zaphq/shared_invite/enQtMzgyNDA2NDI2Nzg0LWQ1OGMyMWI3YTdmYTQ0YTVmODg4ZmNkYjQ1MzUxNGExMGRmZWEyNTUyOGQzMzZkYTdhODE3NmQxZWZiOGFkYWI


### PR DESCRIPTION
Been getting reports that our Slack invite expired, so I generated a new one and updated it