### PR TITLE
fix(lnd): connect to additional neutrino peers

### DIFF
--- a/services/neutrino/neutrino.js
+++ b/services/neutrino/neutrino.js
@@ -372,7 +372,7 @@ class Neutrino extends EventEmitter {
     neutrinoArgs.push(`--neutrino.useragentversion=${getPackageDetails().version}`)
     neutrinoArgs.push(`--${this.lndConfig.chain}.${this.lndConfig.network}`)
     config.lnd.neutrino[this.lndConfig.chain][this.lndConfig.network].forEach(node =>
-      neutrinoArgs.push(`--neutrino.connect=${node}`)
+      neutrinoArgs.push(`--neutrino.addpeer=${node}`)
     )
 
     return neutrinoArgs


### PR DESCRIPTION
## Description:

Use `--neutrino.addpeer` instead of `--neutrino.connect` to connect to our neutrino nodes. This tells lnd to add our peers but also to seak out additional peers from the network.

## Motivation and Context:

This will help prevent syncing issues if our peers are offline.

## How Has This Been Tested?

Manually

## Types of changes:

Fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
