### PR TITLE
feat(ui): show multiple node uris if there is more than one

### DIFF
--- a/renderer/components/Profile/ProfilePaneNodeInfo/ProfilePaneNodeInfo.js
+++ b/renderer/components/Profile/ProfilePaneNodeInfo/ProfilePaneNodeInfo.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { FormattedMessage, injectIntl } from 'react-intl'
 import { clean } from 'semver'
-import { Box } from 'rebass/styled-components'
+import { Box, Flex } from 'rebass/styled-components'
 import { Bar, CopyBox, DataRow, QRCode, Text } from 'components/UI'
 import messages from './messages'
 import { intlShape } from '@zap/i18n'
@@ -27,7 +27,7 @@ const ProfilePaneNodeInfo = ({
   intl,
   activeWalletSettings,
   commitString,
-  nodeUriOrPubkey,
+  nodeUrisOrPubkey,
   showNotification,
   backupProvider,
   versionString,
@@ -37,36 +37,68 @@ const ProfilePaneNodeInfo = ({
     showNotification(intl.formatMessage({ ...messages.pubkey_copied_notification_description }))
   const isLocalWallet = activeWalletSettings.type === 'local'
 
+  const renderMultipleNodeUris = () => (
+    <>
+      <Box mb={4}>
+        <Text fontWeight="normal" mb={2}>
+          <FormattedMessage {...messages.node_pubkey_title} />
+        </Text>
+        <Text color="gray" fontWeight="light">
+          <FormattedMessage {...messages.node_pubkey_description} />
+        </Text>
+      </Box>
+      {nodeUrisOrPubkey.map(uriOrPubkey => (
+        <Box key={uriOrPubkey} mb={6}>
+          {!isLocalWallet && (
+            <Flex justifyContent="center">
+              <QRCode size="xxlarge" value={uriOrPubkey} />
+            </Flex>
+          )}
+          <CopyBox
+            hint={intl.formatMessage({ ...messages.copy_pubkey })}
+            my={3}
+            onCopy={notifyOfCopy}
+            value={uriOrPubkey}
+          />
+        </Box>
+      ))}
+    </>
+  )
+
+  const renderSingleNodeUri = () => (
+    <>
+      <DataRow
+        left={
+          <Box mr={3}>
+            <Text fontWeight="normal" mb={2}>
+              <FormattedMessage {...messages.node_pubkey_title} />
+            </Text>
+            <Text color="gray" fontWeight="light">
+              <FormattedMessage {...messages.node_pubkey_description} />
+            </Text>
+          </Box>
+        }
+        py={2}
+        right={!isLocalWallet && <QRCode size="xxlarge" value={nodeUrisOrPubkey[0]} />}
+      />
+      <CopyBox
+        hint={intl.formatMessage({ ...messages.copy_pubkey })}
+        my={3}
+        onCopy={notifyOfCopy}
+        value={nodeUrisOrPubkey[0]}
+      />
+    </>
+  )
+
   return (
     <Box as="section" {...rest}>
       <Text fontWeight="normal">
         <FormattedMessage {...messages.nodeinfo_pane_title} />
       </Text>
       <Bar mb={4} mt={2} />
-      {nodeUriOrPubkey && (
-        <>
-          <DataRow
-            left={
-              <Box mr={3}>
-                <Text fontWeight="normal" mb={2}>
-                  <FormattedMessage {...messages.node_pubkey_title} />
-                </Text>
-                <Text color="gray" fontWeight="light">
-                  <FormattedMessage {...messages.node_pubkey_description} />
-                </Text>
-              </Box>
-            }
-            py={2}
-            right={!isLocalWallet && <QRCode size="xxlarge" value={nodeUriOrPubkey} />}
-          />
-          <CopyBox
-            hint={intl.formatMessage({ ...messages.copy_pubkey })}
-            my={3}
-            onCopy={notifyOfCopy}
-            value={nodeUriOrPubkey}
-          />
-        </>
-      )}
+      {nodeUrisOrPubkey && nodeUrisOrPubkey.length > 0 && nodeUrisOrPubkey.length > 1
+        ? renderMultipleNodeUris()
+        : renderSingleNodeUri()}
       <DataRow
         left={
           <Text fontWeight="normal">
@@ -105,7 +137,7 @@ ProfilePaneNodeInfo.propTypes = {
   backupProvider: PropTypes.string,
   commitString: PropTypes.string,
   intl: intlShape.isRequired,
-  nodeUriOrPubkey: PropTypes.string.isRequired,
+  nodeUrisOrPubkey: PropTypes.arrayOf(PropTypes.string).isRequired,
   showNotification: PropTypes.func.isRequired,
   versionString: PropTypes.string.isRequired,
 }

--- a/renderer/containers/Profile/ProfilePaneNodeInfo.js
+++ b/renderer/containers/Profile/ProfilePaneNodeInfo.js
@@ -7,7 +7,7 @@ import ProfilePaneNodeInfo from 'components/Profile/ProfilePaneNodeInfo'
 
 const mapStateToProps = state => ({
   activeWalletSettings: walletSelectors.activeWalletSettings(state),
-  nodeUriOrPubkey: infoSelectors.nodeUriOrPubkey(state),
+  nodeUrisOrPubkey: infoSelectors.nodeUrisOrPubkey(state),
   versionString: infoSelectors.versionString(state),
   commitString: infoSelectors.commitString(state),
   backupProvider: backupSelectors.providerSelector(state),

--- a/renderer/reducers/info.js
+++ b/renderer/reducers/info.js
@@ -262,7 +262,7 @@ infoSelectors.hasSynced = state => state.info.hasSynced
 infoSelectors.isSyncedToChain = state => get(state, 'info.data.synced_to_chain', false)
 infoSelectors.version = state => get(state, 'info.data.version')
 infoSelectors.identityPubkey = state => get(state, 'info.data.identity_pubkey')
-infoSelectors.nodeUri = state => get(state, 'info.data.uris[0]')
+infoSelectors.nodeUris = state => get(state, 'info.data.uris')
 
 // Extract the version string from the version.
 infoSelectors.versionString = createSelector(
@@ -284,19 +284,19 @@ infoSelectors.commitString = createSelector(
 
 // Get the node pubkey. If not set, try to extract it from the node uri.
 infoSelectors.nodePubkey = createSelector(
-  infoSelectors.nodeUri,
+  infoSelectors.nodeUris,
   infoSelectors.identityPubkey,
-  (nodeUri, identityPubkey) => {
-    const parseFromDataUri = () => nodeUri && nodeUri.split('@')[0]
+  (nodeUris, identityPubkey) => {
+    const parseFromDataUri = () => nodeUris && nodeUris[0].split('@')[0]
     return identityPubkey || parseFromDataUri()
   }
 )
 
 // Get the node uri or pubkey.
-infoSelectors.nodeUriOrPubkey = createSelector(
-  infoSelectors.nodeUri,
+infoSelectors.nodeUrisOrPubkey = createSelector(
+  infoSelectors.nodeUris,
   infoSelectors.nodePubkey,
-  (nodeUri, nodePubkey) => nodeUri || nodePubkey
+  (nodeUris, nodePubkey) => nodeUris || [nodePubkey]
 )
 
 infoSelectors.networkInfo = createSelector(


### PR DESCRIPTION
I'm proposing to show the QR codes and corresponding node uri strings in a centered column if there is more than one uri. If there is one uri, the UI stays the same as previously.

## Description:

<!--- Describe your changes in detail -->

## Motivation and Context:

Address #3150

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):

View with more than one node uri:
![Screen Shot 2019-11-09 at 3 41 59 PM](https://user-images.githubusercontent.com/1934678/68536533-7f16a180-0309-11ea-8831-1fc7ab90e1bd.png)

View with one uri only:
![Screen Shot 2019-11-09 at 3 59 48 PM](https://user-images.githubusercontent.com/1934678/68536565-03692480-030a-11ea-93ca-d2df2b385961.png)

## Types of changes:

New feature: show all node uris if there is more than one.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
