### PR TITLE
Enable notarization for mac builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,12 +41,13 @@ branches:
   only:
     - master
     - next
+    - build
     - "/^feat\\//"
 jobs:
   include:
     - stage: deploy
       name: Deploy to Github
-      if: '(NOT type IN (pull_request)) AND (branch IN (master,next))'
+      if: (NOT type IN (pull_request)) AND (branch IN (master,next,build))
       script: skip
       deploy:
         skip_cleanup: true
@@ -55,10 +56,10 @@ jobs:
         on:
           repo: LN-Zap/zap-desktop
           all_branches: true
-          condition: '$TRAVIS_BRANCH =~ ^master|next$'
+          condition: '$TRAVIS_BRANCH =~ ^master|next|build$'
     - os: osx
       name: Deploy to Github
-      if: '(NOT type IN (pull_request)) AND (branch IN (master,next))'
+      if: (NOT type IN (pull_request)) AND (branch IN (master,next,build))
       script: skip
       deploy:
         skip_cleanup: true
@@ -67,4 +68,4 @@ jobs:
         on:
           repo: LN-Zap/zap-desktop
           all_branches: true
-          condition: '$TRAVIS_BRANCH =~ ^master|next$'
+          condition: '$TRAVIS_BRANCH =~ ^master|next|build$'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: xenial
 sudo: required
-osx_image: xcode11
+osx_image: xcode11.2
 env:
   global:
     - DEBUG=electron-builder

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 osx_image: xcode11.2
 env:
   global:
-    - DEBUG=electron-builder
+    - DEBUG=electron-builder,electron-notarize
     - ARTIFACTS_BUCKET=zap-travis
     - ARTIFACTS_REGION=us-east-1
     - ARTIFACTS_DEBUG=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,8 @@ jobs:
       deploy:
         skip_cleanup: true
         provider: script
-        script: yarn release --linux
+        script:
+          - yarn release --linux
         on:
           repo: LN-Zap/zap-desktop
           all_branches: true
@@ -64,7 +65,8 @@ jobs:
       deploy:
         skip_cleanup: true
         provider: script
-        script: yarn release --mac
+        script:
+          - yarn release --mac
         on:
           repo: LN-Zap/zap-desktop
           all_branches: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,4 +39,4 @@ on_failure:
   - ps: $root = Resolve-Path .\screenshots; [IO.Directory]::GetFiles($root.Path, '*.*', 'AllDirectories') | % { Push-AppveyorArtifact $_ -FileName $_.Substring($root.Path.Length + 1) -DeploymentName to-publish }
 
 deploy_script:
-  - cmd: powershell if (($env:appveyor_repo_name -eq 'LN-Zap/zap-desktop') -and (($env:appveyor_repo_branch -eq 'master') -or ($env:appveyor_repo_branch -eq 'next'))) { yarn release --win }
+  - cmd: powershell if (($env:appveyor_repo_name -eq 'LN-Zap/zap-desktop') -and (($env:appveyor_repo_branch -eq 'master') -or ($env:appveyor_repo_branch -eq 'next') -or ($env:appveyor_repo_branch -eq 'build'))) { yarn release --win }

--- a/package.json
+++ b/package.json
@@ -103,9 +103,17 @@
       }
     ],
     "artifactName": "${productName}-${os}-${arch}-v${version}.${ext}",
+    "afterSign": "./scripts/afterSignHook.js",
+    "asarUnpack": [
+      "**/*.node"
+    ],
     "mac": {
       "category": "public.app-category.finance",
       "icon": "resources/icon.icns",
+      "hardenedRuntime": true,
+      "gatekeeperAssess": false,
+      "entitlements": "./resources/mac/entitlements.mac.inherit.plist",
+      "entitlementsInherit": "./resources/mac/entitlements.mac.inherit.plist",
       "target": [
         "dmg",
         "zip"
@@ -244,6 +252,7 @@
     "electron": "6.1.4",
     "electron-builder": "22.1.0",
     "electron-devtools-installer": "2.2.4",
+    "electron-notarize": "0.2.0",
     "electron-updater": "4.2.0",
     "enzyme": "3.10.0",
     "enzyme-adapter-react-16": "1.15.1",

--- a/resources/mac/entitlements.mac.inherit.plist
+++ b/resources/mac/entitlements.mac.inherit.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+  </dict>
+</plist>

--- a/scripts/afterSignHook.js
+++ b/scripts/afterSignHook.js
@@ -1,0 +1,38 @@
+// See: https://medium.com/@TwitterArchiveEraser/notarize-electron-apps-7a5f988406db
+/* eslint-disable no-console */
+
+const fs = require('fs')
+const path = require('path')
+const electron_notarize = require('electron-notarize')
+
+module.exports = async function afterSignHook(params) {
+  // Only notarize the app on Mac OS only.
+  if (process.platform !== 'darwin') {
+    return
+  }
+  console.log('afterSign hook triggered', params)
+
+  // Same appId in electron-builder.
+  const appBundleId = 'org.develar.Zap'
+
+  const appPath = path.join(params.appOutDir, `${params.packager.appInfo.productFilename}.app`)
+  if (!fs.existsSync(appPath)) {
+    throw new Error(`Cannot find application at: ${appPath}`)
+  }
+
+  console.log(`Notarizing ${appBundleId} found at ${appPath}`)
+
+  try {
+    await electron_notarize.notarize({
+      appBundleId,
+      appPath,
+      appleId: process.env.APPLE_ID,
+      appleIdPassword: process.env.APPLE_ID_PASSWORD,
+      ascProvider: process.env.APPLE_ID_TEAMID,
+    })
+  } catch (error) {
+    console.error(error)
+  }
+
+  console.log(`Done notarizing ${appBundleId}`)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7763,6 +7763,14 @@ electron-is-dev@1.1.0:
   resolved "https://registry.yarnpkg.com/electron-is-dev/-/electron-is-dev-1.1.0.tgz#b15a2a600bdc48a51a857d460e05f15b19a2522c"
   integrity sha512-Z1qA/1oHNowGtSBIcWk0pcLEqYT/j+13xUw/MYOrBUOL4X7VN0i0KCTf5SqyvMPmW5pSPKbo28wkxMxzZ20YnQ==
 
+electron-notarize@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/electron-notarize/-/electron-notarize-0.2.0.tgz#676c71688ee84149bab27b22426d0a9452e7e262"
+  integrity sha512-u3KdEMOEcGMF9yCML8ej4ZF+O29VmGYIjrs/DoOi23neTWOMiIc5YCeFs4vxq3JG496omcw7Y5pimPm0sH9A7g==
+  dependencies:
+    debug "^4.1.1"
+    fs-extra "^8.1.0"
+
 electron-publish@21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-21.2.0.tgz#cc225cb46aa62e74b899f2f7299b396c9802387d"


### PR DESCRIPTION
## Description:

Enable notarization for mac builds

## Motivation and Context:

Mac Catalinia has made it a requirement for apps to be notarized by apple and by default will not allow installation of apps that have not been notarized.

## How Has This Been Tested?

Travis build

## Types of changes:

Build process

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
