### PR TITLE
test(unit): use mock date in countdown tests

### DIFF
--- a/test/unit/components/UI/Countdown.spec.js
+++ b/test/unit/components/UI/Countdown.spec.js
@@ -3,11 +3,23 @@ import { IntlProvider } from 'react-intl'
 import { renderWithTheme } from '@zap/test/unit/__helpers__/renderWithTheme'
 import { Countdown } from 'components/UI'
 
+const CURRENT_DATE = 1573466266762
+
 describe('component.UI.Countdown', () => {
-  it('should render correctly with expiry set to a date in the past', () => {
+  let dateNowMockFn
+
+  beforeEach(() => {
+    dateNowMockFn = jest.spyOn(Date, 'now').mockImplementation(() => CURRENT_DATE)
+  })
+
+  afterEach(() => {
+    dateNowMockFn.mockRestore()
+  })
+
+  it('should render correctly with expiry set to a date 1 hour in the past', () => {
     const tree = renderWithTheme(
       <IntlProvider locale="en">
-        <Countdown offset={new Date('2009-01-03T18:15:05+00:00')} />
+        <Countdown offset={new Date(1573466266762 - 3600000)} />
       </IntlProvider>
     ).toJSON()
     expect(tree).toMatchSnapshot()

--- a/test/unit/components/UI/__snapshots__/Countdown.spec.js.snap
+++ b/test/unit/components/UI/__snapshots__/Countdown.spec.js.snap
@@ -46,7 +46,7 @@ exports[`component.UI.Countdown should render correctly with expiry in 365 days 
 </div>
 `;
 
-exports[`component.UI.Countdown should render correctly with expiry set to a date in the past 1`] = `
+exports[`component.UI.Countdown should render correctly with expiry set to a date 1 hour in the past 1`] = `
 .c0 {
   box-sizing: border-box;
   margin: 0;
@@ -65,6 +65,6 @@ exports[`component.UI.Countdown should render correctly with expiry set to a dat
   <i>
      
   </i>
-  3,963 days ago
+  1 hour ago
 </div>
 `;


### PR DESCRIPTION
## Description:

Use mock date in countdown tests to ensure predictability.

## Motivation and Context:

The `Countdown` component applies offsets to the current date. Unit tests should mock the current date to a predictable value to ensure that tests don't give varying results depending on when they are run.

## How Has This Been Tested?

`yarn test-unit`

## Types of changes:

Test suite fixes.

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
