### PR TITLE
fix(wallet): increase fee limit on payment retries

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -102,7 +102,8 @@ module.exports = {
   invoices: {
     expire: 3600,
     baseRetryDelay: 1000,
-    retryCount: 3, // Number of retries for pay invoice failure
+    retryCount: 2, // Number of retries for pay invoice failure
+    feeIncrementExponent: 1.1, // Exponent applied to fee limit on payment retry attempts
   },
 
   autopay: {

--- a/renderer/components/Pay/Pay.js
+++ b/renderer/components/Pay/Pay.js
@@ -6,7 +6,14 @@ import get from 'lodash/get'
 import { Box, Flex } from 'rebass'
 import { animated, Keyframes, Transition } from 'react-spring/renderprops.cjs'
 import { FormattedMessage, injectIntl, intlShape } from 'react-intl'
-import { decodePayReq, getMinFee, getMaxFee, isOnchain, isLn } from '@zap/utils/crypto'
+import {
+  decodePayReq,
+  getMinFee,
+  getMaxFee,
+  getMaxFeeInclusive,
+  isOnchain,
+  isLn,
+} from '@zap/utils/crypto'
 import { convert } from '@zap/utils/btc'
 import {
   Bar,
@@ -559,10 +566,10 @@ class Pay extends React.Component {
 
     const formState = this.formApi.getState()
     const { speed, payReq, isCoinSweep } = formState.values
-    let minFee, maxFee
+    let minFee, maxFeeInclusive
     if (routes.length) {
       minFee = getMinFee(routes)
-      maxFee = getMaxFee(routes)
+      maxFeeInclusive = getMaxFeeInclusive(routes)
     }
     const render = () => {
       // convert entered amount to satoshis
@@ -584,7 +591,7 @@ class Pay extends React.Component {
         return (
           <PaySummaryLightning
             amount={amount}
-            maxFee={maxFee}
+            maxFee={maxFeeInclusive}
             minFee={minFee}
             mt={-3}
             payReq={payReq}

--- a/test/unit/utils/crypto.spec.js
+++ b/test/unit/utils/crypto.spec.js
@@ -1,5 +1,12 @@
 /* eslint-disable max-len */
-import { formatValue, isLn, isOnchain } from '@zap/utils/crypto'
+import {
+  formatValue,
+  isLn,
+  isOnchain,
+  getMinFee,
+  getMaxFee,
+  getMaxFeeInclusive,
+} from '@zap/utils/crypto'
 
 const VALID_BITCOIN_MAINNET_LN =
   'lnbc10u1pduey89pp57gt0mqvh9gv4m5kkxmy9a0a46ha5jlzr3mcfcz2fx8tzu63vpjksdq8w3jhxaqcqzystfg0drarrx89nvpegwykvfr4fypvwz2d9ktcr6tj5s08f0nn8gdjnv74y9amksk3rjw7englhjrsev70k77vwf603qh2pr4tnqeue6qp5n92gy'
@@ -119,5 +126,41 @@ describe('formatValue', () => {
 
     test(['1', '0'], '1.0')
     test(['01', '0'], '01.0')
+  })
+})
+
+describe('getMinFee', () => {
+  const test = (from, to) => expect(getMinFee(from)).toEqual(to)
+  it('returns the minimum fee (1 above the lowest value)', () => {
+    test([], null)
+    test([{ total_fees: 2 }], 3)
+    test([{ total_fees: 2 }, { total_fees: 5 }], 3)
+    test([{ total_fees: 4 }], 5)
+    test([{ total_fees: 0 }], 1)
+    test([{ total_fees: 85 }, { total_fees: 95 }], 86)
+  })
+})
+
+describe('getMaxFee', () => {
+  const test = (from, to) => expect(getMaxFee(from)).toEqual(to)
+  it('returns the maximum fee (1 above the highest value)', () => {
+    test([], null)
+    test([{ total_fees: 2 }], 3)
+    test([{ total_fees: 2 }, { total_fees: 5 }], 6)
+    test([{ total_fees: 4 }], 5)
+    test([{ total_fees: 0 }], 1)
+    test([{ total_fees: 85 }, { total_fees: 95 }], 96)
+  })
+})
+
+describe('getMaxFeeInclusive', () => {
+  const test = (from, to) => expect(getMaxFeeInclusive(from)).toEqual(to)
+  it('returns the minimum fee includding increases after all retry attempts', () => {
+    test([], null)
+    test([{ total_fees: 2 }], 5)
+    test([{ total_fees: 2 }, { total_fees: 5 }], 8)
+    test([{ total_fees: 4 }], 7)
+    test([{ total_fees: 0 }], 3)
+    test([{ total_fees: 85 }, { total_fees: 95 }], 117)
   })
 })

--- a/utils/crypto.js
+++ b/utils/crypto.js
@@ -1,4 +1,6 @@
 import get from 'lodash/get'
+import config from 'config'
+import range from 'lodash/range'
 import { address } from 'bitcoinjs-lib'
 import lightningRequestReq from 'bolt11'
 import coininfo from 'coininfo'
@@ -172,9 +174,9 @@ export const getNodeAlias = (pubkey, nodes = []) => {
 }
 
 /**
- * getMinFee - Given a list of routest, find the minimum fee.
+ * getMinFee - Given a list of routes, find the minimum fee.
  *
- * @param {*} routes List of routes
+ * @param {Array} routes List of routes
  * @returns {number} minimum fee rounded up to the nearest satoshi
  */
 export const getMinFee = (routes = []) => {
@@ -188,9 +190,9 @@ export const getMinFee = (routes = []) => {
 }
 
 /**
- * getMaxFee - Given a list of routest, find the maximum fee.
+ * getMaxFee - Given a list of routes, find the maximum fee.
  *
- * @param {*} routes List of routes
+ * @param {Array} routes List of routes
  * @returns {number} maximum fee
  */
 export const getMaxFee = routes => {
@@ -204,9 +206,28 @@ export const getMaxFee = routes => {
 }
 
 /**
+ * getMaxFee - Given a list of routes, find the maximum fee factoring in all possible payment retry attempts.
+ *
+ * @param {Array} routes List of routes
+ * @returns {number} maximum fee
+ */
+export const getMaxFeeInclusive = routes => {
+  if (!routes || !routes.length) {
+    return null
+  }
+
+  const {
+    invoices: { retryCount, feeIncrementExponent },
+  } = config
+
+  let fee = getMaxFee(routes)
+  return range(retryCount).reduce(max => Math.ceil(max * feeIncrementExponent), fee)
+}
+
+/**
  * getFeeRange - Given a list of routest, find the maximum and maximum fee.
  *
- * @param {*} routes List of routes
+ * @param {Array} routes List of routes
  * @returns {{min:number, max:number}} object with keys `min` and `max`
  */
 export const getFeeRange = (routes = []) => ({


### PR DESCRIPTION




## Description:

In the case the queryRoutes gives us an unplayable route we retry the payment a couple of times. When doing the retries, increase the fee limit to increase the chance of payment success.

## Motivation and Context:

fix 32952

## How Has This Been Tested?

Manually

## Types of changes:

Fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
