### PR TITLE
Don't re-render SeedConfirm on mount

### DIFF
--- a/renderer/components/Onboarding/Steps/SeedConfirm.js
+++ b/renderer/components/Onboarding/Steps/SeedConfirm.js
@@ -7,9 +7,26 @@ import { Bar, Header, Span } from 'components/UI'
 import { Form, Input, Label } from 'components/Form'
 import messages from './messages'
 
+/**
+ * genIndices - Generate a random selection of seed word indexes.
+ *
+ * @param {number} qty Number of indexes to generate
+ * @returns {Array} Array of random seed indexes
+ */
+const genIndices = qty => {
+  const seedWordIndexes = []
+  while (seedWordIndexes.length < qty) {
+    const r = Math.floor(Math.random() * 24) + 1
+    if (seedWordIndexes.indexOf(r) === -1) {
+      seedWordIndexes.push(r)
+    }
+  }
+  return seedWordIndexes
+}
+
 class SeedConfirm extends React.Component {
   state = {
-    seedWordIndexes: [],
+    seedWordIndexes: genIndices(3),
   }
 
   static propTypes = {
@@ -22,21 +39,6 @@ class SeedConfirm extends React.Component {
   static defaultProps = {
     wizardApi: {},
     wizardState: {},
-  }
-
-  componentDidMount() {
-    this.fetchSeedWordIndexes()
-  }
-
-  fetchSeedWordIndexes = () => {
-    const seedWordIndexes = []
-    while (seedWordIndexes.length < 3) {
-      const r = Math.floor(Math.random() * 24) + 1
-      if (seedWordIndexes.indexOf(r) === -1) {
-        seedWordIndexes.push(r)
-      }
-    }
-    this.setState({ seedWordIndexes })
   }
 
   setFormApi = formApi => {


### PR DESCRIPTION
## Description:

Don't re render SeedConfirm on mount.

## Motivation and Context:

Fix #3118

## How Has This Been Tested?

Manually

## Types of changes:

Fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
