### PR TITLE
fix(lnd): switch to testnet1 and testnet2 neutrino peers

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -75,7 +75,7 @@ module.exports = {
 
     neutrino: {
       bitcoin: {
-        testnet: ['testnet3-btcd.zaphq.io', 'testnet4-btcd.zaphq.io'],
+        testnet: ['testnet1-btcd.zaphq.io', 'testnet2-btcd.zaphq.io'],
         mainnet: ['mainnet1-btcd.zaphq.io', 'mainnet2-btcd.zaphq.io'],
       },
       litecoin: {


### PR DESCRIPTION
## Description:

Switch to testnet1 and testnet2 neutrino peers

## Motivation and Context:

t1 and t2 have been brought back online and are using a legacy version of bitcoind to serve neutrino filters to 5.x clients.

t3 and t4 have been updated to serve updated filters for the upcoming 0.6 release and are no longer compatible with lnd 0.7.

## How Has This Been Tested?

Manually - sync a testnet neutrino node

## Types of changes:

Fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
