### PR TITLE
Display transaction as unconfirmed if confs less than min finality

### DIFF
--- a/renderer/components/Activity/Transaction/Transaction.js
+++ b/renderer/components/Activity/Transaction/Transaction.js
@@ -38,7 +38,7 @@ const Transaction = ({
 
     // returns color for the current number of confirmations
     const getDisplayParams = () =>
-      findLast(DISPLAY_PARAMS, ({ finality }) => num_confirmations >= finality)
+      findLast(DISPLAY_PARAMS, ({ finality }) => num_confirmations >= finality) || DISPLAY_PARAMS[0]
 
     if (num_confirmations > confirmed) {
       return (


### PR DESCRIPTION
## Description:

Prevent app from crashing if there is a transaction whose number of confirmations is unknown or is less than the configured onchain finality settings.

## Motivation and Context:

Fix https://github.com/LN-Zap/zap-desktop/issues/3277
Fix https://github.com/LN-Zap/zap-desktop/issues/3258
Fix https://github.com/LN-Zap/zap-desktop/issues/3195

## How Has This Been Tested?

Change default config from:
```js
  onchainFinality: {
    pending: 0,
    confirmed: 1,
  },
```

to

```js
  onchainFinality: {
    pending: 1,
    confirmed: 3,
  },
```
And then restart the app and make an on-chain transaction.

App will crash with `Cannot read property 'color' of undefined at` error.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
