### PR TITLE
fix(ui): set delete wallet header width to same as content width

### DIFF
--- a/renderer/components/Channels/ChannelCloseDialog.js
+++ b/renderer/components/Channels/ChannelCloseDialog.js
@@ -53,7 +53,7 @@ const DialogWrapper = ({ intl, isForceClose, isOpen, onClose, onCancel, csvDelay
       <Form onSubmit={handleSubmit}>
         <Dialog buttons={buttons} header={header} onClose={onCancel} width={640}>
           <Flex alignItems="center" flexDirection="column">
-            <Text color="gray" mb={2} textAlign={isForceClose ? 'left' : 'center'} width={500}>
+            <Text color="gray" mb={2} textAlign={isForceClose ? 'left' : 'center'}>
               <FormattedMessage
                 {...(isForceClose
                   ? messages.close_channel_dialog_force_warning

--- a/renderer/components/Home/DeleteWalletDialog.js
+++ b/renderer/components/Home/DeleteWalletDialog.js
@@ -53,7 +53,7 @@ const DialogWrapper = ({ intl, isOpen, walletDir, onDelete, onCancel }) => {
           {walletDir && (
             <Flex alignItems="center" flexDirection="column">
               <Flex alignItems="flex-start" flexDirection="column">
-                <Text color="gray" mb={2} width={550}>
+                <Text color="gray" mb={2}>
                   <FormattedMessage {...messages.delete_wallet_dialog_warning} />
                 </Text>
 

--- a/renderer/components/Onboarding/Steps/components/ErrorDialog.js
+++ b/renderer/components/Onboarding/Steps/components/ErrorDialog.js
@@ -39,7 +39,7 @@ const ErrorDialog = ({ onClose, error, isRestoreMode, isOpen }) => {
         width={640}
       >
         <FormattedMessage {...subHeaderMsg} />
-        <Text color="gray" px={4} py={2}>
+        <Text color="gray" py={2}>
           {error}
         </Text>
       </Dialog>

--- a/renderer/components/Onboarding/Steps/components/SkipBackupsDialog.js
+++ b/renderer/components/Onboarding/Steps/components/SkipBackupsDialog.js
@@ -58,7 +58,7 @@ const DialogWrapper = ({ intl, isOpen, isRestoreMode, onSkip, onCancel }) => {
         <Dialog buttons={buttons} header={header} onClose={onCancel} width={640}>
           <Flex alignItems="center" flexDirection="column">
             <Flex alignItems="flex-start" flexDirection="column">
-              <Text color="gray" mb={2} width={550}>
+              <Text color="gray" mb={2}>
                 <FormattedMessage {...warningMessage} />
               </Text>
             </Flex>

--- a/renderer/components/UI/Dialog.js
+++ b/renderer/components/UI/Dialog.js
@@ -32,6 +32,7 @@ const Dialog = ({ header, onClose, buttons, width, children }) => {
         flexDirection="column"
         justifyContent="center"
         pb={4}
+        px={5}
       >
         <Flex alignItems="center" flexDirection="column" justifyContent="flex-start">
           {headerLayout}

--- a/test/unit/components/UI/__snapshots__/Dialog.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Dialog.spec.js.snap
@@ -76,6 +76,7 @@ exports[`component.UI.Dialog should render correctly with one button 1`] = `
     flexDirection="column"
     justifyContent="center"
     pb={4}
+    px={5}
   >
     <Styled(styled.div)
       alignItems="center"
@@ -130,6 +131,7 @@ exports[`component.UI.Dialog should render correctly with two buttons 1`] = `
     flexDirection="column"
     justifyContent="center"
     pb={4}
+    px={5}
   >
     <Styled(styled.div)
       alignItems="center"


### PR DESCRIPTION

## Motivation and Context:

fix #2926

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):

![Screen Shot 2019-10-06 at 2 17 40 PM](https://user-images.githubusercontent.com/1934678/66276079-2785a180-e844-11e9-9f06-8985300805e4.png)


## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
