### PR TITLE
feat(ui): add zero amount payment request message

### DIFF
--- a/renderer/components/Form/LightningInvoiceInput.js
+++ b/renderer/components/Form/LightningInvoiceInput.js
@@ -23,8 +23,12 @@ const validate = (intl, network, chain, value) => {
     if (isLn(value, chain, network)) {
       try {
         const invoice = decodePayReq(value)
-        if (!invoice || (!invoice.satoshis && !invoice.millisatoshis)) {
+        if (!invoice) {
           throw new Error('Invalid invoice')
+        }
+
+        if (!invoice.satoshis && !invoice.millisatoshis) {
+          return intl.formatMessage({ ...messages.zero_amount_request })
         }
       } catch (e) {
         return invalidRequestMessage

--- a/renderer/components/Form/messages.js
+++ b/renderer/components/Form/messages.js
@@ -24,4 +24,6 @@ export default defineMessages({
   transaction_speed_description_medium: 'less than 3 hours',
   transaction_speed_description_slow: 'up to 24 hours',
   transaction_speed_description_slowest: 'more than 24 hours',
+  zero_amount_request:
+    'Unsupported lightning payment request: payment requests must include a non-zero amount.',
 })

--- a/translations/af-ZA.json
+++ b/translations/af-ZA.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "",
   "components.Form.valid_pubkey": "",
   "components.Form.valid_request": "",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "",
   "components.Home.button_save": "",
   "components.Home.cert_description": "",

--- a/translations/ar-SA.json
+++ b/translations/ar-SA.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "",
   "components.Form.valid_pubkey": "",
   "components.Form.valid_request": "",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "",
   "components.Home.button_save": "",
   "components.Home.cert_description": "",

--- a/translations/bg-BG.json
+++ b/translations/bg-BG.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "",
   "components.Form.valid_pubkey": "",
   "components.Form.valid_request": "",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "",
   "components.Home.button_save": "",
   "components.Home.cert_description": "",

--- a/translations/ca-ES.json
+++ b/translations/ca-ES.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "",
   "components.Form.valid_pubkey": "",
   "components.Form.valid_request": "",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "",
   "components.Home.button_save": "",
   "components.Home.cert_description": "",

--- a/translations/cs-CZ.json
+++ b/translations/cs-CZ.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "Pomalu",
   "components.Form.valid_pubkey": "Validní PubKey",
   "components.Form.valid_request": "Validní {chain} požadavek",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "Zrušit",
   "components.Home.button_save": "Uložit",
   "components.Home.cert_description": "Cesta k lnd tls certifikátu.",

--- a/translations/da-DK.json
+++ b/translations/da-DK.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "",
   "components.Form.valid_pubkey": "",
   "components.Form.valid_request": "Gyldig {chain} anmodning",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "",
   "components.Home.button_save": "",
   "components.Home.cert_description": "",

--- a/translations/de-DE.json
+++ b/translations/de-DE.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "Langsam",
   "components.Form.valid_pubkey": "Gültiger PubKey",
   "components.Form.valid_request": "Gültige {chain} -Anfrage",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "Abbrechen",
   "components.Home.button_save": "Speichern",
   "components.Home.cert_description": "Pfad zum Lnd TLS-Zertifikat.",

--- a/translations/el-GR.json
+++ b/translations/el-GR.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "",
   "components.Form.valid_pubkey": "",
   "components.Form.valid_request": "",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "",
   "components.Home.button_save": "",
   "components.Home.cert_description": "",

--- a/translations/en.json
+++ b/translations/en.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "Slow",
   "components.Form.valid_pubkey": "Valid PubKey",
   "components.Form.valid_request": "Valid {chain} request",
+  "components.Form.zero_amount_request": "Unsupported lightning payment request: payment requests must include a non-zero amount.",
   "components.Home.button_cancel": "Cancel",
   "components.Home.button_save": "Save",
   "components.Home.cert_description": "Path to the lnd tls cert.",

--- a/translations/es-ES.json
+++ b/translations/es-ES.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "Lento",
   "components.Form.valid_pubkey": "Pubkey Valida",
   "components.Form.valid_request": "Solicitud valida de {chain}",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "Cancelar",
   "components.Home.button_save": "Guardar",
   "components.Home.cert_description": "La ruta al certificado tls de lnd.",

--- a/translations/fi-FI.json
+++ b/translations/fi-FI.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "",
   "components.Form.valid_pubkey": "",
   "components.Form.valid_request": "",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "",
   "components.Home.button_save": "",
   "components.Home.cert_description": "",

--- a/translations/fr-FR.json
+++ b/translations/fr-FR.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "Lente",
   "components.Form.valid_pubkey": "PubKey valide",
   "components.Form.valid_request": "Requête {chain} valide",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "Annuler",
   "components.Home.button_save": "Enregistrer",
   "components.Home.cert_description": "Le chemin d'accès au certificat TLS de lnd.",

--- a/translations/ga-IE.json
+++ b/translations/ga-IE.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "",
   "components.Form.valid_pubkey": "",
   "components.Form.valid_request": "Iarratas bailí {chain}",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "",
   "components.Home.button_save": "",
   "components.Home.cert_description": "",

--- a/translations/he-IL.json
+++ b/translations/he-IL.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "",
   "components.Form.valid_pubkey": "",
   "components.Form.valid_request": "",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "",
   "components.Home.button_save": "",
   "components.Home.cert_description": "",

--- a/translations/hi-IN.json
+++ b/translations/hi-IN.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "",
   "components.Form.valid_pubkey": "",
   "components.Form.valid_request": "",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "",
   "components.Home.button_save": "",
   "components.Home.cert_description": "",

--- a/translations/hr-HR.json
+++ b/translations/hr-HR.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "Sporo",
   "components.Form.valid_pubkey": "Valjan PubKey",
   "components.Form.valid_request": "Valjan {chain} zahtijev",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "Odustani",
   "components.Home.button_save": "Spremi",
   "components.Home.cert_description": "Staza do lnd tls cert.",

--- a/translations/hu-HU.json
+++ b/translations/hu-HU.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "",
   "components.Form.valid_pubkey": "",
   "components.Form.valid_request": "",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "",
   "components.Home.button_save": "",
   "components.Home.cert_description": "",

--- a/translations/it-IT.json
+++ b/translations/it-IT.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "",
   "components.Form.valid_pubkey": "",
   "components.Form.valid_request": "",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "",
   "components.Home.button_save": "",
   "components.Home.cert_description": "",

--- a/translations/ja-JP.json
+++ b/translations/ja-JP.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "",
   "components.Form.valid_pubkey": "",
   "components.Form.valid_request": "",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "",
   "components.Home.button_save": "",
   "components.Home.cert_description": "",

--- a/translations/ko-KR.json
+++ b/translations/ko-KR.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "",
   "components.Form.valid_pubkey": "",
   "components.Form.valid_request": "",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "",
   "components.Home.button_save": "",
   "components.Home.cert_description": "",

--- a/translations/nl-NL.json
+++ b/translations/nl-NL.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "",
   "components.Form.valid_pubkey": "",
   "components.Form.valid_request": "",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "",
   "components.Home.button_save": "",
   "components.Home.cert_description": "",

--- a/translations/no-NO.json
+++ b/translations/no-NO.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "Sakte",
   "components.Form.valid_pubkey": "Gyldig PubKey",
   "components.Form.valid_request": "Gyldig {chain} forespørsel",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "Avbryt",
   "components.Home.button_save": "Lagre",
   "components.Home.cert_description": "",

--- a/translations/pl-PL.json
+++ b/translations/pl-PL.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "",
   "components.Form.valid_pubkey": "",
   "components.Form.valid_request": "",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "",
   "components.Home.button_save": "",
   "components.Home.cert_description": "",

--- a/translations/pt-BR.json
+++ b/translations/pt-BR.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "",
   "components.Form.valid_pubkey": "",
   "components.Form.valid_request": "",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "",
   "components.Home.button_save": "",
   "components.Home.cert_description": "",

--- a/translations/pt-PT.json
+++ b/translations/pt-PT.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "",
   "components.Form.valid_pubkey": "",
   "components.Form.valid_request": "",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "",
   "components.Home.button_save": "",
   "components.Home.cert_description": "",

--- a/translations/ro-RO.json
+++ b/translations/ro-RO.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "",
   "components.Form.valid_pubkey": "",
   "components.Form.valid_request": "",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "",
   "components.Home.button_save": "",
   "components.Home.cert_description": "",

--- a/translations/ru-RU.json
+++ b/translations/ru-RU.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "",
   "components.Form.valid_pubkey": "",
   "components.Form.valid_request": "",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "Отмена",
   "components.Home.button_save": "Сохранить",
   "components.Home.cert_description": "",

--- a/translations/sr-SP.json
+++ b/translations/sr-SP.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "",
   "components.Form.valid_pubkey": "",
   "components.Form.valid_request": "",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "",
   "components.Home.button_save": "",
   "components.Home.cert_description": "",

--- a/translations/sv-SE.json
+++ b/translations/sv-SE.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "",
   "components.Form.valid_pubkey": "",
   "components.Form.valid_request": "",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "",
   "components.Home.button_save": "",
   "components.Home.cert_description": "",

--- a/translations/tr-TR.json
+++ b/translations/tr-TR.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "",
   "components.Form.valid_pubkey": "",
   "components.Form.valid_request": "",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "",
   "components.Home.button_save": "",
   "components.Home.cert_description": "",

--- a/translations/uk-UA.json
+++ b/translations/uk-UA.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "",
   "components.Form.valid_pubkey": "",
   "components.Form.valid_request": "",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "Скасувати",
   "components.Home.button_save": "Зберегти",
   "components.Home.cert_description": "",

--- a/translations/vi-VN.json
+++ b/translations/vi-VN.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "",
   "components.Form.valid_pubkey": "",
   "components.Form.valid_request": "",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "",
   "components.Home.button_save": "",
   "components.Home.cert_description": "",

--- a/translations/zh-CN.json
+++ b/translations/zh-CN.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "",
   "components.Form.valid_pubkey": "",
   "components.Form.valid_request": "",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "",
   "components.Home.button_save": "",
   "components.Home.cert_description": "",

--- a/translations/zh-TW.json
+++ b/translations/zh-TW.json
@@ -248,6 +248,7 @@
   "components.Form.transaction_speed_slow": "",
   "components.Form.valid_pubkey": "",
   "components.Form.valid_request": "",
+  "components.Form.zero_amount_request": "",
   "components.Home.button_cancel": "",
   "components.Home.button_save": "",
   "components.Home.cert_description": "",


### PR DESCRIPTION
address #1510

<!--- Provide a general summary of your changes in the Title above -->

## Description:

Add a message for why we do not allow zero amount payment request.

## Motivation and Context:

Some users are confused when they try to make a payment to a zero amount invoice produced by a service like tippin.me and see an error message saying it's an invalid payment request. This PR adds a more specific message for zero amount payment requests.

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):

![Screen Shot 2020-03-09 at 9 26 30 PM](https://user-images.githubusercontent.com/1934678/76279695-c2980280-624c-11ea-98d0-2e4694e8d239.png)


## Types of changes:

<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
