### PR TITLE
fix(wallet): present correct fee when no route

### DIFF
--- a/renderer/components/Pay/PaySummary.js
+++ b/renderer/components/Pay/PaySummary.js
@@ -8,29 +8,16 @@ import { PAY_FORM_STEPS } from './constants'
 import { getFeeRate } from './utils'
 
 const PaySummary = props => {
-  const { amountInSats, formApi, isOnchain, lndTargetConfirmations } = props
+  const { amountInSats, formApi, isOnchain, lndTargetConfirmations, onchainFees, routes } = props
   const formState = formApi.getState()
   const { speed, payReq, isCoinSweep } = formState.values
-
-  /**
-   * getFee - Get the current per byte fee based on the form values.
-   *
-   * @returns {number} Fee rate for currently selected conf speed
-   */
-  const getFee = () => {
-    const { formApi, onchainFees } = props
-    const formState = formApi.getState()
-    const { speed } = formState.values
-
-    return getFeeRate(onchainFees, speed)
-  }
 
   if (isOnchain) {
     return (
       <PaySummaryOnChain
         address={payReq}
         amount={amountInSats}
-        fee={getFee()}
+        fee={getFeeRate(onchainFees, speed)}
         isCoinSweep={isCoinSweep}
         lndTargetConfirmations={lndTargetConfirmations}
         mt={-3}
@@ -39,19 +26,11 @@ const PaySummary = props => {
     )
   }
 
-  const { routes } = props
-  let minFee = 0
-  let maxFeeInclusive = 0
-  if (routes.length) {
-    minFee = getMinFee(routes)
-    maxFeeInclusive = getMaxFeeInclusive(routes)
-  }
-
   return (
     <PaySummaryLightning
       amount={amountInSats}
-      maxFee={maxFeeInclusive}
-      minFee={minFee}
+      maxFee={getMaxFeeInclusive(routes)}
+      minFee={getMinFee(routes)}
       mt={-3}
       payReq={payReq}
     />

--- a/renderer/components/Pay/PaySummaryLightning.js
+++ b/renderer/components/Pay/PaySummaryLightning.js
@@ -76,7 +76,7 @@ class PaySummaryLightning extends React.Component {
     let feeMessage = messages.fee_unknown
 
     // If thex max fee is 0 or 1 then show a message like "less than 1".
-    if (maxFee === 0 || maxFee === 1) {
+    if (maxFee >= 0 && maxFee < 1) {
       feeMessage = messages.fee_less_than_1
     }
     // Otherwise, if we have both a min and max fee that are different, present the fee range.

--- a/renderer/reducers/pay.js
+++ b/renderer/reducers/pay.js
@@ -203,7 +203,7 @@ export const queryFees = (address, amountInSats) => async (dispatch, getState) =
 
     dispatch({ type: QUERY_FEES_SUCCESS, onchainFees })
   } catch (e) {
-    const error = get(e, 'response.statusText', e)
+    const error = get(e, 'response.statusText', e.message)
     dispatch({ type: QUERY_FEES_FAILURE, error })
   }
 }
@@ -225,7 +225,7 @@ export const queryRoutes = (pubKey, amount) => async dispatch => {
     })
     dispatch({ type: QUERY_ROUTES_SUCCESS, routes })
   } catch (e) {
-    dispatch({ type: QUERY_ROUTES_FAILURE })
+    dispatch({ type: QUERY_ROUTES_FAILURE, error: e.message })
   }
 }
 


### PR DESCRIPTION
## Description:

Ensure fee rate is displayed as `unknown` if no routes are found.

## Motivation and Context:

Fix #3154

## How Has This Been Tested?

Manually

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
