### PR TITLE
Support bolt11 invoices encoded in bip21 uris

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -62,6 +62,7 @@ mainLog.time('Time until app is ready')
  * @param {string} input Bitcoin link
  */
 const handleBitcoinLink = input => {
+  mainLog.info('Attempting to process bitcoin uri: %s', input)
   try {
     const decoded = bip21.decode(input)
     zap.sendMessage('bitcoinPaymentUri', decoded)

--- a/renderer/reducers/pay.js
+++ b/renderer/reducers/pay.js
@@ -107,8 +107,17 @@ export const lightningPaymentUri = (event, { address }) => (dispatch, getState) 
  * @param  {{ address, options }} options Decoded bip21 payment url
  * @returns {Function} Thunk
  */
-export const bitcoinPaymentUri = (event, { address, options: { amount } }) => dispatch => {
-  dispatch(setRedirectPayReq({ address, amount }))
+export const bitcoinPaymentUri = (event, { address, options = {} }) => dispatch => {
+  // If the bip21 data includes a bolt11 invoice in the `lightning` key handle as a lightning payment.
+  const { lightning } = options
+  if (lightning) {
+    dispatch(lightningPaymentUri(event, { address: lightning }))
+  }
+  // Otherwise, use the bitcoin address for on-chain payment.
+  else {
+    const { amount } = options
+    dispatch(setRedirectPayReq({ address, amount }))
+  }
 }
 
 /**


### PR DESCRIPTION
## Description:

Support lightning invoices that are encoded within a bip21 bitcoin uri.

## Motivation and Context:

https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md#encoding-overview

> If a URI scheme is desired, the current recommendation is to either use 'lightning:' as a prefix before the BOLT-11 encoding (note: not 'lightning://'), or for fallback to Bitcoin payments, to use 'bitcoin:', as per BIP-21, with the key 'lightning' and the value equal to the BOLT-11 encoding.

The spec is pretty unclear about exactly how this should work, but there is some discussion about it here:
https://github.com/lightningnetwork/lightning-rfc/issues/323

Also some related discussion about this here:
https://www.reddit.com/r/Bitcoin/comments/8wyloi/making_lightning_invoices_backwards_compatible/

Ultimately at this point it is down to wallets to decide how to handle these things. My take on this is that by supporting this we can add better compatibility for services that might be using this bip21 bolt11 format, and we are making the decision to ignore the on-chain address and present the user with the bolt11 invoice, since we are a LN-first wallet. As a possible future enhancement we could provide some way to switch between the two address types.

Fix #200

## How Has This Been Tested?

Try using either of the following:

`bitcoin:1EHNa6Q4Jz2uvNExL497mE43ikXhwF6kZm`

`bitcoin:1EHNa6Q4Jz2uvNExL497mE43ikXhwF6kZm?lightning=lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpuaztrnwngzn3kdzw5hydlzf03qdgm2hdq27cqv3agm2awhz5se903vruatfhq77w3ls4evs3ch9zw97j25emudupq63nyw24cg27h2rspfj9srp`

In the first case we bring up the on-chain payment form as normal.

In the second case we bring up the lightning payment form since the bip21 uri includes a bolt11 invoice.

## Types of changes:

Enhancement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
