### PR TITLE
Use payment probing to improve fee estimate

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -103,8 +103,13 @@ module.exports = {
     useAddressFallback: false,
     retryCount: 2, // Number of retries for pay invoice failure
     feeIncrementExponent: 1.1, // Exponent applied to fee limit on payment retry attempts
-    probeTimeout: 30, // Upper limit on the amount of time (s) we should spend when attempting to probe the payment
-    paymentTimeout: 30, // Upper limit on the amount of time (s) we should spend when attempting to fulfill the payment
+  },
+
+  payments: {
+    timeout: 30, // Upper limit on the amount of time (s) we should spend when attempting to probe a payment
+    feeLimit: 1000, // Upper limit on the routing fees we should accept when sending payment without a limit
+    probeTimeout: 30, // Upper limit on the amount of time (s) we should spend when attempting to send a payment
+    probeFeeLimit: 1000, // Upper limit on the routing fees we want to consider in payment probes
   },
 
   autopay: {

--- a/config/default.js
+++ b/config/default.js
@@ -103,6 +103,8 @@ module.exports = {
     useAddressFallback: false,
     retryCount: 2, // Number of retries for pay invoice failure
     feeIncrementExponent: 1.1, // Exponent applied to fee limit on payment retry attempts
+    probeTimeout: 30, // Upper limit on the amount of time (s) we should spend when attempting to probe the payment
+    paymentTimeout: 30, // Upper limit on the amount of time (s) we should spend when attempting to fulfill the payment
   },
 
   autopay: {

--- a/renderer/components/Channels/ChannelCreateForm.js
+++ b/renderer/components/Channels/ChannelCreateForm.js
@@ -94,9 +94,9 @@ class ChannelCreateForm extends React.Component {
       slow: PropTypes.number.isRequired,
     }).isRequired,
     onchainFees: PropTypes.shape({
-      fast: PropTypes.number,
-      medium: PropTypes.number,
-      slow: PropTypes.number,
+      fast: PropTypes.string,
+      medium: PropTypes.string,
+      slow: PropTypes.string,
     }),
     onSubmit: PropTypes.func.isRequired,
     openChannel: PropTypes.func.isRequired,

--- a/renderer/components/Pay/Pay.js
+++ b/renderer/components/Pay/Pay.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import config from 'config'
 import get from 'lodash/get'
 import { injectIntl } from 'react-intl'
-import { decodePayReq, getMaxFee, isOnchain, isBolt11, isPubkey } from '@zap/utils/crypto'
+import { decodePayReq, getMaxFeeInclusive, isOnchain, isBolt11, isPubkey } from '@zap/utils/crypto'
 import { Panel } from 'components/UI'
 import { Form } from 'components/Form'
 import { getAmountInSats, getFeeRate } from './utils'
@@ -245,7 +245,7 @@ class Pay extends React.Component {
       payInvoice({
         payReq: values.payReq,
         amt: this.amountInSats(),
-        feeLimit: getMaxFee(routes),
+        feeLimit: getMaxFeeInclusive(routes),
         route: get(routes, '[0].isExact') && routes[0],
         retries: config.invoices.retryCount,
       })

--- a/renderer/components/Pay/Pay.js
+++ b/renderer/components/Pay/Pay.js
@@ -131,16 +131,15 @@ class Pay extends React.Component {
     const isNowSummary =
       currentStep === PAY_FORM_STEPS.summary && prevState.currentStep !== PAY_FORM_STEPS.summary
     if (isNowSummary) {
-      let payeeNodeKey
       if (invoice) {
-        ;({ payeeNodeKey } = invoice)
+        const { paymentRequest } = invoice
+        queryRoutes(paymentRequest, this.amountInSats())
       } else if (isPubkey) {
         const {
           values: { payReq },
         } = this.formApi.getState()
-        payeeNodeKey = payReq
+        queryRoutes(payReq, this.amountInSats())
       }
-      payeeNodeKey && queryRoutes(payeeNodeKey, this.amountInSats())
     }
   }
 

--- a/renderer/components/Pay/Pay.js
+++ b/renderer/components/Pay/Pay.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import config from 'config'
+import get from 'lodash/get'
 import { injectIntl } from 'react-intl'
 import { decodePayReq, getMaxFee, isOnchain, isBolt11, isPubkey } from '@zap/utils/crypto'
 import { Panel } from 'components/UI'
@@ -245,6 +246,7 @@ class Pay extends React.Component {
         payReq: values.payReq,
         amt: this.amountInSats(),
         feeLimit: getMaxFee(routes),
+        route: get(routes, '[0].isExact') && routes[0],
         retries: config.invoices.retryCount,
       })
       // Clear payment request

--- a/renderer/components/Pay/Pay.js
+++ b/renderer/components/Pay/Pay.js
@@ -38,9 +38,9 @@ class Pay extends React.Component {
     mx: PropTypes.string,
     network: PropTypes.string.isRequired,
     onchainFees: PropTypes.shape({
-      fast: PropTypes.number,
-      medium: PropTypes.number,
-      slow: PropTypes.number,
+      fast: PropTypes.string,
+      medium: PropTypes.string,
+      slow: PropTypes.string,
     }),
     payInvoice: PropTypes.func.isRequired,
     queryFees: PropTypes.func.isRequired,

--- a/renderer/components/Pay/PayAmountFields.js
+++ b/renderer/components/Pay/PayAmountFields.js
@@ -59,9 +59,9 @@ class PayAmountFields extends React.Component {
       slow: PropTypes.number.isRequired,
     }).isRequired,
     onchainFees: PropTypes.shape({
-      fast: PropTypes.number,
-      medium: PropTypes.number,
-      slow: PropTypes.number,
+      fast: PropTypes.string,
+      medium: PropTypes.string,
+      slow: PropTypes.string,
     }),
     queryFees: PropTypes.func.isRequired,
     walletBalanceConfirmed: PropTypes.string.isRequired,

--- a/renderer/components/Pay/PayPanelBody.js
+++ b/renderer/components/Pay/PayPanelBody.js
@@ -111,9 +111,9 @@ PayPanelBody.propTypes = {
   }).isRequired,
   network: PropTypes.string.isRequired,
   onchainFees: PropTypes.shape({
-    fast: PropTypes.number,
-    medium: PropTypes.number,
-    slow: PropTypes.number,
+    fast: PropTypes.string,
+    medium: PropTypes.string,
+    slow: PropTypes.string,
   }),
   previousStep: PropTypes.string,
   queryFees: PropTypes.func.isRequired,

