### PR TITLE
Fix getInfo subscription cornercases

### DIFF
--- a/renderer/hooks/useTimeout.js
+++ b/renderer/hooks/useTimeout.js
@@ -23,6 +23,6 @@ export default function useTimeout(callback, delay) {
       const id = setTimeout(tick, delay)
       return () => clearTimeout(id)
     }
-    return null
+    return undefined
   }, [delay])
 }

--- a/services/grpc/lightning.subscriptions.js
+++ b/services/grpc/lightning.subscriptions.js
@@ -129,12 +129,13 @@ function subscribeChannelBackups(payload = {}) {
  * @param {{pollInterval}} options Subscription options
  * @returns {object} polling stream for the LND getInfo command
  */
-function subscribeGetInfo({ pollInterval = 5000 } = {}) {
+function subscribeGetInfo({ pollInterval = 5000, pollImmediately = false } = {}) {
   const stream = streamify({
     command: methods.getInfo.bind(this),
     dataEventName: 'subscribeGetInfo.data',
     errorEventName: 'subscribeGetInfo.error',
     pollInterval,
+    pollImmediately,
   })
   // Setup subscription event forwarders.
   forwardAll(stream, 'subscribeGetInfo', this)

--- a/test/unit/utils/scheduler.spec.js
+++ b/test/unit/utils/scheduler.spec.js
@@ -154,4 +154,16 @@ describe('createScheduler tasks execution', () => {
     const promise = Promise.race([originalTask, replacedTask])
     return expect(promiseTimeout(200, promise)).resolves.toBe(undefined)
   })
+
+  test('handles runImmediately correctly', () => {
+    const scheduler = createScheduler()
+
+    const promise = new Promise(resolve => {
+      scheduler.addTask({ task: () => resolve(true), baseDelay: 10, runImmediately: true })
+    })
+
+    scheduler.removeAllTasks()
+
+    return expect(promiseTimeout(5, promise)).resolves.toBe(true)
+  })
 })

--- a/utils/streamify.js
+++ b/utils/streamify.js
@@ -11,6 +11,7 @@ import createScheduler from '@zap/utils/scheduler'
  * @param {string} streamDefinition.dataEventName - event name to that it used to dispatch `data` event,
  * @param {string} streamDefinition.errorEventName - event name to that it used to dispatch `error` event,
  * @param {number} streamDefinition.pollInterval - how frequent to execute `command`,
+ * @param {number} streamDefinition.pollImmediately - execute `command` immediately after stream construction,
  * @param {boolean} streamDefinition.cancelOnError - if `cancel` should be called when `command` throws an exception,
  * @returns {*} - returns stream-like object that has `on` and `cancel` methods
  */
@@ -19,6 +20,7 @@ export default function streamify({
   dataEventName,
   errorEventName,
   pollInterval,
+  pollImmediately,
   cancelOnError,
 }) {
   // internal emitter to create stream-like behavior
@@ -47,7 +49,7 @@ export default function streamify({
     }
   }
 
-  scheduler.addTask({ task, baseDelay: pollInterval })
+  scheduler.addTask({ task, baseDelay: pollInterval, runImmediately: pollImmediately })
 
   return emitter
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
Improve `synced_to_chain` status polling
Other:
Add ability to execute tasks immediately after they are added via `scheduler` (`runImmediately` flag)
Fix react hook warning and comments typos
<!--- Describe your changes in detail -->

## Motivation and Context:
If the user connects to a wallet that is already synced, it will continue to do the fast polling for up to 10 minutes or so - until the next block comes in.
Problem is that the info stream only emits data when something in the result changes, so when we first set it up if the chain is already synced then no event will be emitted until block_hash changes
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually. Connecting to different types of wallets
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes:
Bugfix/Refactor
<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
