### PR TITLE
fix(select): correctly update select when underlying field changes

### DIFF
--- a/renderer/components/UI/Select.js
+++ b/renderer/components/UI/Select.js
@@ -73,11 +73,11 @@ const StyledInput = styled(BasicInput)`
 
 const itemToString = item => (item ? item.value : '')
 
-const getInitialSelectedItem = (items, initialSelectedItem) => {
-  return initialSelectedItem
+const getSelectedItem = (items, key) => {
+  return key
     ? {
-        initialInputValue: itemToString(initialSelectedItem),
-        initialSelectedItem: items.find(i => i.key === initialSelectedItem),
+        inputValue: itemToString(key),
+        selectedItem: items.find(i => i.key === key),
       }
     : {}
 }
@@ -129,22 +129,22 @@ const Select = props => {
   } = props
   const { setValue, setTouched } = fieldApi
 
-  const { initialInputValue, initialSelectedItem } = getInitialSelectedItem(
+  const { inputValue, selectedItem: initialSelectedItem } = getSelectedItem(
     items,
     initialSelectedItemOriginal || fieldState.value
   )
 
   return (
     <Downshift
-      initialInputValue={initialInputValue}
+      initialInputValue={inputValue}
       initialSelectedItem={initialSelectedItem}
       itemToString={itemToString}
-      // When an item is selected, set the item in the Informed form state.
       onInputValueChange={(inputValue, stateAndHelpers) => {
         if (inputValue && inputValue !== itemToString(stateAndHelpers.selectedItem)) {
           fieldApi.setValue(itemToString(stateAndHelpers.selectedItem))
         }
       }}
+      // When an item is selected, set the item in the Informed form state.
       onSelect={item => {
         if (!item) {
           return
@@ -156,6 +156,7 @@ const Select = props => {
         }
         blurInput()
       }}
+      selectedItem={getSelectedItem(items, fieldState.value).selectedItem}
     >
       {({
         getInputProps,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
It seems that our `Select` component is missing one important piece: syncing its value with the underlying form field in case the latter is changed programmatically.

For example consider this:
1. Go to wallet settings
2. Select some invoice expiry period
3. Press cancel

Form will reset, but select will show stale value.
This PR attempts to add sync between underlying form field and select by leveraging downshift control props:
https://github.com/downshift-js/downshift#control-props

PS: These kind of changes are known to be tricky and usually introduce some other corner cases, so it maybe worth to test this for a while before merging
<!--- Describe your changes in detail -->


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes:
Bugfix
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
