### PR TITLE
Improve address generation error handling

### DIFF
--- a/renderer/reducers/address.js
+++ b/renderer/reducers/address.js
@@ -65,16 +65,17 @@ export const initAddresses = () => async (dispatch, getState) => {
 
     // Get existing addresses for the node.
     const addresses = get(node, 'addresses', {})
-    dispatch({ type: FETCH_ADDRESSES_SUCCESS, addresses })
 
     // Ensure that we have an address for all supported address types.
     await Promise.all(
-      Object.keys(ADDRESS_TYPES).forEach(type => {
+      Object.keys(ADDRESS_TYPES).map(async type => {
         if (!addresses[type]) {
-          dispatch(newAddress(type))
+          return dispatch(newAddress(type))
         }
+        return null
       })
     )
+    dispatch({ type: FETCH_ADDRESSES_SUCCESS, addresses })
   } catch (error) {
     dispatch({ type: FETCH_ADDRESSES_FAILURE, error: error.message })
   }


### PR DESCRIPTION
## Description:

Ensure failures and successes are properly handled in initAddresses. Wait until all addresses have been fetched/generated before dispatching success action.

## Motivation and Context:

Fix #3116

## How Has This Been Tested?

Manually

## Types of changes:

Fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
