### PR TITLE
Set user-agent to `Chrome` for google oauth

### DIFF
--- a/electron/walletBackup/gdrive/gdriveApi.js
+++ b/electron/walletBackup/gdrive/gdriveApi.js
@@ -209,7 +209,7 @@ export function createAuthWindow(oAuthClient, scope, windowParams = { width: 500
       handleNavigation(newUrl)
     })
 
-    authWindow.loadURL(authUrl)
+    authWindow.loadURL(authUrl, { userAgent: 'Chrome' })
   })
 }
 


### PR DESCRIPTION
## Description:

Set user-agent to `Chrome` for google oauth

## Motivation and Context:

fix #3342

## How Has This Been Tested?

Manually