### PR TITLE
Disable sign message functionality for local wallets

### DIFF
--- a/renderer/components/Profile/ProfileMenu/ProfileMenu.js
+++ b/renderer/components/Profile/ProfileMenu/ProfileMenu.js
@@ -19,7 +19,7 @@ const ProfileMenu = ({ group, setGroup, isLocalWallet, ...rest }) => {
   const verifyMessageLink = menuLink(PANE_VERIFYMESSAGE, messages.verify_message_title)
 
   // Get set of menu links based on wallet type.
-  const getLocalLinks = () => [nodeInfoLink, signMessageLink, verifyMessageLink]
+  const getLocalLinks = () => [nodeInfoLink, verifyMessageLink]
   const getRemoteLinks = () => [nodeInfoLink, connectLink, signMessageLink, verifyMessageLink]
   const items = isLocalWallet ? getLocalLinks() : getRemoteLinks()
 

--- a/renderer/components/Profile/ProfilePage/ProfilePage.js
+++ b/renderer/components/Profile/ProfilePage/ProfilePage.js
@@ -22,7 +22,7 @@ const ProfilePage = ({ activeWalletSettings }) => {
   const isLocalWallet = activeWalletSettings.type === 'local'
 
   const hasNodeInfoPane = group === PANE_NODEINFO
-  const hasSignMessagePane = group === PANE_SIGNMESSAGE
+  const hasSignMessagePane = group === PANE_SIGNMESSAGE && !isLocalWallet
   const hasVerifyMessagePane = group === PANE_VERIFYMESSAGE
   const hasConnectPane = group === PANE_LNDCONNECT && !isLocalWallet
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Disable sign message functionality for local wallets.
<!--- Describe your changes in detail -->

## Motivation and Context:
Local wallets are private nodes and aren't visible in the network graph which renders "sign message" a useless feature for them, because of `verifymessage` implementation details in LND no one will be able to verify such a message.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/14069193/68610082-9d260280-04bf-11ea-8441-6a0cf14f20b8.png)

## Types of changes:
UI fix
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