--- a/renderer/components/Pay/PaySummary.js
+++ b/renderer/components/Pay/PaySummary.js
@@ -60,9 +60,9 @@ PaySummary.propTypes = {
     slow: PropTypes.number.isRequired,
   }).isRequired,
   onchainFees: PropTypes.shape({
-    fast: PropTypes.number,
-    medium: PropTypes.number,
-    slow: PropTypes.number,
+    fast: PropTypes.string,
+    medium: PropTypes.string,
+    slow: PropTypes.string,
   }),
   routes: PropTypes.array,
 }

--- a/renderer/components/Pay/PaySummary.js
+++ b/renderer/components/Pay/PaySummary.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { animated, Transition } from 'react-spring/renderprops.cjs'
 import PaySummaryLightning from 'containers/Pay/PaySummaryLightning'
 import PaySummaryOnChain from 'containers/Pay/PaySummaryOnChain'
-import { getMaxFeeInclusive, getMinFee } from '@zap/utils/crypto'
+import { getMaxFeeInclusive, getMinFee, getExactFee } from '@zap/utils/crypto'
 import { PAY_FORM_STEPS } from './constants'
 import { getFeeRate } from './utils'
 
@@ -37,6 +37,7 @@ const PaySummary = props => {
   return (
     <PaySummaryLightning
       amount={amountInSats}
+      exactFee={getExactFee(routes)}
       isPubkey={isPubkey}
       maxFee={getMaxFeeInclusive(routes)}
       minFee={getMinFee(routes)}

--- a/renderer/components/Pay/PaySummaryLightning.js
+++ b/renderer/components/Pay/PaySummaryLightning.js
@@ -13,21 +13,13 @@ import messages from './messages'
 
 class PaySummaryLightning extends React.Component {
   static propTypes = {
-    /** Amount to send (in satoshis). */
     amount: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    /** Boolean indicating whether payment is to pubkey (or bolt11) */
-    isPubkey: PropTypes.bool,
-    /** Boolean indicating whether routing information is currently being fetched. */
     exactFee: PropTypes.number,
-    /** Maximum fee for the payment */
+    isPubkey: PropTypes.bool,
     isQueryingRoutes: PropTypes.bool,
-    /** Minimumfee for the payment */
     maxFee: PropTypes.string,
-    /** Minimumfee for the payment */
     minFee: PropTypes.string,
-    /** List of nodes as returned by lnd */
     nodes: PropTypes.array,
-    /** Lightning Payment request */
     payReq: PropTypes.string.isRequired,
   }
 

--- a/renderer/components/Pay/PaySummaryLightning.js
+++ b/renderer/components/Pay/PaySummaryLightning.js
@@ -40,9 +40,9 @@ class PaySummaryLightning extends React.Component {
 
   renderFee() {
     const { exactFee, maxFee, minFee } = this.props
-    const hasExactFee = Number.isFinite(exactFee)
-    const hasMinFee = Number.isFinite(minFee)
-    const hasMaxFee = Number.isFinite(maxFee)
+    const hasExactFee = CoinBig(exactFee).isFinite()
+    const hasMinFee = CoinBig(minFee).isFinite()
+    const hasMaxFee = CoinBig(maxFee).isFinite()
 
     if (hasExactFee) {
       return (
@@ -111,10 +111,9 @@ class PaySummaryLightning extends React.Component {
     }
 
     const nodeAlias = getNodeAlias(payeeNodeKey, nodes)
-
-    const totalAmountInSatoshis = Number.isFinite(exactFee)
-      ? CoinBig.sum(amountInSatoshis, exactFee).toString()
-      : CoinBig.sum(amountInSatoshis, maxFee || 0).toString()
+    const totalAmountInSatoshis = CoinBig(exactFee).isFinite()
+      ? CoinBig.sum(amountInSatoshis, convert('msats', 'sats', exactFee)).toString()
+      : CoinBig.sum(amountInSatoshis, convert('msats', 'sats', maxFee)).toString()
 
     return (
       <Box {...rest}>

--- a/renderer/components/Pay/PaySummaryLightning.js
+++ b/renderer/components/Pay/PaySummaryLightning.js
@@ -166,10 +166,19 @@ class PaySummaryLightning extends React.Component {
         <DataRow
           left={<FormattedMessage {...messages.total} />}
           right={
-            <Flex alignItems="baseline">
-              <CryptoSelector mr={2} />
-              <CryptoValue value={totalAmountInSatoshis} />
-            </Flex>
+            isQueryingRoutes ? (
+              <Flex alignItems="center" justifyContent="flex-end" ml="auto">
+                <Text mr={2}>
+                  <FormattedMessage {...messages.searching_routes} />
+                </Text>
+                <Spinner color="primaryAccent" />
+              </Flex>
+            ) : (
+              <Flex alignItems="baseline">
+                <CryptoSelector mr={2} />
+                <CryptoValue value={totalAmountInSatoshis} />
+              </Flex>
+            )
           }
         />
 

--- a/renderer/components/Pay/PaySummaryLightning.js
+++ b/renderer/components/Pay/PaySummaryLightning.js
@@ -14,7 +14,7 @@ import messages from './messages'
 class PaySummaryLightning extends React.Component {
   static propTypes = {
     amount: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    exactFee: PropTypes.number,
+    exactFee: PropTypes.string,
     isPubkey: PropTypes.bool,
     isQueryingRoutes: PropTypes.bool,
     maxFee: PropTypes.string,

--- a/renderer/components/Pay/PaySummaryOnChain.js
+++ b/renderer/components/Pay/PaySummaryOnChain.js
@@ -26,9 +26,9 @@ class PaySummaryOnChain extends React.Component {
     lndTargetConfirmations: PropTypes.object.isRequired,
     /** Current fee information as provided by bitcoinfees.earn.com */
     onchainFees: PropTypes.shape({
-      fast: PropTypes.number,
-      medium: PropTypes.number,
-      slow: PropTypes.number,
+      fast: PropTypes.string,
+      medium: PropTypes.string,
+      slow: PropTypes.string,
     }),
     /** Method to fetch fee information for onchain transactions. */
     queryFees: PropTypes.func.isRequired,

--- a/renderer/components/UI/Value.js
+++ b/renderer/components/UI/Value.js
@@ -28,7 +28,7 @@ const Value = ({ value, currency, currentTicker, fiatTicker, style }) => {
   let dp
   switch (currency) {
     case 'btc':
-      dp = 8
+      dp = 11
       break
     case 'bits':
       dp = 5

--- a/renderer/reducers/info.js
+++ b/renderer/reducers/info.js
@@ -214,6 +214,7 @@ infoSelectors.isSyncedToChain = state => get(state, 'info.data.syncedToChain', f
 infoSelectors.version = state => get(state, 'info.data.version')
 infoSelectors.identityPubkey = state => get(state, 'info.data.identityPubkey')
 infoSelectors.nodeUri = state => get(state, 'info.data.uris[0]')
+infoSelectors.grpcProtoVersion = state => get(state, 'info.data.grpcProtoVersion')
 
 // Extract the version string from the version.
 infoSelectors.versionString = createSelector(

--- a/renderer/reducers/info.js
+++ b/renderer/reducers/info.js
@@ -232,7 +232,7 @@ infoSelectors.commitString = createSelector(infoSelectors.version, version => {
   return commitString ? commitString.replace('commit=', '') : undefined
 })
 
-// Check wether node has support for Router service
+// Check whether node has support for Router service
 infoSelectors.hasRouterSupport = createSelector(
   infoSelectors.grpcProtoVersion,
   version => {

--- a/renderer/reducers/info.js
+++ b/renderer/reducers/info.js
@@ -233,15 +233,12 @@ infoSelectors.commitString = createSelector(infoSelectors.version, version => {
 })
 
 // Check whether node has support for Router service
-infoSelectors.hasRouterSupport = createSelector(
-  infoSelectors.grpcProtoVersion,
-  version => {
-    if (!version) {
-      return false
-    }
-    return semver.gte(version, '0.7.1-beta', { includePrerelease: true })
+infoSelectors.hasRouterSupport = createSelector(infoSelectors.grpcProtoVersion, version => {
+  if (!version) {
+    return false
   }
-)
+  return semver.gte(version, '0.7.1-beta', { includePrerelease: true })
+})
 
 // Get the node pubkey. If not set, try to extract it from the node uri.
 infoSelectors.nodePubkey = createSelector(

--- a/renderer/reducers/info.js
+++ b/renderer/reducers/info.js
@@ -1,4 +1,5 @@
 import { createSelector } from 'reselect'
+import semver from 'semver'
 import get from 'lodash/get'
 import createReducer from '@zap/utils/createReducer'
 import { networks } from '@zap/utils/crypto'
@@ -230,6 +231,17 @@ infoSelectors.commitString = createSelector(infoSelectors.version, version => {
   const commitString = version.split(' ')[1]
   return commitString ? commitString.replace('commit=', '') : undefined
 })
+
+// Check wether node has support for Router service
+infoSelectors.hasRouterSupport = createSelector(
+  infoSelectors.grpcProtoVersion,
+  version => {
+    if (!version) {
+      return false
+    }
+    return semver.gte(version, '0.7.1-beta', { includePrerelease: true })
+  }
+)
 
 // Get the node pubkey. If not set, try to extract it from the node uri.
 infoSelectors.nodePubkey = createSelector(

--- a/renderer/reducers/pay.js
+++ b/renderer/reducers/pay.js
@@ -253,8 +253,13 @@ export const queryRoutes = invoice => async (dispatch, getState) => {
       try {
         routes = await callProbePayment()
       } catch (error) {
+        // If the probe didn't find a route trigger a failure.
+        if (['FAILED_TIMEOUT', 'FAILED_NO_ROUTE', 'FAILED_ERROR'].includes(error.message)) {
+          throw error
+        }
+
         // There is no guarentee that the lnd node has the Router service enabled.
-        // If we didn't get a route from probing fall back to using queryRoutes.
+        // Fall back to using queryRoutes if we got some other type of error.
         routes = await callQueryRoutes()
       }
     }

--- a/renderer/reducers/pay.js
+++ b/renderer/reducers/pay.js
@@ -250,7 +250,7 @@ export const queryRoutes = (payReq, amt, finalCltvDelta = DEFAULT_CLTV_DELTA) =>
       ...payload,
       amt,
       dest: Buffer.from(payReq, 'hex'),
-      dest_custom_records: {
+      destCustomRecords: {
         [KEYSEND_PREIMAGE_TYPE]: preimage,
       },
     }

--- a/renderer/reducers/pay.js
+++ b/renderer/reducers/pay.js
@@ -224,10 +224,10 @@ export const queryRoutes = (pubKey, amount) => async (dispatch, getState) => {
 
     // Use payment probing if lnd version supports the Router service.
     if (infoSelectors.hasRouterSupport(getState())) {
-      // First probe with a small amount for check for a valid route.
-      await grpc.services.Router.probePayment(pubKey, 1)
-      // Then probe with the full amount to check whether the channels contain enough balance for the payment.
-      routes.push(await grpc.services.Router.probePayment(pubKey, amount))
+      const route = await grpc.services.Router.probePayment(pubKey, amount)
+      // Flag this as an exact route. This can be used as a hint for whether to use sendToRoute to fulfil the payment.
+      route.isExact = true
+      routes.push(route)
     }
 
     // For older versions use queryRoutes.
@@ -239,6 +239,7 @@ export const queryRoutes = (pubKey, amount) => async (dispatch, getState) => {
       })
       routes = result
     }
+
     dispatch({ type: QUERY_ROUTES_SUCCESS, routes })
   } catch (e) {
     dispatch({ type: QUERY_ROUTES_FAILURE, error: e.message })

--- a/renderer/reducers/pay.js
+++ b/renderer/reducers/pay.js
@@ -1,7 +1,6 @@
 import get from 'lodash/get'
 import { createSelector } from 'reselect'
 import { send } from 'redux-electron-ipc'
-import semver from 'semver'
 import { grpc } from 'workers'
 import { getIntl } from '@zap/i18n'
 import { convert } from '@zap/utils/btc'
@@ -223,9 +222,8 @@ export const queryRoutes = (pubKey, amount) => async (dispatch, getState) => {
   try {
     let routes = []
 
-    // For lnd 0.7.1-beta and later, use payment probing.
-    const lndVersion = infoSelectors.grpcProtoVersion(getState())
-    if (semver.gte(lndVersion, '0.7.1-beta', { includePrerelease: true })) {
+    // Use payment probing if lnd version supports the Router service.
+    if (infoSelectors.hasRouterSupport(getState())) {
       // First probe with a small amount for check for a valid route.
       await grpc.services.Router.probePayment(pubKey, 1)
       // Then probe with the full amount to check whether the channels contain enough balance for the payment.

--- a/renderer/reducers/payment.js
+++ b/renderer/reducers/payment.js
@@ -1,7 +1,6 @@
 import config from 'config'
 import { randomBytes, createHash } from 'crypto'
 import { createSelector } from 'reselect'
-import semver from 'semver'
 import uniqBy from 'lodash/uniqBy'
 import find from 'lodash/find'
 import createReducer from '@zap/utils/createReducer'
@@ -270,9 +269,8 @@ export const payInvoice = ({ payReq, amt, feeLimit, retries = 0, originalPayment
   try {
     let data
 
-    // For lnd 0.7.1-beta and later, use the Router API.
-    const lndVersion = infoSelectors.grpcProtoVersion(getState())
-    if (semver.gte(lndVersion, '0.7.1-beta', { includePrerelease: true })) {
+    // Use Router service if lnd version supports it.
+    if (infoSelectors.hasRouterSupport(getState())()) {
       data = await grpc.services.Router.sendPayment({
         ...payload,
         timeoutSeconds: PAYMENT_TIMEOUT,

--- a/renderer/reducers/payment.js
+++ b/renderer/reducers/payment.js
@@ -11,6 +11,7 @@ import { convert } from '@zap/utils/btc'
 import delay from '@zap/utils/delay'
 import genId from '@zap/utils/genId'
 import { mainLog } from '@zap/utils/log'
+import { CoinBig } from '@zap/utils/coin'
 import { grpc } from 'workers'
 import { fetchBalance } from './balance'
 import { fetchChannels } from './channels'
@@ -448,10 +449,14 @@ const ACTION_HANDLERS = {
     if (item) {
       item.remainingRetries = Math.max(item.remainingRetries - 1, 0)
       if (item.feeLimit) {
-        item.feeLimit = Math.ceil(item.feeLimit * config.invoices.feeIncrementExponent)
+        item.feeLimit = CoinBig(item.feeLimit)
+          .times(config.invoices.feeIncrementExponent)
+          .decimalPlaces(0)
+          .toString()
       }
     }
   },
+
   [PAYMENT_SUCCESSFUL]: (state, { paymentId }) => {
     const { paymentsSending } = state
     const item = find(paymentsSending, { paymentId })

--- a/renderer/reducers/payment.js
+++ b/renderer/reducers/payment.js
@@ -431,6 +431,9 @@ const ACTION_HANDLERS = {
     const item = find(paymentsSending, { paymentId })
     if (item) {
       item.remainingRetries = Math.max(item.remainingRetries - 1, 0)
+      if (item.feeLimit) {
+        item.feeLimit = Math.ceil(item.feeLimit * config.invoices.feeIncrementExponent)
+      }
     }
   },
   [PAYMENT_SUCCESSFUL]: (state, { paymentId }) => {

--- a/renderer/reducers/payment.js
+++ b/renderer/reducers/payment.js
@@ -279,6 +279,7 @@ export const payInvoice = ({
     if (infoSelectors.hasRouterSupport(getState())) {
       payload = {
         ...payload,
+        feeLimit,
         timeoutSeconds: PAYMENT_TIMEOUT,
       }
 

--- a/renderer/reducers/payment.js
+++ b/renderer/reducers/payment.js
@@ -390,6 +390,10 @@ export const paymentFailed = (error, { paymentId }) => async (dispatch, getState
     'payment attempt not completed before timeout', // ErrPaymentAttemptTimeout
     'unable to find a path to destination', // ErrNoPathFound
     'target not found', // ErrTargetNotInNetwork
+    'FAILED_NO_ROUTE',
+    'FAILED_ERROR',
+    'FAILED_TIMEOUT',
+    'TERMINATED_EARLY', // Triggered if sendPayment aborts without giveing a proper response.
   ]
 
   // If we found a related entery in paymentsSending, gracefully remove it and handle as error case.

--- a/renderer/reducers/payment.js
+++ b/renderer/reducers/payment.js
@@ -45,7 +45,7 @@ const PAYMENT_STATUS_SENDING = 'sending'
 const PAYMENT_STATUS_SUCCESSFUL = 'successful'
 const PAYMENT_STATUS_FAILED = 'failed'
 
-const PAYMENT_TIMEOUT = 15
+const PAYMENT_TIMEOUT = config.invoices.paymentTimeout
 
 // ------------------------------------
 // Helpers

--- a/renderer/reducers/payment.js
+++ b/renderer/reducers/payment.js
@@ -431,9 +431,6 @@ const ACTION_HANDLERS = {
     const item = find(paymentsSending, { paymentId })
     if (item) {
       item.remainingRetries = Math.max(item.remainingRetries - 1, 0)
-      if (item.feeLimit) {
-        item.feeLimit = Math.ceil(item.feeLimit * config.invoices.feeIncrementExponent)
-      }
     }
   },
   [PAYMENT_SUCCESSFUL]: (state, { paymentId }) => {

--- a/services/grpc/grpc.js
+++ b/services/grpc/grpc.js
@@ -9,6 +9,7 @@ import promiseTimeout from '@zap/utils/promiseTimeout'
 import isObject from '@zap/utils/isObject'
 import { forwardAll, unforwardAll } from '@zap/utils/events'
 import lightningMethods from './lightning.methods'
+import routerMethods from './router.methods'
 import lightningSubscriptions from './lightning.subscriptions'
 
 const GRPC_WALLET_UNLOCKER_SERVICE_ACTIVE = 'GRPC_WALLET_UNLOCKER_SERVICE_ACTIVE'
@@ -70,6 +71,8 @@ class ZapGrpc extends EventEmitter {
     // Inject helper methods.
     Object.assign(this.services.Lightning, lightningMethods)
     Object.assign(this.services.Lightning, lightningSubscriptions)
+    Object.assign(this.services.Router, routerMethods)
+
     // Setup gRPC event handlers.
     this.grpc.on('locked', () => {
       this.emit(GRPC_WALLET_UNLOCKER_SERVICE_ACTIVE)

--- a/services/grpc/router.methods.js
+++ b/services/grpc/router.methods.js
@@ -1,8 +1,9 @@
 import { randomBytes } from 'crypto'
+import config from 'config'
 import { grpcLog } from '@zap/utils/log'
 import { logGrpcCmd } from './helpers'
 
-const PAYMENT_PROBE_TIMEOUT = 15
+const PAYMENT_PROBE_TIMEOUT = config.invoices.probeTimeout
 
 // ------------------------------------
 // Wrappers / Overrides

--- a/services/grpc/router.methods.js
+++ b/services/grpc/router.methods.js
@@ -1,3 +1,4 @@
+import { randomBytes } from 'crypto'
 import { grpcLog } from '@zap/utils/log'
 import { logGrpcCmd } from './helpers'
 
@@ -18,8 +19,10 @@ const PAYMENT_PROBE_TIMEOUT = 15
 async function probePayment(dest, amt, timeout = PAYMENT_PROBE_TIMEOUT) {
   logGrpcCmd('Router.probePayment', { dest, amt, timeout })
 
+  // Use a payload that has the payment hash set to some random bytes.
+  // This will cause the payment to fail at the final destination.
   const payload = {
-    payment_hash: Buffer.from('0'),
+    payment_hash: new Uint8Array(randomBytes(32)),
     dest: Buffer.from(dest, 'hex'),
     amt,
     timeout_seconds: timeout,

--- a/services/grpc/router.methods.js
+++ b/services/grpc/router.methods.js
@@ -36,6 +36,7 @@ async function probePayment(options) {
   }
 
   return new Promise((resolve, reject) => {
+    grpcLog.time('probePayment')
     const call = this.service.sendPayment(payload)
 
     call.on('data', data => {
@@ -67,6 +68,7 @@ async function probePayment(options) {
     })
 
     call.on('end', () => {
+      grpcLog.timeEnd('probePayment')
       grpcLog.info('PROBE END')
       if (error) {
         return reject(decorateError(error))
@@ -98,6 +100,7 @@ async function sendPayment(payload = {}) {
   }
 
   return new Promise((resolve, reject) => {
+    grpcLog.time('sendPayment')
     const call = this.service.sendPayment(payload)
 
     call.on('data', data => {
@@ -134,6 +137,7 @@ async function sendPayment(payload = {}) {
     })
 
     call.on('end', () => {
+      grpcLog.timeEnd('sendPayment')
       grpcLog.info('PAYMENT END')
       if (error) {
         return reject(decorateError(error))

--- a/services/grpc/router.methods.js
+++ b/services/grpc/router.methods.js
@@ -1,9 +1,54 @@
 import { grpcLog } from '@zap/utils/log'
 import { logGrpcCmd } from './helpers'
 
+const PAYMENT_PROBE_TIMEOUT = 15
+
 // ------------------------------------
 // Wrappers / Overrides
 // ------------------------------------
+
+/**
+ * probePayment - Call lnd grpc sendPayment method with a fake payment hash in order to probe for a route.
+ *
+ * @param {string} dest Identity pubkey of the payment recipient
+ * @param {number} amt Number of satoshis to send
+ * @param {number} timeout Upper limit on the amount of time spent attempting to fulfill the payment
+ * @returns {Promise} The taken route when state is SUCCEEDED.
+ */
+async function probePayment(dest, amt, timeout = PAYMENT_PROBE_TIMEOUT) {
+  logGrpcCmd('Router.probePayment', { dest, amt, timeout })
+
+  const payload = {
+    payment_hash: Buffer.from('0'),
+    dest: Buffer.from(dest, 'hex'),
+    amt,
+    timeout_seconds: timeout,
+  }
+
+  return new Promise((resolve, reject) => {
+    const call = this.service.sendPayment(payload)
+
+    call.on('data', data => {
+      grpcLog.debug('PROBE DATA :%o', data)
+
+      switch (data.state) {
+        case 'IN_FLIGHT':
+          // Payment is still in progress, do nothing.
+          grpcLog.debug('PROBE IN_FLIGHT...')
+          break
+
+        case 'FAILED_INCORRECT_PAYMENT_DETAILS':
+          grpcLog.info('PROBE SUCCESS: %o', data)
+          resolve(data.route)
+          break
+
+        default:
+          grpcLog.warn('PROBE FAILED: %o', data)
+          reject(new Error(data.state))
+      }
+    })
+  })
+}
 
 /**
  * sendPayment - Call lnd grpc sendPayment method.
@@ -56,5 +101,6 @@ async function sendPayment(payload = {}) {
 }
 
 export default {
+  probePayment,
   sendPayment,
 }

--- a/services/grpc/router.methods.js
+++ b/services/grpc/router.methods.js
@@ -1,0 +1,60 @@
+import { grpcLog } from '@zap/utils/log'
+import { logGrpcCmd } from './helpers'
+
+// ------------------------------------
+// Wrappers / Overrides
+// ------------------------------------
+
+/**
+ * sendPayment - Call lnd grpc sendPayment method.
+ *
+ * @param {object} payload Payload
+ * @returns {Promise} Original payload augmented with lnd sendPayment response data.
+ */
+async function sendPayment(payload = {}) {
+  logGrpcCmd('Router.sendPayment', payload)
+
+  // Our response will always include the original payload.
+  const res = { ...payload }
+
+  const handleError = data => {
+    const error = new Error(data.state)
+    error.details = res
+    return error
+  }
+
+  return new Promise((resolve, reject) => {
+    const call = this.service.sendPayment(payload)
+
+    call.on('data', data => {
+      grpcLog.debug('PAYMENT DATA :%o', data)
+
+      switch (data.state) {
+        case 'IN_FLIGHT':
+          // Payment is still in progress, do nothing.
+          grpcLog.debug('IN_FLIGHT...')
+          break
+
+        case 'SUCCEEDED':
+          grpcLog.info('PAYMENT SUCCESS: %o', data)
+
+          // Convert the preimage to a hex string.
+          data.preimage = data.preimage && data.preimage.toString('hex')
+
+          // Add lnd return data, as well as payment preimage and hash as hex strings to the response.
+          Object.assign(res, data)
+
+          resolve(res)
+          break
+
+        default:
+          grpcLog.warn('PAYMENT FAILED: %o', data)
+          reject(handleError(data))
+      }
+    })
+  })
+}
+
+export default {
+  sendPayment,
+}

--- a/services/grpc/router.methods.js
+++ b/services/grpc/router.methods.js
@@ -26,14 +26,14 @@ export const KEYSEND_PREIMAGE_TYPE = '5482373484'
  */
 async function probePayment(options) {
   const payload = defaults(omitBy(options, isNil), {
-    timeout_seconds: PAYMENT_PROBE_TIMEOUT,
-    fee_limit_sat: PAYMENT_PROBE_FEE_LIMIT,
-    allow_self_payment: true,
+    timeoutSeconds: PAYMENT_PROBE_TIMEOUT,
+    feeLimitSat: PAYMENT_PROBE_FEE_LIMIT,
+    allowSelfPayment: true,
   })
 
   // Use a payload that has the payment hash set to some random bytes.
   // This will cause the payment to fail at the final destination.
-  payload.payment_hash = new Uint8Array(randomBytes(32))
+  payload.paymentHash = new Uint8Array(randomBytes(32))
 
   logGrpcCmd('Router.probePayment', payload)
 
@@ -59,12 +59,12 @@ async function probePayment(options) {
 
         case 'FAILED_INCORRECT_PAYMENT_DETAILS':
           grpcLog.info('PROBE SUCCESS: %o', data)
-          // FIXME: For some reason the custom_records key is corrupt in the grpc response object.
+          // FIXME: For some reason the customRecords key is corrupt in the grpc response object.
           // For now, assume that if a custom_record key is set that it is a keysend record and fix it accordingly.
           data.route.hops = data.route.hops.map(hop => {
-            Object.keys(hop.custom_records).forEach(key => {
-              hop.custom_records[KEYSEND_PREIMAGE_TYPE] = hop.custom_records[key]
-              delete hop.custom_records[key]
+            Object.keys(hop.customRecords).forEach(key => {
+              hop.customRecords[KEYSEND_PREIMAGE_TYPE] = hop.customRecords[key]
+              delete hop.customRecords[key]
             })
             return hop
           })
@@ -110,8 +110,8 @@ async function sendPayment(options = {}) {
   // Use a payload that has the payment hash set to some random bytes.
   // This will cause the payment to fail at the final destination.
   const payload = defaults(omitBy(options, isNil), {
-    timeout_seconds: PAYMENT_TIMEOUT,
-    fee_limit: PAYMENT_FEE_LIMIT,
+    timeoutSeconds: PAYMENT_TIMEOUT,
+    feeLimit: PAYMENT_FEE_LIMIT,
   })
 
   logGrpcCmd('Router.sendPayment', payload)

--- a/test/unit/components/Pay/__snapshots__/PaySummaryLightning.spec.js.snap
+++ b/test/unit/components/Pay/__snapshots__/PaySummaryLightning.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`component.Form.PaySummaryLightning should render correctly 1`] = `
 <styled.div
   cryptoUnit="btc"
+  cryptoUnitName="BTC"
   cryptoUnits={
     Array [
       Object {

--- a/test/unit/utils/btc.spec.js
+++ b/test/unit/utils/btc.spec.js
@@ -117,9 +117,9 @@ describe('bits to..', () => {
       expect(bitsToFiat('1', '10000')).toEqual('0.01')
     })
 
-    it('should return 0.01 when 1 bit is passed in at a price of 14,999', () => {
-      expect(bitsToFiat(1, 14999)).toEqual('0.01')
-      expect(bitsToFiat('1', '14999')).toEqual('0.01')
+    it('should return 0.02 when 1 bit is passed in at a price of 14,999', () => {
+      expect(bitsToFiat(1, 14999)).toEqual('0.02')
+      expect(bitsToFiat('1', '14999')).toEqual('0.02')
     })
   })
 })

--- a/test/unit/utils/btc.spec.js
+++ b/test/unit/utils/btc.spec.js
@@ -131,9 +131,9 @@ describe('satoshi to..', () => {
       expect(satoshisToBtc('1')).toEqual('0.00000001')
     })
 
-    it('should return 0.00000002 when a between 1 and 2 satoshi value is passed in', () => {
-      expect(satoshisToBtc(1.5)).toEqual('0.00000002')
-      expect(satoshisToBtc('1.5')).toEqual('0.00000002')
+    it('should return 0.000000015 when 1.5 satoshi value is passed in', () => {
+      expect(satoshisToBtc(1.5)).toEqual('0.000000015')
+      expect(satoshisToBtc('1.5')).toEqual('0.000000015')
     })
   })
 
@@ -178,9 +178,9 @@ describe('millisatoshis to..', () => {
       expect(millisatoshisToBits('100000')).toEqual('1')
     })
 
-    it('should return 1.23 when 123,456 millisatoshis are passed in', () => {
-      expect(millisatoshisToBits(123456)).toEqual('1.23')
-      expect(millisatoshisToBits('123456')).toEqual('1.23')
+    it('should return 1.23 when 123,45678 millisatoshis are passed in', () => {
+      expect(millisatoshisToBits(123456)).toEqual('1.23456')
+      expect(millisatoshisToBits('123456')).toEqual('1.23456')
     })
   })
 
@@ -188,6 +188,11 @@ describe('millisatoshis to..', () => {
     it('should return 1 when 1000 millisatoshis are passed in', () => {
       expect(millisatoshisToSatoshis(1000)).toEqual('1')
       expect(millisatoshisToSatoshis('1000')).toEqual('1')
+    })
+
+    it('should return 0.001 when 1 millisatoshis are passed in', () => {
+      expect(millisatoshisToSatoshis(1)).toEqual('0.001')
+      expect(millisatoshisToSatoshis('1')).toEqual('0.001')
     })
   })
 

--- a/test/unit/utils/crypto.spec.js
+++ b/test/unit/utils/crypto.spec.js
@@ -87,11 +87,23 @@ describe('getMinFee', () => {
   const test = (from, to) => expect(getMinFee(from)).toEqual(to)
   it('returns the minimum fee (1 above the lowest value)', () => {
     test([], null)
-    test([{ totalFees: 2 }], '3')
-    test([{ totalFees: 2 }, { totalFees: 5 }], '3')
-    test([{ totalFees: 4 }], '5')
-    test([{ totalFees: 0 }], '1')
-    test([{ totalFees: 85 }, { totalFees: 95 }], '86')
+    test([{ totalFees: 2, totalFeesMsat: 2000 }], '3')
+    test(
+      [
+        { totalFees: 2, totalFeesMsat: 2000 },
+        { totalFees: 5, totalFeesMsat: 5000 },
+      ],
+      '3'
+    )
+    test([{ totalFees: 4, totalFeesMsat: 4000 }], '5')
+    test([{ totalFees: 0, totalFeesMsat: 0 }], '1')
+    test(
+      [
+        { totalFees: 85, totalFeesMsat: 85000 },
+        { totalFees: 95, totalFeesMsat: 95000 },
+      ],
+      '86'
+    )
   })
 })
 
@@ -99,11 +111,23 @@ describe('getMaxFee', () => {
   const test = (from, to) => expect(getMaxFee(from)).toEqual(to)
   it('returns the maximum fee (1 above the highest value)', () => {
     test([], null)
-    test([{ totalFees: 2 }], '3')
-    test([{ totalFees: 2 }, { totalFees: 5 }], '6')
-    test([{ totalFees: 4 }], '5')
-    test([{ totalFees: 0 }], '1')
-    test([{ totalFees: 85 }, { totalFees: 95 }], '96')
+    test([{ totalFees: 2, totalFeesMsat: 2000 }], '3')
+    test(
+      [
+        { totalFees: 2, totalFeesMsat: 2000 },
+        { totalFees: 5, totalFeesMsat: 5000 },
+      ],
+      '6'
+    )
+    test([{ totalFees: 4, totalFeesMsat: 4000 }], '5')
+    test([{ totalFees: 0, totalFeesMsat: 0 }], '1')
+    test(
+      [
+        { totalFees: 85, totalFeesMsat: 85000 },
+        { totalFees: 95, totalFeesMsat: 95000 },
+      ],
+      '96'
+    )
   })
 })
 
@@ -111,10 +135,22 @@ describe('getMaxFeeInclusive', () => {
   const test = (from, to) => expect(getMaxFeeInclusive(from)).toEqual(to)
   it('returns the minimum fee includding increases after all retry attempts', () => {
     test([], null)
-    test([{ totalFees: 2 }], '5')
-    test([{ totalFees: 2 }, { totalFees: 5 }], '8')
-    test([{ totalFees: 4 }], '7')
-    test([{ totalFees: 0 }], '3')
-    test([{ totalFees: 85 }, { totalFees: 95 }], '117')
+    test([{ totalFees: 2, totalFeesMsat: 2000 }], '5')
+    test(
+      [
+        { totalFees: 2, totalFeesMsat: 2000 },
+        { totalFees: 5, totalFeesMsat: 5000 },
+      ],
+      '8'
+    )
+    test([{ totalFees: 4, totalFeesMsat: 4000 }], '7')
+    test([{ totalFees: 0, totalFeesMsat: 0 }], '3')
+    test(
+      [
+        { totalFees: 85, totalFeesMsat: 85000 },
+        { totalFees: 95, totalFeesMsat: 95000 },
+      ],
+      '117'
+    )
   })
 })

--- a/utils/btc.js
+++ b/utils/btc.js
@@ -44,7 +44,7 @@ export function btcToSatoshis(btc) {
 export function btcToMillisatoshis(btc) {
   if (isEmptyAmount(btc)) return null
 
-  return Coin(btc, 11)
+  return Coin(btc)
     .multiply(100000000000)
     .toString()
 }

--- a/utils/coin.js
+++ b/utils/coin.js
@@ -26,7 +26,7 @@ export const CoinBig = BigNumber.clone()
 
 CoinBig.config({
   DECIMAL_PLACES: PRECISION,
-  ROUNDING_MODE: BigNumber.ROUND_HALF_UP,
+  ROUNDING_MODE: BigNumber.ROUND_UP,
   EXPONENTIAL_AT: 1e+9 // prettier-ignore
 })
 

--- a/utils/coin.js
+++ b/utils/coin.js
@@ -2,7 +2,7 @@
 
 import BigNumber from 'bignumber.js'
 
-const PRECISION = 8
+const PRECISION = 11
 const getCurrencyPrecision = code => {
   switch (code) {
     case 'CHF':
@@ -32,16 +32,14 @@ CoinBig.config({
 
 /**
  * @param {number|string|Coin|BigNumber} value Value
- * @param {number} precision Decimal precision
  * @returns {Coin} Coin instance
  * @class
  */
-function Coin(value, precision) {
+function Coin(value) {
   if (!(this instanceof Coin)) {
-    return new Coin(value, precision)
+    return new Coin(value)
   }
-  const p = precision || PRECISION
-  const big = CoinBig(value).decimalPlaces(p)
+  const big = CoinBig(value).decimalPlaces(PRECISION)
 
   /**
    *
@@ -74,7 +72,7 @@ function Coin(value, precision) {
   /**
    * @returns {string} String representation of value
    */
-  this.toString = () => big.decimalPlaces(p).toPrecision()
+  this.toString = () => big.decimalPlaces(PRECISION).toPrecision()
 
   /**
    * returns a string that represents value, truncated to the specified precision
@@ -82,7 +80,8 @@ function Coin(value, precision) {
    * @param {number} digits Digits
    * @returns {string} String representation of value
    */
-  this.toPrecision = digits => big.decimalPlaces(Math.min(Math.max(0, digits), p)).toPrecision()
+  this.toPrecision = digits =>
+    big.decimalPlaces(Math.min(Math.max(0, digits), PRECISION)).toPrecision()
 
   /**
    * returns a string that represents value, truncated to the specified precision per given code of currency

--- a/utils/crypto.js
+++ b/utils/crypto.js
@@ -240,6 +240,20 @@ export const getMaxFee = routes => {
 }
 
 /**
+ * getMaxFee - Given a list of routes, find the exact fee from the first route.
+ *
+ * @param {Array} routes List of routes
+ * @returns {number} exact fee
+ */
+export const getExactFee = routes => {
+  if (!routes || !routes.length) {
+    return null
+  }
+  const route = routes.find(r => r.isExact)
+  return route ? route.total_fees : null
+}
+
+/**
  * getMaxFee - Given a list of routes, find the maximum fee factoring in all possible payment retry attempts.
  *
  * @param {Array} routes List of routes

--- a/utils/fee.js
+++ b/utils/fee.js
@@ -3,6 +3,7 @@ import mapValues from 'lodash/mapValues'
 import { grpc } from 'workers'
 import { requestFees } from '@zap/utils/api'
 import { mainLog } from '@zap/utils/log'
+import { CoinBig } from '@zap/utils/coin'
 import { createError, UNSUPPORTED } from '@zap/utils/error'
 
 /**
@@ -11,7 +12,7 @@ import { createError, UNSUPPORTED } from '@zap/utils/error'
  * @param  {object} fees Fee rate object
  * @returns {object} Sanitized fee rate object
  */
-const sanitizeFeeRange = fees => mapValues(fees, fee => Math.max(1, fee))
+const sanitizeFeeRange = fees => mapValues(fees, fee => CoinBig.max(1, fee).toString())
 
 /**
  * estimateLndFee - Returns fee estimation for the specified @address @amount & @targetConf using LND gRPC API.


### PR DESCRIPTION
## Description:

And implementation of payment probing.

Implements the recommendations from LL to use payment probing in order to determine an accurate fee estimate along a routable path.

Payment probing will only be used for lnd nodes on version 0.7.1 and above as it requires improved error handing provided by the new Router api.

See https://github.com/lightningnetwork/lnd/pull/2537 for context.

## Motivation and Context:

Improve fee estimate accuracy.

## How Has This Been Tested?

Manually

## Types of changes:

Enhancement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
