### PR TITLE
Upgrade consistent-return from warn to error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,6 @@ var path = require('path')
 
 const downgraded = [
   'class-methods-use-this',
-  'consistent-return',
   'max-classes-per-file',
   'no-async-promise-executor',
   'no-await-in-loop',


### PR DESCRIPTION
## Description:

Upgrade consistent-return from warn to error

## Motivation and Context:

All `consistent-return` lint violations have been fixed, so upgrade this rule from warn to error to prevent new issues creeping into the codebase.

## How Has This Been Tested?

manually

## Types of changes:

lint update

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
