### PR TITLE
feat: add tooltip to the Home.Autopilot section describing its function

### DIFF
--- a/renderer/components/Home/WalletSettingsFormLocal.js
+++ b/renderer/components/Home/WalletSettingsFormLocal.js
@@ -7,7 +7,7 @@ import { FormattedMessage, injectIntl } from 'react-intl'
 import { Box, Flex } from 'rebass/styled-components'
 import uniq from 'lodash/uniq'
 import { intlShape } from '@zap/i18n'
-import { Bar, Button, DataRow, Text } from 'components/UI'
+import { Bar, Button, DataRow, Text, Tooltip } from 'components/UI'
 import { Input, Label, Toggle, TextArea, FieldLabelFactory } from 'components/Form'
 import messages from './messages'
 import AutopilotAllocation from './AutopilotAllocation'
@@ -207,9 +207,14 @@ class WalletSettingsFormLocal extends React.Component {
         <Box as="section" mb={4}>
           <DataRow
             left={
-              <Label htmlFor="autopilot">
-                <FormattedMessage {...messages.section_autopilot_title} />
-              </Label>
+              <Flex>
+                <Label htmlFor="autopilot">
+                  <FormattedMessage {...messages.section_autopilot_title} />
+                </Label>
+                <Tooltip ml={1} mt="2px">
+                  <FormattedMessage {...messages.section_autopilot_tooltip} />
+                </Tooltip>
+              </Flex>
             }
             mt={4}
             py={2}

--- a/renderer/components/Home/messages.js
+++ b/renderer/components/Home/messages.js
@@ -7,6 +7,8 @@ export default defineMessages({
   host: 'Host',
   section_basic_title: 'Basic',
   section_autopilot_title: 'Autopilot',
+  section_autopilot_tooltip:
+    'Autopilot automates the process of finding, funding and establishing payment channels with other nodes.',
   section_naming_title: 'Naming',
   section_naming_connections: 'Connections',
   section_delete_title: 'Delete',

--- a/translations/af-ZA.json
+++ b/translations/af-ZA.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "",
   "components.Home.saved_notification": "",
   "components.Home.section_autopilot_title": "",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "",
   "components.Home.section_connection_details": "",
   "components.Home.section_delete_title": "",

--- a/translations/ar-SA.json
+++ b/translations/ar-SA.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "",
   "components.Home.saved_notification": "",
   "components.Home.section_autopilot_title": "",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "",
   "components.Home.section_connection_details": "",
   "components.Home.section_delete_title": "",

--- a/translations/bg-BG.json
+++ b/translations/bg-BG.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "",
   "components.Home.saved_notification": "",
   "components.Home.section_autopilot_title": "",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "",
   "components.Home.section_connection_details": "",
   "components.Home.section_delete_title": "",

--- a/translations/ca-ES.json
+++ b/translations/ca-ES.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "",
   "components.Home.saved_notification": "",
   "components.Home.section_autopilot_title": "",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "",
   "components.Home.section_connection_details": "",
   "components.Home.section_delete_title": "",

--- a/translations/cs-CZ.json
+++ b/translations/cs-CZ.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "Něco se pokazilo",
   "components.Home.saved_notification": "Nastavení bylo aktualizováno",
   "components.Home.section_autopilot_title": "Autopilot",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "Základní",
   "components.Home.section_connection_details": "Podrobnosti o připojení",
   "components.Home.section_delete_title": "Smazat",

--- a/translations/da-DK.json
+++ b/translations/da-DK.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "",
   "components.Home.saved_notification": "",
   "components.Home.section_autopilot_title": "",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "Grundlæggende",
   "components.Home.section_connection_details": "Forbindelses detaljer",
   "components.Home.section_delete_title": "Slet",

--- a/translations/de-DE.json
+++ b/translations/de-DE.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "Da ist was schiefgelaufen",
   "components.Home.saved_notification": "Einstellungen aktualisiert",
   "components.Home.section_autopilot_title": "Autopilot",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "Basis",
   "components.Home.section_connection_details": "Verbindungsdetails",
   "components.Home.section_delete_title": "Löschen",

--- a/translations/el-GR.json
+++ b/translations/el-GR.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "",
   "components.Home.saved_notification": "",
   "components.Home.section_autopilot_title": "",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "",
   "components.Home.section_connection_details": "",
   "components.Home.section_delete_title": "",

--- a/translations/en.json
+++ b/translations/en.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "Something went wrong",
   "components.Home.saved_notification": "Settings have been updated",
   "components.Home.section_autopilot_title": "Autopilot",
+  "components.Home.section_autopilot_tooltip": "Autopilot automates the process of finding, funding and establishing payment channels with other nodes.",
   "components.Home.section_basic_title": "Basic",
   "components.Home.section_connection_details": "Connection details",
   "components.Home.section_delete_title": "Delete",

--- a/translations/es-ES.json
+++ b/translations/es-ES.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "Ha ocurrido un error",
   "components.Home.saved_notification": "Configuraciónes actualizadas",
   "components.Home.section_autopilot_title": "Piloto automático",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "Básico",
   "components.Home.section_connection_details": "Detalles de conexión",
   "components.Home.section_delete_title": "Borrar",

--- a/translations/fi-FI.json
+++ b/translations/fi-FI.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "",
   "components.Home.saved_notification": "",
   "components.Home.section_autopilot_title": "",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "",
   "components.Home.section_connection_details": "",
   "components.Home.section_delete_title": "",

--- a/translations/fr-FR.json
+++ b/translations/fr-FR.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "Une erreur s'est produite",
   "components.Home.saved_notification": "Les réglages ont été mis à jour",
   "components.Home.section_autopilot_title": "Autopilot",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "Informations",
   "components.Home.section_connection_details": "Détails de connexion",
   "components.Home.section_delete_title": "Supprimer",

--- a/translations/ga-IE.json
+++ b/translations/ga-IE.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "",
   "components.Home.saved_notification": "",
   "components.Home.section_autopilot_title": "",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "Bunúsach",
   "components.Home.section_connection_details": "",
   "components.Home.section_delete_title": "Scrios",

--- a/translations/he-IL.json
+++ b/translations/he-IL.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "",
   "components.Home.saved_notification": "",
   "components.Home.section_autopilot_title": "",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "",
   "components.Home.section_connection_details": "",
   "components.Home.section_delete_title": "",

--- a/translations/hi-IN.json
+++ b/translations/hi-IN.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "",
   "components.Home.saved_notification": "",
   "components.Home.section_autopilot_title": "",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "",
   "components.Home.section_connection_details": "",
   "components.Home.section_delete_title": "",

--- a/translations/hr-HR.json
+++ b/translations/hr-HR.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "Nešto je pošlo po zlu",
   "components.Home.saved_notification": "Postavke su ažurirane",
   "components.Home.section_autopilot_title": "Autopilot",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "Osnovno",
   "components.Home.section_connection_details": "Detalji veze",
   "components.Home.section_delete_title": "Obriši",

--- a/translations/hu-HU.json
+++ b/translations/hu-HU.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "",
   "components.Home.saved_notification": "",
   "components.Home.section_autopilot_title": "",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "",
   "components.Home.section_connection_details": "",
   "components.Home.section_delete_title": "",

--- a/translations/it-IT.json
+++ b/translations/it-IT.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "",
   "components.Home.saved_notification": "",
   "components.Home.section_autopilot_title": "",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "",
   "components.Home.section_connection_details": "",
   "components.Home.section_delete_title": "",

--- a/translations/ja-JP.json
+++ b/translations/ja-JP.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "",
   "components.Home.saved_notification": "",
   "components.Home.section_autopilot_title": "",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "",
   "components.Home.section_connection_details": "",
   "components.Home.section_delete_title": "",

--- a/translations/ko-KR.json
+++ b/translations/ko-KR.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "",
   "components.Home.saved_notification": "",
   "components.Home.section_autopilot_title": "",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "",
   "components.Home.section_connection_details": "",
   "components.Home.section_delete_title": "",

--- a/translations/nl-NL.json
+++ b/translations/nl-NL.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "",
   "components.Home.saved_notification": "",
   "components.Home.section_autopilot_title": "",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "",
   "components.Home.section_connection_details": "",
   "components.Home.section_delete_title": "",

--- a/translations/no-NO.json
+++ b/translations/no-NO.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "Noe gikk galt",
   "components.Home.saved_notification": "Innstillingene er oppdatert",
   "components.Home.section_autopilot_title": "Autopilot",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "",
   "components.Home.section_connection_details": "Forbindelses-detaljer",
   "components.Home.section_delete_title": "Slett",

--- a/translations/pl-PL.json
+++ b/translations/pl-PL.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "",
   "components.Home.saved_notification": "",
   "components.Home.section_autopilot_title": "",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "",
   "components.Home.section_connection_details": "",
   "components.Home.section_delete_title": "",

--- a/translations/pt-BR.json
+++ b/translations/pt-BR.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "",
   "components.Home.saved_notification": "",
   "components.Home.section_autopilot_title": "",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "",
   "components.Home.section_connection_details": "",
   "components.Home.section_delete_title": "",

--- a/translations/pt-PT.json
+++ b/translations/pt-PT.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "",
   "components.Home.saved_notification": "",
   "components.Home.section_autopilot_title": "",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "",
   "components.Home.section_connection_details": "",
   "components.Home.section_delete_title": "",

--- a/translations/ro-RO.json
+++ b/translations/ro-RO.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "",
   "components.Home.saved_notification": "",
   "components.Home.section_autopilot_title": "",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "",
   "components.Home.section_connection_details": "",
   "components.Home.section_delete_title": "",

--- a/translations/ru-RU.json
+++ b/translations/ru-RU.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "Произошла ошибка",
   "components.Home.saved_notification": "Настройки были сохранены",
   "components.Home.section_autopilot_title": "",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "",
   "components.Home.section_connection_details": "",
   "components.Home.section_delete_title": "",

--- a/translations/sr-SP.json
+++ b/translations/sr-SP.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "",
   "components.Home.saved_notification": "",
   "components.Home.section_autopilot_title": "",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "",
   "components.Home.section_connection_details": "",
   "components.Home.section_delete_title": "",

--- a/translations/sv-SE.json
+++ b/translations/sv-SE.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "",
   "components.Home.saved_notification": "",
   "components.Home.section_autopilot_title": "",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "",
   "components.Home.section_connection_details": "",
   "components.Home.section_delete_title": "",

--- a/translations/tr-TR.json
+++ b/translations/tr-TR.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "",
   "components.Home.saved_notification": "",
   "components.Home.section_autopilot_title": "",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "",
   "components.Home.section_connection_details": "",
   "components.Home.section_delete_title": "",

--- a/translations/uk-UA.json
+++ b/translations/uk-UA.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "Виникла помилка",
   "components.Home.saved_notification": "Налаштування збережені",
   "components.Home.section_autopilot_title": "",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "",
   "components.Home.section_connection_details": "",
   "components.Home.section_delete_title": "",

--- a/translations/vi-VN.json
+++ b/translations/vi-VN.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "",
   "components.Home.saved_notification": "",
   "components.Home.section_autopilot_title": "",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "",
   "components.Home.section_connection_details": "",
   "components.Home.section_delete_title": "",

--- a/translations/zh-CN.json
+++ b/translations/zh-CN.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "",
   "components.Home.saved_notification": "",
   "components.Home.section_autopilot_title": "",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "",
   "components.Home.section_connection_details": "",
   "components.Home.section_delete_title": "",

--- a/translations/zh-TW.json
+++ b/translations/zh-TW.json
@@ -279,6 +279,7 @@
   "components.Home.saved_error": "",
   "components.Home.saved_notification": "",
   "components.Home.section_autopilot_title": "",
+  "components.Home.section_autopilot_tooltip": "",
   "components.Home.section_basic_title": "",
   "components.Home.section_connection_details": "",
   "components.Home.section_delete_title": "",


### PR DESCRIPTION
## Description:

Add a tooltip to the Autopilot section heading in the Home screen explaining the function of enabling autopilot.

## Motivation and Context:

As a new lnd/Lightning/Zap user I was unsure what Autopilot actually did. Definitely had some ideas based on the name _"autopilot"_, but it's still nice to know for sure what it will do.

## How Has This Been Tested?

Locally (see screenshot).

## Screenshots (if appropriate):

![Zap Autopilot Tooltip](https://user-images.githubusercontent.com/8009243/75179377-d7937280-5731-11ea-95d6-dad4828607cd.png)

## Types of changes:

Feature/Enhancement

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
