### PR TITLE
fix(grpc): ensure that protobuf has Long support

### DIFF
--- a/renderer/workers/grpc.worker.js
+++ b/renderer/workers/grpc.worker.js
@@ -1,6 +1,18 @@
 /* eslint-disable no-restricted-globals */
 
 import { expose } from 'comlinkjs'
+import * as Protobuf from 'protobufjs'
+import Long from 'long'
 import ZapGrpc from '@zap/services/grpc/grpc'
+
+// Protobuf assumes that long.js is either available on the global scope or available to be required. However, when
+// used from the context of one of our web workers neither of these assumptions is true. In order to ensure that Long
+// support is available in protobuf we manually configure protobuf here, before it is used.
+//
+// See https://github.com/protobufjs/protobuf.js#browserify-integration
+//
+// This ensures that large numbers (such as those returned from chan_id props) can be properly handled without rounding.
+Protobuf.util.Long = Long
+Protobuf.configure()
 
 expose(ZapGrpc, self)


### PR DESCRIPTION
## Description:

Ensure that protobuf has Long support

NOTE: This PR only enables long support. In order to leverage it we will also need to switch to handling long as Number to handling as String

## Motivation and Context:

Protobuf assumes that long.js is either available on the global scope or available to be required. However, when used from the context of one of our web workers neither of these assumptions is true. In order to ensure that Long support is available in protobuf we manually configure protobuf here, before it is used.

See https://github.com/protobufjs/protobuf.js#browserify-integration

This ensures that large numbers (such as those returned from chan_id props) can be properly handled without rounding.

## How Has This Been Tested?

Manually

## Types of changes:

Fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
