### PR TITLE
Ensure correct expire date for invoices with far future expiry

### DIFF
--- a/renderer/components/UI/Countdown.js
+++ b/renderer/components/UI/Countdown.js
@@ -1,94 +1,70 @@
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { FormattedMessage, FormattedRelativeTime } from 'react-intl'
+import { useTimeout } from 'hooks'
 import Text from './Text'
 import messages from './messages'
 
-class Countdown extends React.Component {
-  state = {
-    isExpired: null,
-    timer: null,
+const Countdown = ({
+  offset,
+  onExpire,
+  colorActive,
+  colorExpired,
+  countdownStyle,
+  isContinual,
+  updateInterval,
+  ...rest
+}) => {
+  let expiresIn = offset
+  if (offset instanceof Date) {
+    expiresIn = offset - Date.now()
+    expiresIn = Math.round(expiresIn / 1000)
   }
 
-  static propTypes = {
-    colorActive: PropTypes.string,
-    colorExpired: PropTypes.string,
-    countdownStyle: PropTypes.string,
-    isContinual: PropTypes.bool,
-    offset: PropTypes.oneOfType([PropTypes.number, PropTypes.instanceOf(Date)]).isRequired,
-    onExpire: PropTypes.func,
-    updateInterval: PropTypes.number,
-  }
+  const [isExpired, setIsExpired] = useState(expiresIn <= 0)
 
-  static defaultProps = {
-    colorActive: 'superGreen',
-    colorExpired: 'superRed',
-    countdownStyle: 'long',
-    isContinual: true,
-    updateInterval: 1,
-  }
+  useTimeout(() => {
+    setIsExpired(true)
+    onExpire && onExpire()
+  }, expiresIn * 1000)
 
-  componentDidMount() {
-    const { offset, onExpire } = this.props
-    let expiresIn = offset
+  return (
+    <Text color={isExpired ? colorExpired : colorActive} {...rest}>
+      {isExpired ? (
+        <FormattedMessage {...messages.expired} />
+      ) : (
+        <FormattedMessage {...messages.expires} />
+      )}
+      {(!isExpired || (isExpired && isContinual)) && (
+        <>
+          <i> </i>
+          <FormattedRelativeTime
+            style={countdownStyle}
+            updateIntervalInSeconds={updateInterval}
+            value={expiresIn}
+          />
+        </>
+      )}
+    </Text>
+  )
+}
 
-    if (offset instanceof Date) {
-      expiresIn = offset - Date.now()
-      this.expiresIn = Math.round(expiresIn / 1000)
-    } else {
-      this.expiresIn = expiresIn
-    }
+Countdown.propTypes = {
+  colorActive: PropTypes.string,
+  colorExpired: PropTypes.string,
+  countdownStyle: PropTypes.string,
+  isContinual: PropTypes.bool,
+  offset: PropTypes.oneOfType([PropTypes.number, PropTypes.instanceOf(Date)]).isRequired,
+  onExpire: PropTypes.func,
+  updateInterval: PropTypes.number,
+}
 
-    if (expiresIn >= 0) {
-      this.setState({ isExpired: false })
-      const timer = setInterval(() => {
-        this.setState({ isExpired: true })
-        onExpire && onExpire()
-      }, this.expiresIn * 1000)
-      this.setState({ timer })
-    } else {
-      this.setState({ isExpired: true })
-      onExpire && onExpire()
-    }
-  }
-
-  componentWillUnmount() {
-    const { timer } = this.state
-    clearInterval(timer)
-  }
-
-  render() {
-    const {
-      colorActive,
-      colorExpired,
-      countdownStyle,
-      isContinual,
-      offset,
-      onExpire,
-      updateInterval,
-      ...rest
-    } = this.props
-    const { isExpired } = this.state
-    return (
-      <Text color={isExpired ? colorExpired : colorActive} {...rest}>
-        {isExpired ? (
-          <FormattedMessage {...messages.expired} />
-        ) : (
-          <FormattedMessage {...messages.expires} />
-        )}
-        {(!isExpired || (isExpired && isContinual)) && (
-          <>
-            &nbsp;
-            <FormattedRelativeTime
-              style={countdownStyle}
-              updateIntervalInSeconds={updateInterval}
-              value={this.expiresIn}
-            />
-          </>
-        )}
-      </Text>
-    )
-  }
+Countdown.defaultProps = {
+  colorActive: 'superGreen',
+  colorExpired: 'superRed',
+  countdownStyle: 'long',
+  isContinual: true,
+  updateInterval: 1,
 }
 
 export default Countdown

--- a/stories/components/countdown.stories.js
+++ b/stories/components/countdown.stories.js
@@ -15,6 +15,10 @@ storiesOf('Components', module).addWithChapters('Countdown', {
           sectionFn: () => <Countdown isContinual={false} offset={5} />,
         },
         {
+          title: 'Far future expire',
+          sectionFn: () => <Countdown isContinual={false} offset={31556952} />,
+        },
+        {
           title: 'Custom colors',
           sectionFn: () => (
             <Countdown colorActive="primaryAccent" colorExpired="yellow" offset={5} />

--- a/test/unit/components/UI/Countdown.spec.js
+++ b/test/unit/components/UI/Countdown.spec.js
@@ -4,10 +4,28 @@ import { renderWithTheme } from '@zap/test/unit/__helpers__/renderWithTheme'
 import { Countdown } from 'components/UI'
 
 describe('component.UI.Countdown', () => {
-  it('should render correctly with default props', () => {
+  it('should render correctly with expiry set to a date in the past', () => {
     const tree = renderWithTheme(
       <IntlProvider locale="en">
-        <Countdown offset={new Date(Date.UTC('2009-01-03T18:15:05+00:00'))} />
+        <Countdown offset={new Date('2009-01-03T18:15:05+00:00')} />
+      </IntlProvider>
+    ).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('should render correctly with expiry in 60 seconds', () => {
+    const tree = renderWithTheme(
+      <IntlProvider locale="en">
+        <Countdown offset={60} />
+      </IntlProvider>
+    ).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('should render correctly with expiry in 365 days', () => {
+    const tree = renderWithTheme(
+      <IntlProvider locale="en">
+        <Countdown offset={86400 * 365} />
       </IntlProvider>
     ).toJSON()
     expect(tree).toMatchSnapshot()

--- a/test/unit/components/UI/__snapshots__/Countdown.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Countdown.spec.js.snap
@@ -1,6 +1,52 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`component.UI.Countdown should render correctly with default props 1`] = `
+exports[`component.UI.Countdown should render correctly with expiry in 60 seconds 1`] = `
+.c0 {
+  box-sizing: border-box;
+  margin: 0;
+  min-width: 0;
+  color: #39e673;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+<div
+  className="c0"
+  color="superGreen"
+  fontSize="m"
+>
+  Expires
+  <i>
+     
+  </i>
+  in 1 minute
+</div>
+`;
+
+exports[`component.UI.Countdown should render correctly with expiry in 365 days 1`] = `
+.c0 {
+  box-sizing: border-box;
+  margin: 0;
+  min-width: 0;
+  color: #39e673;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+<div
+  className="c0"
+  color="superGreen"
+  fontSize="m"
+>
+  Expires
+  <i>
+     
+  </i>
+  in 365 days
+</div>
+`;
+
+exports[`component.UI.Countdown should render correctly with expiry set to a date in the past 1`] = `
 .c0 {
   box-sizing: border-box;
   margin: 0;
@@ -16,7 +62,9 @@ exports[`component.UI.Countdown should render correctly with default props 1`] =
   fontSize="m"
 >
   Expired
-   
-  in 0 seconds
+  <i>
+     
+  </i>
+  3,963 days ago
 </div>
 `;


### PR DESCRIPTION
## Description:

The largest number (ms) supported by setInterval is 2147483647. If countdown expire date is outside of this range do not use a timer.

Note: Technically if a user was to keep a countdown on the screen for over 24 days it would display an inaccurate expired message, but in practice this is probably such an edge case that it's not worth investing time into addressing at this point.

## Motivation and Context:

Fix #3144

## How Has This Been Tested?

Manually

## Types of changes:

Fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
