### PR TITLE
Skip generation of lndconnect qrcode links for temporary wallets

### DIFF
--- a/utils/lndConfig.js
+++ b/utils/lndConfig.js
@@ -232,6 +232,12 @@ class LndConfig {
    * @returns {string} Embedded lndconnect uri.
    */
   async generateLndconnectQRCode() {
+    // Temporary wallets are only used for the purpose of generating a new seed and will not support QR code generation
+    // as they will never be running long enough to have a certificate or macaroon generated.
+    if (this.id === TEMP_WALLET_ID) {
+      return null
+    }
+
     const { decoder, lndconnectUri } = this
     switch (decoder) {
       case 'lnd.lndconnect.v1':

--- a/utils/lndConfig.js
+++ b/utils/lndConfig.js
@@ -66,10 +66,16 @@ class LndConfig {
           return isReadyStore.get(this)
         },
       },
+      isTemporary: {
+        enumerable: true,
+        get() {
+          return this.id === TEMP_WALLET_ID
+        },
+      },
       lndDir: {
         enumerable: true,
         get() {
-          if (this.id === TEMP_WALLET_ID) {
+          if (this.isTemporary) {
             const cache = tmpDirStore.get(this)
             if (cache) {
               return cache
@@ -234,7 +240,7 @@ class LndConfig {
   async generateLndconnectQRCode() {
     // Temporary wallets are only used for the purpose of generating a new seed and will not support QR code generation
     // as they will never be running long enough to have a certificate or macaroon generated.
-    if (this.id === TEMP_WALLET_ID) {
+    if (this.isTemporary) {
       return null
     }
 


### PR DESCRIPTION
## Description:

Skip generation of lndconnect qrcode links for temporary wallets.

## Motivation and Context:

Temporary wallets are only used for the purpose of generating a new seed and will not support QR code generation as they will never be running long enough to have a certificate or macaroon generated.

## How Has This Been Tested?

Create new local wallet and verify there is no console warning when starting up the temp wallet to generate the seed.

## Types of changes:

Fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
