### PR TITLE
Ensure onboarding dialogs display on top of wizard controls

### DIFF
--- a/renderer/components/Onboarding/Steps/BackupSetup.js
+++ b/renderer/components/Onboarding/Steps/BackupSetup.js
@@ -129,6 +129,7 @@ class BackupSetup extends React.Component {
           isRestoreMode={isRestoreMode}
           onCancel={this.onCancelSkip}
           onSkip={this.onSkip}
+          position="fixed"
         />
       </Container>
     )

--- a/renderer/components/Onboarding/Steps/WalletCreate.js
+++ b/renderer/components/Onboarding/Steps/WalletCreate.js
@@ -89,6 +89,7 @@ class WalletCreate extends React.Component {
             error={createWalletError}
             isOpen={Boolean(createWalletError)}
             onClose={this.resetOnboarding}
+            position="fixed"
           />
         </Form>
       </CenteredContent>

--- a/renderer/components/Onboarding/Steps/WalletRecover.js
+++ b/renderer/components/Onboarding/Steps/WalletRecover.js
@@ -136,6 +136,7 @@ class WalletRecover extends React.Component {
                       isOpen={Boolean(createWalletError)}
                       isRestoreMode
                       onClose={this.resetOnboarding}
+                      position="fixed"
                     />
                   )}
                 </>

--- a/renderer/components/Onboarding/Steps/components/ErrorDialog.js
+++ b/renderer/components/Onboarding/Steps/components/ErrorDialog.js
@@ -6,7 +6,7 @@ import Delete from 'components/Icon/Delete'
 import { Dialog, Heading, DialogOverlay, Text, Button } from 'components/UI'
 import messages from './messages'
 
-const ErrorDialog = ({ onClose, error, isRestoreMode, isOpen }) => {
+const ErrorDialog = ({ onClose, error, isRestoreMode, isOpen, position }) => {
   if (!isOpen) {
     return null
   }
@@ -27,7 +27,7 @@ const ErrorDialog = ({ onClose, error, isRestoreMode, isOpen }) => {
     : messages.error_dialog_create_wallet_error_desc
 
   return (
-    <DialogOverlay alignItems="center" justifyContent="center">
+    <DialogOverlay alignItems="center" justifyContent="center" position={position}>
       <Dialog
         buttons={
           <Button onClick={onClose} type="button" variant="danger">
@@ -52,6 +52,7 @@ ErrorDialog.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   isRestoreMode: PropTypes.bool,
   onClose: PropTypes.func.isRequired,
+  position: PropTypes.string,
 }
 
 export default ErrorDialog

--- a/renderer/components/Onboarding/Steps/components/SkipBackupsDialog.js
+++ b/renderer/components/Onboarding/Steps/components/SkipBackupsDialog.js
@@ -9,7 +9,7 @@ import { Dialog, Text, Heading, Button, DialogOverlay } from 'components/UI'
 import { Checkbox, Form } from 'components/Form'
 import messages from './messages'
 
-const DialogWrapper = ({ intl, isOpen, isRestoreMode, onSkip, onCancel }) => {
+const DialogWrapper = ({ intl, isOpen, isRestoreMode, onSkip, onCancel, position }) => {
   if (!isOpen) {
     return null
   }
@@ -52,7 +52,7 @@ const DialogWrapper = ({ intl, isOpen, isRestoreMode, onSkip, onCancel }) => {
     : messages.skip_backup_dialog_warning
 
   return (
-    <DialogOverlay alignItems="center" justifyContent="center">
+    <DialogOverlay alignItems="center" justifyContent="center" position={position}>
       <Form onSubmit={handleSubmit}>
         <Dialog buttons={buttons} header={header} onClose={onCancel} width={640}>
           <Flex alignItems="center" flexDirection="column">
@@ -75,6 +75,7 @@ DialogWrapper.propTypes = {
   isRestoreMode: PropTypes.bool,
   onCancel: PropTypes.func.isRequired,
   onSkip: PropTypes.func.isRequired,
+  position: PropTypes.string,
 }
 
 export default injectIntl(DialogWrapper)


### PR DESCRIPTION
## Description:

Use fixed positioning for dialogs that are displayed in the onboarding process to ensure that they appear on top of the wizard controls.

## Motivation and Context:

fix #3119

## How Has This Been Tested?

Check dialog display in onboarding process and in the storybook

## Types of changes:

Fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
