### PR TITLE
refactor: ensure window.Zap.getPlatform exists in storybook

### DIFF
--- a/stories/Provider.js
+++ b/stories/Provider.js
@@ -21,6 +21,7 @@ window.db = db
 window.Zap = {
   openExternal: uri => window.open(uri, '_blank'),
   sha256digest,
+  getPlatform: () => null,
   splitHostname: host => {
     const { hostname = host, port } = new URL(`http://${host}`)
     return { host: hostname, port }


### PR DESCRIPTION
## Description:

Ensure window.Zap.getPlatform exists in storybook

## Motivation and Context:

Storybook not working due to the fact that `window.Zap.getPlatform` doesn't exist but is now used in some components.

## How Has This Been Tested?

`yarn storybook`

## Types of changes:

Fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
