### PR TITLE
fix: update help page link

### DIFF
--- a/electron/preload.js
+++ b/electron/preload.js
@@ -62,7 +62,7 @@ function openExternal(urlString) {
  * openHelpPage - Open the help page in a new browser window.
  */
 function openHelpPage() {
-  openExternal('https://ln-zap.github.io/zap-tutorials/zap-desktop-getting-started')
+  openExternal('https://docs.zaphq.io/docs-desktop-getting-started')
 }
 
 /**


### PR DESCRIPTION
Current help page link leads to old docs which 404. This fixes that.