### PR TITLE
fix(ui): no form error when form is empty

### DIFF
--- a/renderer/components/Pay/Pay.js
+++ b/renderer/components/Pay/Pay.js
@@ -382,6 +382,7 @@ class Pay extends React.Component {
                 cryptoUnitName={cryptoUnitName}
                 currentStep={currentStep}
                 formApi={this.formApi}
+                formState={formState}
                 handlePayReqChange={this.handlePayReqChange}
                 initialAmountCrypto={initialAmountCrypto}
                 initialAmountFiat={initialAmountFiat}

--- a/renderer/components/Pay/PayAddressField.js
+++ b/renderer/components/Pay/PayAddressField.js
@@ -24,11 +24,18 @@ class PayAddressField extends React.Component {
   static propTypes = {
     chain: PropTypes.string.isRequired,
     currentStep: PropTypes.string.isRequired,
+    formState: PropTypes.object,
     handlePayReqChange: PropTypes.func.isRequired,
     intl: intlShape.isRequired,
     isLn: PropTypes.bool,
     network: PropTypes.string.isRequired,
     redirectPayReq: PropTypes.object,
+  }
+
+  static defaultProps = {
+    formState: {
+      values: {},
+    },
   }
 
   /**
@@ -54,34 +61,44 @@ class PayAddressField extends React.Component {
   }
 
   render() {
-    const { chain, currentStep, handlePayReqChange, isLn, network, redirectPayReq } = this.props
+    const {
+      chain,
+      currentStep,
+      formState,
+      handlePayReqChange,
+      isLn,
+      network,
+      redirectPayReq,
+    } = this.props
     const addressFieldState = currentStep === PAY_FORM_STEPS.address || isLn ? 'big' : 'small'
+
+    const { payReq } = formState.values
+    const { submits } = formState
+    const willValidateInline = submits > 0 || (submits === 0 && Boolean(payReq))
 
     return (
       <Box className={currentStep === PAY_FORM_STEPS.summary ? 'element-hide' : 'element-show'}>
         <ShowHidePayReq context={this} state={addressFieldState}>
           {styles => (
-            <React.Fragment>
-              <LightningInvoiceInput
-                chain={chain}
-                css="resize: vertical;"
-                field="payReq"
-                forwardedRef={this.payReqInput}
-                initialValue={redirectPayReq && redirectPayReq.address}
-                isReadOnly={currentStep !== PAY_FORM_STEPS.address}
-                isRequired
-                label={this.getPaymentRequestLabel()}
-                minHeight={48}
-                name="payReq"
-                network={network}
-                onValueChange={handlePayReqChange}
-                style={styles}
-                validateOnBlur
-                validateOnChange
-                width={1}
-                willAutoFocus
-              />
-            </React.Fragment>
+            <LightningInvoiceInput
+              chain={chain}
+              css="resize: vertical;"
+              field="payReq"
+              forwardedRef={this.payReqInput}
+              initialValue={redirectPayReq && redirectPayReq.address}
+              isReadOnly={currentStep !== PAY_FORM_STEPS.address}
+              isRequired
+              label={this.getPaymentRequestLabel()}
+              minHeight={48}
+              name="payReq"
+              network={network}
+              onValueChange={handlePayReqChange}
+              style={styles}
+              validateOnBlur={willValidateInline}
+              validateOnChange={willValidateInline}
+              width={1}
+              willAutoFocus
+            />
           )}
         </ShowHidePayReq>
       </Box>

--- a/renderer/components/Pay/PayPanelBody.js
+++ b/renderer/components/Pay/PayPanelBody.js
@@ -15,6 +15,7 @@ const PayPanelBody = props => {
     cryptoUnitName,
     currentStep,
     formApi,
+    formState,
     handlePayReqChange,
     initialAmountCrypto,
     initialAmountFiat,
@@ -45,6 +46,7 @@ const PayPanelBody = props => {
       <PayAddressField
         chain={chain}
         currentStep={currentStep}
+        formApi={formState}
         handlePayReqChange={handlePayReqChange}
         intl={intl}
         isLn={isLn}
@@ -87,6 +89,7 @@ PayPanelBody.propTypes = {
   cryptoUnitName: PropTypes.string.isRequired,
   currentStep: PropTypes.string.isRequired,
   formApi: PropTypes.object.isRequired,
+  formState: PropTypes.object.isRequired,
   handlePayReqChange: PropTypes.func.isRequired,
   initialAmountCrypto: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   initialAmountFiat: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),

--- a/renderer/components/Request/Request.js
+++ b/renderer/components/Request/Request.js
@@ -162,12 +162,16 @@ class Request extends React.Component {
 
   renderAmountFields = () => {
     const { isAnimating } = this.props
+    const { submits } = this.formApi.getState()
+    const willValidateInline = submits > 0
     return (
       <CurrencyFieldGroup
         formApi={this.formApi}
         forwardedRef={this.amountInput}
         isRequired
         mb={3}
+        validateOnBlur={willValidateInline}
+        validateOnChange={willValidateInline}
         willAutoFocus={!isAnimating}
       />
     )

--- a/test/unit/components/Pay/PayAddressField.spec.js
+++ b/test/unit/components/Pay/PayAddressField.spec.js
@@ -11,6 +11,7 @@ const props = {
   isLn: null,
   network: 'testnet',
   redirectPayReq: {},
+  formState: { values: {}, submits: 0 },
 }
 
 describe('component.Pay.PayAddressField', () => {

--- a/test/unit/components/Pay/__snapshots__/PayAddressField.spec.js.snap
+++ b/test/unit/components/Pay/__snapshots__/PayAddressField.spec.js.snap
@@ -16,6 +16,10 @@ exports[`component.Pay.PayAddressField current step is "address" should render c
         "props": Object {
           "chain": "Bitcoin",
           "currentStep": "address",
+          "formState": Object {
+            "submits": 0,
+            "values": Object {},
+          },
           "handlePayReqChange": [Function],
           "intl": Object {},
           "isLn": null,
@@ -47,6 +51,12 @@ exports[`component.Pay.PayAddressField current step is "address" should render c
             "_element": <PayAddressField
               chain="Bitcoin"
               currentStep="address"
+              formState={
+                Object {
+                  "submits": 0,
+                  "values": Object {},
+                }
+              }
               handlePayReqChange={[Function]}
               intl={Object {}}
               isLn={null}
@@ -100,6 +110,10 @@ exports[`component.Pay.PayAddressField current step is "summary" and it is an LN
         "props": Object {
           "chain": "Bitcoin",
           "currentStep": "summary",
+          "formState": Object {
+            "submits": 0,
+            "values": Object {},
+          },
           "handlePayReqChange": [Function],
           "intl": Object {},
           "isLn": true,
@@ -131,6 +145,12 @@ exports[`component.Pay.PayAddressField current step is "summary" and it is an LN
             "_element": <PayAddressField
               chain="Bitcoin"
               currentStep="summary"
+              formState={
+                Object {
+                  "submits": 0,
+                  "values": Object {},
+                }
+              }
               handlePayReqChange={[Function]}
               intl={Object {}}
               isLn={true}
@@ -184,6 +204,10 @@ exports[`component.Pay.PayAddressField current step is "summary" and it is an on
         "props": Object {
           "chain": "Bitcoin",
           "currentStep": "summary",
+          "formState": Object {
+            "submits": 0,
+            "values": Object {},
+          },
           "handlePayReqChange": [Function],
           "intl": Object {},
           "isLn": false,
@@ -215,6 +239,12 @@ exports[`component.Pay.PayAddressField current step is "summary" and it is an on
             "_element": <PayAddressField
               chain="Bitcoin"
               currentStep="summary"
+              formState={
+                Object {
+                  "submits": 0,
+                  "values": Object {},
+                }
+              }
               handlePayReqChange={[Function]}
               intl={Object {}}
               isLn={false}

--- a/test/unit/components/Pay/__snapshots__/PayPanelBody.spec.js.snap
+++ b/test/unit/components/Pay/__snapshots__/PayPanelBody.spec.js.snap
@@ -10,6 +10,11 @@ exports[`component.Pay.PayPanelBody current step is not summary should render co
   <PayAddressField
     chain="testnet"
     currentStep="amount"
+    formState={
+      Object {
+        "values": Object {},
+      }
+    }
     handlePayReqChange={[Function]}
     intl={Object {}}
     network=""
@@ -56,6 +61,11 @@ exports[`component.Pay.PayPanelBody current step is summary should render correc
   <PayAddressField
     chain="testnet"
     currentStep="summary"
+    formState={
+      Object {
+        "values": Object {},
+      }
+    }
     handlePayReqChange={[Function]}
     intl={Object {}}
     network=""


### PR DESCRIPTION
## Description:

Don't validate pay/request forms unless there are some values to validate. This prevents the form showing errors when closing the modal in the case that nothing has been entered into the form yet.

## Motivation and Context:

fix #3016

## How Has This Been Tested?

Close pay and receive forms without entering any values and verify form fields do not turn red.

## Types of changes:

Fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
