### PR TITLE
fix(ui): open dialog inputs

### DIFF
--- a/renderer/components/Form/OpenDialogInput.js
+++ b/renderer/components/Form/OpenDialogInput.js
@@ -27,8 +27,8 @@ const OpenDialogInput = props => {
         <Flex alignItems="center" {...spaceProps}>
           <InnerInput width={1} {...otherProps} />
           <OpenDialogButton
-            onClick={() => {
-              const result = openDialog(mode)
+            onClick={async () => {
+              const result = await openDialog(mode)
               //set value only if something was selected to avoid
               //overriding an existing state
               if (result) {

--- a/renderer/hocs/withOpenDialog.js
+++ b/renderer/hocs/withOpenDialog.js
@@ -1,3 +1,4 @@
+import { mainLog } from '@zap/utils/log'
 /**
  * Invokes electron open dialog
  */
@@ -6,18 +7,23 @@
  * openDialog - Open electron dialog.
  *
  * @param {string} mode electron dialog.showOpenDialog compatible mode
- * @returns {string[]} An array of file paths chosen by the user
+ * @returns {string|null} File path chosen by the user or `null` if dialog was cancelled/error has occurred
  */
-function openDialog(mode = 'openFile') {
-  const result = window.showOpenDialog({
-    properties: [mode],
-  })
+async function openDialog(mode = 'openFile') {
+  try {
+    const { canceled, filePaths } = await window.showOpenDialog({
+      properties: [mode],
+    })
 
-  if (result && result.length) {
-    return result[0]
+    if (!canceled && filePaths.length) {
+      return filePaths[0]
+    }
+
+    return null
+  } catch (e) {
+    mainLog.warn('openDialog error: %o', e)
+    return null
   }
-
-  return ''
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
`dialog.showDialog` was signature was changed in `electron 6` and now is async. Our code relies on `v5` api (which is used in master) so `OpenDialog` inputs functionality is currently broken in `next`. This PR updates the code to use `v6` api.
<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes:
Bugfix
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
