### PR TITLE
fix(ui): close channel create modal after channel opening is finished

### DIFF
--- a/renderer/containers/Channels/ChannelCreate.js
+++ b/renderer/containers/Channels/ChannelCreate.js
@@ -1,6 +1,9 @@
 import { connect } from 'react-redux'
 import ChannelCreate from 'components/Channels/ChannelCreate'
+import { closeModal } from 'reducers/modal'
 import { updateContactFormSearchQuery, contactFormSelectors } from 'reducers/contactsform'
+
+const onSubmit = () => closeModal()
 
 const mapStateToProps = state => ({
   searchQuery: state.contactsform.searchQuery,
@@ -9,6 +12,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = {
   updateContactFormSearchQuery,
+  onSubmit,
 }
 
 export default connect(

--- a/renderer/reducers/channels.js
+++ b/renderer/reducers/channels.js
@@ -1,5 +1,4 @@
 import { createSelector } from 'reselect'
-import { proxyValue } from 'comlinkjs'
 import orderBy from 'lodash/orderBy'
 import throttle from 'lodash/throttle'
 import config from 'config'
@@ -546,10 +545,6 @@ export const openChannel = data => async (dispatch, getState) => {
       spendUnconfirmed,
     })
     dispatch(pushchannelupdated(data))
-    grpc.services.Lightning.once(
-      'openChannel.data',
-      proxyValue(data => dispatch(pushchannelupdated(data)))
-    )
   } catch (e) {
     dispatch(
       pushchannelerror({
@@ -647,10 +642,6 @@ export const closeChannel = () => async (dispatch, getState) => {
         force: !active,
       })
       dispatch(pushclosechannelupdated(data))
-      grpc.services.Lightning.once(
-        'closeChannel.data',
-        proxyValue(data => dispatch(pushclosechannelupdated(data)))
-      )
     } catch (e) {
       dispatch(
         pushchannelerror({

--- a/services/grpc/lightning.methods.js
+++ b/services/grpc/lightning.methods.js
@@ -175,7 +175,6 @@ async function openChannel(payload = {}) {
       call.on('data', data => {
         grpcLog.debug('OPEN_CHANNEL DATA', data)
         const response = { ...parsePayload(payload), data }
-        this.emit('openChannel.data', response)
         resolve(response)
       })
 
@@ -183,18 +182,15 @@ async function openChannel(payload = {}) {
         grpcLog.error('OPEN_CHANNEL ERROR', data)
         const error = new Error(data.message)
         error.payload = parsePayload(payload)
-        this.emit('openChannel.error', error)
         reject(error)
       })
 
       call.on('status', status => {
         grpcLog.debug('OPEN_CHANNEL STATUS', status)
-        this.emit('openChannel.status', status)
       })
 
       call.on('end', () => {
         grpcLog.debug('OPEN_CHANNEL END')
-        this.emit('openChannel.end')
       })
     } catch (e) {
       const error = new Error(e.message)
@@ -235,7 +231,6 @@ async function closeChannel(payload = {}) {
       call.on('data', data => {
         grpcLog.debug('CLOSE_CHANNEL DATA', data)
         const response = { data, chan_id }
-        this.emit('closeChannel.data', response)
         resolve(response)
       })
 
@@ -243,18 +238,15 @@ async function closeChannel(payload = {}) {
         grpcLog.error('CLOSE_CHANNEL ERROR', data)
         const error = new Error(data.message)
         error.payload = { chan_id }
-        this.emit('closeChannel.error', error)
         reject(error)
       })
 
       call.on('status', status => {
         grpcLog.debug('CLOSE_CHANNEL STATUS', status)
-        this.emit('closeChannel.status', status)
       })
 
       call.on('end', () => {
         grpcLog.debug('CLOSE_CHANNEL END')
-        this.emit('closeChannel.end')
       })
     } catch (e) {
       const error = new Error(e.message)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Close `Create channel` modal after channel opening is finished (either successful or not). This functionality was broken some time during `Modal Stack` refactoring. Also remove redundant `openChannel.data` handler which was causing `comlink` error. 
```
    grpc.services.Lightning.once(	
      'openChannel.data',	
      proxyValue(data => dispatch(pushchannelupdated(data)))	
    )
```
Is redundant because `openChannel` call resolves with exactly same data as per
https://github.com/LN-Zap/zap-desktop/blob/10440046872a95fbe3b33a11ac0f923d3978a25b/services/grpc/lightning.methods.js#L178

Fix #2920 
<!--- Describe your changes in detail -->


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes:
Bugfix
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
