### PR TITLE
Update misleading wallet unlock description

### DIFF
--- a/renderer/components/Onboarding/Steps/messages.js
+++ b/renderer/components/Onboarding/Steps/messages.js
@@ -29,7 +29,7 @@ export default defineMessages({
   connection_string_invalid: 'Invalid Connection String',
   connection_title: 'How will you connect to the Lightning Network?',
   create_wallet_password_description:
-    'Set a password to encrypt your wallet. This password will be needed to unlock Zap in the future.',
+    'Set a password to encrypt your wallet. This password will be needed to unlock the wallet in the future.',
   create_wallet_password_title: 'Welcome!',
   custom: 'Custom',
   default: 'Default',

--- a/translations/cs-CZ.json
+++ b/translations/cs-CZ.json
@@ -364,7 +364,7 @@
   "components.Onboarding.Steps.connection_uri_btcpay_description": "Vložte celý obsah konfiguračního souboru připojení k serveru BTCPay. To lze najít kliknutím na odkaz s názvem „Klepnutím sem otevřete konfigurační soubor“ v nastavení vašeho BTCPay Serveru gRPC.",
   "components.Onboarding.Steps.connection_uri_label": "Řetězec připojení",
   "components.Onboarding.Steps.connection_uri_lndconnect_description": "Vložit Lnd připojovací URI. Jeden z nich můžete vygenerovat pomocí lndconnect utility. Například: \"lndconnect://1.2.3.4:10009?cert=x&macaroon=y\"",
-  "components.Onboarding.Steps.create_wallet_password_description": "Nastavte heslo pro zašifrování vaší peněženky. Toto heslo bude nutné pro budoucí odemknutí Zapu.",
+  "components.Onboarding.Steps.create_wallet_password_description": "Nastavte heslo pro zašifrování vaší peněženky. Toto heslo bude nutné v budoucnu odemknout.",
   "components.Onboarding.Steps.create_wallet_password_title": "Vítejte!",
   "components.Onboarding.Steps.creating_wallet": "Vytváření peněženky…",
   "components.Onboarding.Steps.custom": "Vlastní",

--- a/translations/da-DK.json
+++ b/translations/da-DK.json
@@ -364,7 +364,7 @@
   "components.Onboarding.Steps.connection_uri_btcpay_description": "Indsæt det fulde indhold af din BTCPay Server-forbindelses konfig fil. Dette kan findes ved at klikke på linket med titlen \"Klik her for at åbne konfigurationsfilen\" i dine BTCPay Server gRPC indstillinger.",
   "components.Onboarding.Steps.connection_uri_label": "Forbindelsesstreng",
   "components.Onboarding.Steps.connection_uri_lndconnect_description": "",
-  "components.Onboarding.Steps.create_wallet_password_description": "Det ser ud som om du er ny her. Indtast et adgangskode for at kryptere din tegnebog. Denne adgangskode vil være nødvendig for at låse Zap op i fremtiden",
+  "components.Onboarding.Steps.create_wallet_password_description": "Indtast et adgangskode for at kryptere din tegnebog. Denne adgangskode kræves for at låse tegnebogen i fremtiden.",
   "components.Onboarding.Steps.create_wallet_password_title": "Velkommen!",
   "components.Onboarding.Steps.creating_wallet": "",
   "components.Onboarding.Steps.custom": "Brugerdefinerede",

--- a/translations/de-DE.json
+++ b/translations/de-DE.json
@@ -364,7 +364,7 @@
   "components.Onboarding.Steps.connection_uri_btcpay_description": "Fügen den vollen Inhalt deiner BTCPay Server Verbindungskonfigurationsdatei ein. Dies kann durch Klicken auf den Link \"Klicken hier, um die Konfigurationsdatei zu öffnen\" in deiner BTCPay Server gRPC Einstellungen gefunden werden.",
   "components.Onboarding.Steps.connection_uri_label": "Zeichenfolge der Verbindung",
   "components.Onboarding.Steps.connection_uri_lndconnect_description": "Füge eine Lnd Connect URI ein. Du kannst eine davon mit dem lndconnect-Dienstprogramm generieren. Beispiel: \"lndconnect://1.2.3.4:10009?cert=x&macaroon=y\"",
-  "components.Onboarding.Steps.create_wallet_password_description": "Sieht aus, als ob du hier neu bist. Setze ein Passwort, um deine Wallet zu verschlüsseln. Dieses Passwort wird benötigt, um Zap in Zukunft freizuschalten.",
+  "components.Onboarding.Steps.create_wallet_password_description": "Setze ein Passwort, um deine Wallet zu verschlüsseln. Dieses Passwort wird benötigt, die Brieftasche in Zukunft freizuschalten.",
   "components.Onboarding.Steps.create_wallet_password_title": "Willkommen!",
   "components.Onboarding.Steps.creating_wallet": "Wallet wird erstellt…",
   "components.Onboarding.Steps.custom": "Benutzerdefiniert",

--- a/translations/en.json
+++ b/translations/en.json
@@ -364,7 +364,7 @@
   "components.Onboarding.Steps.connection_uri_btcpay_description": "Paste the full content of your BTCPay Server connection config file. This can be found by clicking the link entitled 'Click here to open the configuration file' in your BTCPay Server gRPC settings.",
   "components.Onboarding.Steps.connection_uri_label": "Connection String",
   "components.Onboarding.Steps.connection_uri_lndconnect_description": "Paste an Lnd Connect URI. You can generate one of these using the lndconnect utility. Example: \"lndconnect://1.2.3.4:10009?cert=x&macaroon=y\"",
-  "components.Onboarding.Steps.create_wallet_password_description": "Set a password to encrypt your wallet. This password will be needed to unlock Zap in the future.",
+  "components.Onboarding.Steps.create_wallet_password_description": "Set a password to encrypt your wallet. This password will be needed to unlock the wallet in the future.",
   "components.Onboarding.Steps.create_wallet_password_title": "Welcome!",
   "components.Onboarding.Steps.creating_wallet": "Creating wallet…",
   "components.Onboarding.Steps.custom": "Custom",

--- a/translations/es-ES.json
+++ b/translations/es-ES.json
@@ -364,7 +364,7 @@
   "components.Onboarding.Steps.connection_uri_btcpay_description": "Pegar todo el contenido del archivo de configuración de conexión de su servidor BTCPay. Esto se puede encontrar haciendo clic en el enlace titulado \"haga clic aquí para abrir el archivo de configuración.\" en los comandos de configuración del servidor gRPC BTCPay.",
   "components.Onboarding.Steps.connection_uri_label": "Cadena de conexión",
   "components.Onboarding.Steps.connection_uri_lndconnect_description": "Pegar un LND Connect URI. Puedes generar uno de estos usando la utilidad lndconnect. Ejemplo: \"lndconnect://1.2.3.4:10009?cert=x&macaroon=y\"",
-  "components.Onboarding.Steps.create_wallet_password_description": "Parece que eres nuevo aquí. Establezca una contraseña para cifrar su billetera. Esta contraseña será necesaria para desbloquear Zap en el futuro.",
+  "components.Onboarding.Steps.create_wallet_password_description": "Establezca una contraseña para cifrar su billetera. Esta contraseña será necesaria para desbloquear la billetera en el futuro.",
   "components.Onboarding.Steps.create_wallet_password_title": "Bienvenido",
   "components.Onboarding.Steps.creating_wallet": "Creando cartera…",
   "components.Onboarding.Steps.custom": "Personalizado",

--- a/translations/fr-FR.json
+++ b/translations/fr-FR.json
@@ -364,7 +364,7 @@
   "components.Onboarding.Steps.connection_uri_btcpay_description": "Collez le contenu complet de votre fichier de configuration de connexion BTCPay Server. Vous pourrez trouver ce dernier en cliquant sur le lien nommé \"Cliquez ici pour ouvrir le fichier de configuration\" dans vos paramètres gRPC BTCPay Server.",
   "components.Onboarding.Steps.connection_uri_label": "Chaîne de connexion",
   "components.Onboarding.Steps.connection_uri_lndconnect_description": "Collez une URI lndconnect. Vous pouvez en générer une en utilisant l'utilitaire lndconnect. Exemple : \"lndconnect://1.2.3.4:10009?cert=x&macaroon=y\"",
-  "components.Onboarding.Steps.create_wallet_password_description": "Définissez un mot de passe afin de chiffrer votre portefeuille. Ce mot de passe vous sera demandé pour déverrouiller Zap à l'avenir.",
+  "components.Onboarding.Steps.create_wallet_password_description": "Définissez un mot de passe afin de chiffrer votre portefeuille. Ce mot de passe vous sera demandé pour déverrouiller le portefeuille à l'avenir.",
   "components.Onboarding.Steps.create_wallet_password_title": "Bienvenue !",
   "components.Onboarding.Steps.creating_wallet": "Création du portefeuille…",
   "components.Onboarding.Steps.custom": "Personnalisé",

--- a/translations/hr-HR.json
+++ b/translations/hr-HR.json
@@ -364,7 +364,7 @@
   "components.Onboarding.Steps.connection_uri_btcpay_description": "Iskopirajte cijeli sadržaj svoje BTCPay Server konfiguracijske datoteke za spajanje. Možete ga pronaći klikom na link naziva Kliknite ovdje za otvaranje konfiguracijske datoteke. u vašim BTCPay Server gRPC postavkama.",
   "components.Onboarding.Steps.connection_uri_label": "String veze",
   "components.Onboarding.Steps.connection_uri_lndconnect_description": "",
-  "components.Onboarding.Steps.create_wallet_password_description": "Izgleda da ste novi ovdje. Postavite lozinku za šifriranje novčanika. Ova lozinka će biti potrebna za otključati Zapa u budućnosti",
+  "components.Onboarding.Steps.create_wallet_password_description": "Postavite lozinku za šifriranje novčanika. Ova će lozinka će potrebna da biste ubuduće otključali novčanik.",
   "components.Onboarding.Steps.create_wallet_password_title": "Dobrodošli!",
   "components.Onboarding.Steps.creating_wallet": "",
   "components.Onboarding.Steps.custom": "Prilagođeno",


### PR DESCRIPTION
## Description:

Update misleading wallet unlock description.

Change from:
`Set a password to encrypt your wallet. This password will be needed to unlock Zap in the future.`

To:
`Set a password to encrypt your wallet. This password will be needed to unlock the wallet in the future.`

NOTE: I've also updated other text for other languages that have provided translations. Whilst doing so I noticed that some of the other translations still included the phrase `looks like you are new here!`at the start of the text, which was removed from the english translation a while ago so I removed it from those translations too.

## Motivation and Context:

We now have a app-wide password feature which currently operates in addition to the wallet level password. The language on the password setup screen as part of wallet onboarding should be more clear that the password relates to the wallet and not Zap as a whole.

Fix #2978 
## How Has This Been Tested?

Manually

## Types of changes:

Language change

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
