### PR TITLE
Fix components focus issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -325,6 +325,7 @@
     "dropbox": "4.0.30",
     "electron-is-dev": "1.1.0",
     "finalhandler": "1.1.2",
+    "focus-visible": "5.0.2",
     "get-port": "5.0.0",
     "googleapis": "44.0.0",
     "history": "4.10.1",

--- a/renderer/themes/base.js
+++ b/renderer/themes/base.js
@@ -2,7 +2,7 @@
  * @file Defines core theme elements shared across all themes.
  * These items can be overriden on a per theme basis.
  */
-
+import 'focus-visible/dist/focus-visible'
 /**
  * Colour palette
  *
@@ -96,7 +96,7 @@ const buttons = {
     '&:hover:enabled': {
       bg: 'highlight',
     },
-    '&:focus': {
+    '&.focus-visible': {
       bg: 'highlight',
     },
   },
@@ -118,7 +118,7 @@ const buttons = {
     '&.active': {
       opacity: 1,
     },
-    '&:focus': {
+    '&.focus-visible': {
       opacity: 1,
     },
   },
@@ -134,7 +134,7 @@ const buttons = {
     '&:hover:enabled': {
       bg: 'highlight',
     },
-    '&:focus': {
+    '&.focus-visible': {
       bg: 'highlight',
     },
   },

--- a/test/unit/components/Home/__snapshots__/CreateWalletButton.spec.js.snap
+++ b/test/unit/components/Home/__snapshots__/CreateWalletButton.spec.js.snap
@@ -41,7 +41,7 @@ exports[`component.CreateWalletButton should render correctly 1`] = `
   opacity: 1;
 }
 
-.c0:focus {
+.c0.focus-visible {
   opacity: 1;
 }
 

--- a/test/unit/components/Home/__snapshots__/NoWallets.spec.js.snap
+++ b/test/unit/components/Home/__snapshots__/NoWallets.spec.js.snap
@@ -73,7 +73,7 @@ exports[`component.NoWallets should render correctly (no selected wallet) 1`] = 
   opacity: 1;
 }
 
-.c3:focus {
+.c3.focus-visible {
   opacity: 1;
 }
 
@@ -303,7 +303,7 @@ exports[`component.NoWallets should render correctly (no wallets) 1`] = `
   opacity: 1;
 }
 
-.c3:focus {
+.c3.focus-visible {
   opacity: 1;
 }
 

--- a/test/unit/components/UI/__snapshots__/ActionBar.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/ActionBar.spec.js.snap
@@ -42,7 +42,7 @@ exports[`component.UI.ActionBar should render correctly 1`] = `
   opacity: 1;
 }
 
-.c1:focus {
+.c1.focus-visible {
   opacity: 1;
 }
 
@@ -90,7 +90,7 @@ exports[`component.UI.ActionBar should render correctly 1`] = `
   background-color: #353745;
 }
 
-.c4:focus {
+.c4.focus-visible {
   background-color: #353745;
 }
 

--- a/test/unit/components/UI/__snapshots__/Button.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Button.spec.js.snap
@@ -36,7 +36,7 @@ exports[`component.UI.Button should render correctly 1`] = `
   background-color: #353745;
 }
 
-.c0:focus {
+.c0.focus-visible {
   background-color: #353745;
 }
 

--- a/test/unit/components/UI/__snapshots__/Dialog.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Dialog.spec.js.snap
@@ -115,7 +115,7 @@ exports[`component.UI.Dialog should render correctly with custom content 1`] = `
   opacity: 1;
 }
 
-.c13:focus {
+.c13.focus-visible {
   opacity: 1;
 }
 
@@ -748,7 +748,7 @@ exports[`component.UI.Dialog should render correctly with two buttons 1`] = `
   background-color: #353745;
 }
 
-.c10:focus {
+.c10.focus-visible {
   background-color: #353745;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9275,6 +9275,11 @@ focus-lock@^0.6.3:
   resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.6.5.tgz#f6eb37832a9b1b205406175f5277396a28c0fce1"
   integrity sha512-i/mVBOoa9o+tl+u9owOJUF8k8L85odZNIsctB+JAK2HFT8jckiBwmk+3uydlm6FN8czgnkIwQtBv6yyAbrzXjw==
 
+focus-visible@5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/focus-visible/-/focus-visible-5.0.2.tgz#4fae9cf40458b73c10701c9774c462e3ccd53caf"
+  integrity sha512-zT2fj/bmOgEBjqGbURGlowTmCwsIs3bRDMr/sFZz8Ly7VkEiwuCn9swNTL3pPuf8Oua2de7CLuKdnuNajWdDsQ==
+
 follow-redirects@1.5.10:
   version "1.5.10"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Resolves #3127 
<!--- Describe your changes in detail -->

## Motivation and Context:
Currently we use `:focus` selector to described focused state for components. This is used for accessibility support. The side effect is that components also transition to a focused state on click, which causes visual issues in some cases. This pr solves the issue by leveraging `focus-visible` pseudostyle polyfill which was specifically designed to handle such cases.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes:
Bugfix
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
