### PR TITLE
fix(app): store temp wallets in os tmpdir

### DIFF
--- a/electron/migrator.js
+++ b/electron/migrator.js
@@ -2,8 +2,8 @@ import { writeFile, readFile } from 'fs'
 import { join } from 'path'
 import { promisify } from 'util'
 import { app } from 'electron'
-import migration_1 from './migrations/purge-local-wallets'
-import migration_2 from './migrations/delete-tmp-wallets'
+import purgeLocalWallets from './migrations/purge-local-wallets'
+import deleteTmpWallets from './migrations/delete-tmp-wallets'
 
 const fsWriteFile = promisify(writeFile)
 const fsReadFile = promisify(readFile)
@@ -23,11 +23,15 @@ class ZapMigrator {
     return [
       {
         id: 1,
-        up: migration_1,
+        up: purgeLocalWallets,
       },
       {
         id: 2,
-        up: migration_2,
+        up: deleteTmpWallets,
+      },
+      {
+        id: 3,
+        up: deleteTmpWallets,
       },
     ]
   }

--- a/renderer/reducers/wallet.js
+++ b/renderer/reducers/wallet.js
@@ -191,26 +191,24 @@ export const initWallets = () => async dispatch => {
   // Create wallet entry in the database if one doesn't exist already.
   const { chains, networks } = config
   const fsWallets = await window.Zap.getAllLocalWallets(chains, networks)
-  return fsWallets
-    .filter(wallet => wallet.wallet !== 'wallet-tmp')
-    .forEach(walletDetails => {
-      if (
-        !dbWallets.find(
-          w =>
-            w.type === 'local' &&
-            w.chain === walletDetails.chain &&
-            w.network === walletDetails.network &&
-            w.wallet === walletDetails.wallet
-        )
-      ) {
-        walletDetails.decoder = 'lnd.lndconnect.v1'
-        const id = Number(walletDetails.wallet.split('-')[1])
-        if (id && !Number.isNaN(id)) {
-          walletDetails.id = id
-        }
-        dispatch(putWallet(walletDetails))
+  return fsWallets.forEach(walletDetails => {
+    if (
+      !dbWallets.find(
+        w =>
+          w.type === 'local' &&
+          w.chain === walletDetails.chain &&
+          w.network === walletDetails.network &&
+          w.wallet === walletDetails.wallet
+      )
+    ) {
+      walletDetails.decoder = 'lnd.lndconnect.v1'
+      const id = Number(walletDetails.wallet.split('-')[1])
+      if (id && !Number.isNaN(id)) {
+        walletDetails.id = id
       }
-    })
+      dispatch(putWallet(walletDetails))
+    }
+  })
 }
 
 // ------------------------------------

--- a/utils/lndConfig.js
+++ b/utils/lndConfig.js
@@ -18,28 +18,13 @@ const debug = createDebug('zap:lnd-config')
 
 const LNDCONFIG_TYPE_LOCAL = 'local'
 const LNDCONFIG_TYPE_CUSTOM = 'custom'
+const TEMP_WALLET_ID = 'tmp'
+const TEMP_WALLET_DIR = 'zap-tmp-wallet'
 
-// Supported connection types.
-export const types = {
-  [LNDCONFIG_TYPE_LOCAL]: 'Local',
-  [LNDCONFIG_TYPE_CUSTOM]: 'Custom',
-}
-
-// Supported chains.
-export const chains = {
-  bitcoin: 'Bitcoin',
-  litecoin: 'Litecoin',
-}
-
-// Supported networks.
-export const networks = {
-  mainnet: 'Mainnet',
-  testnet: 'Testnet',
-}
-
-const _isReady = new WeakMap()
-const _lndconnectQRCode = new WeakMap()
-const _tmpDir = new WeakMap()
+// Private properties for `LndConfig` instances.
+const isReadyStore = new WeakMap()
+const lndconnectQRCodeStore = new WeakMap()
+const tmpDirStore = new WeakMap()
 
 // Utility methods to clean and prepare data.
 const safeTrim = val => (typeof val === 'string' ? val.trim() : val)
@@ -71,26 +56,26 @@ class LndConfig {
       lndconnectQRCode: {
         enumerable: true,
         get() {
-          return _lndconnectQRCode.get(this)
+          return lndconnectQRCodeStore.get(this)
         },
       },
 
       isReady: {
         enumerable: false,
         get() {
-          return _isReady.get(this)
+          return isReadyStore.get(this)
         },
       },
       lndDir: {
         enumerable: true,
         get() {
-          if (this.id === 'tmp') {
-            const cache = _tmpDir.get(this)
+          if (this.id === TEMP_WALLET_ID) {
+            const cache = tmpDirStore.get(this)
             if (cache) {
               return cache
             }
-            const lndDir = fs.mkdtempSync(join(tmpdir(), 'zap-tmp-wallet'))
-            _tmpDir.set(this, lndDir)
+            const lndDir = fs.mkdtempSync(join(tmpdir(), TEMP_WALLET_DIR))
+            tmpDirStore.set(this, lndDir)
             return lndDir
           }
           if (this.type === LNDCONFIG_TYPE_LOCAL) {
@@ -183,7 +168,7 @@ class LndConfig {
     // a `ready` property that resolves once we have calculated this value so that users of this class to wait until the
     // `ready` property has been resolved before using the class instance in order to ensure that the instance has been
     // fully instantiated.
-    const isReady = async () => {
+    const completeSetup = async () => {
       try {
         // Generate lndConenct uri.
         const lndconnectUri = await this.generateLndconnectUri(options)
@@ -194,7 +179,7 @@ class LndConfig {
         // Generate lndConenct QR code..
         if (this.lndconnectUri) {
           const lndconnectQRCode = await this.generateLndconnectQRCode()
-          _lndconnectQRCode.set(this, lndconnectQRCode)
+          lndconnectQRCodeStore.set(this, lndconnectQRCode)
         }
         return true
       } catch (e) {
@@ -202,7 +187,7 @@ class LndConfig {
         return true
       }
     }
-    _isReady.set(this, isReady())
+    isReadyStore.set(this, completeSetup())
   }
 
   /**

--- a/utils/lndConfig.js
+++ b/utils/lndConfig.js
@@ -4,6 +4,7 @@ import untildify from 'untildify'
 import tildify from 'tildify'
 import lndconnect from 'lndconnect'
 import fs from 'fs'
+import { tmpdir } from 'os'
 import util from 'util'
 import pick from 'lodash/pick'
 import get from 'lodash/get'
@@ -38,6 +39,7 @@ export const networks = {
 
 const _isReady = new WeakMap()
 const _lndconnectQRCode = new WeakMap()
+const _tmpDir = new WeakMap()
 
 // Utility methods to clean and prepare data.
 const safeTrim = val => (typeof val === 'string' ? val.trim() : val)
@@ -82,10 +84,19 @@ class LndConfig {
       lndDir: {
         enumerable: true,
         get() {
+          if (this.id === 'tmp') {
+            const cache = _tmpDir.get(this)
+            if (cache) {
+              return cache
+            }
+            const lndDir = fs.mkdtempSync(join(tmpdir(), 'zap-tmp-wallet'))
+            _tmpDir.set(this, lndDir)
+            return lndDir
+          }
           if (this.type === LNDCONFIG_TYPE_LOCAL) {
             return join(options.userDataDir, 'lnd', this.chain, this.network, this.wallet)
           }
-          return
+          return null
         },
       },
       host: {


### PR DESCRIPTION
## Description:

fix(app): store temp wallets in os tmpdir

## Motivation and Context:

temp wallets are single use and should not be reused. These wallets never get fully initialised since they are only used to generate a seed. This can cause problems when upgrading lnd as lnd's migration scripts have been known to assume that the wallet had certain data files that only get created after initialising the wallet.

## How Has This Been Tested?

## Types of changes:

Fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
