### PR TITLE
Prevent duplicate channel balance during force close

### DIFF
--- a/renderer/reducers/transaction.js
+++ b/renderer/reducers/transaction.js
@@ -142,8 +142,9 @@ export const receiveTransactions = (transactions, updateOnly = false) => (dispat
     }
   })
 
-  // Fetch updated balance.
+  // Fetch updated channels and balance.
   dispatch(fetchBalance())
+  dispatch(fetchChannels())
 }
 
 /**
@@ -252,8 +253,6 @@ export const receiveTransactionData = transaction => (dispatch, getState) => {
       showSystemNotification(intl.formatMessage(messages.transaction_received_title), {
         body: intl.formatMessage(messages.transaction_received_body),
       })
-      // Fetch updated channels.
-      dispatch(fetchChannels())
     } else {
       showSystemNotification(intl.formatMessage(messages.transaction_sent_title), {
         body: intl.formatMessage(messages.transaction_sent_body),


### PR DESCRIPTION
## Description:

Balance shows as double during channel force close.

What seems to happen is that once the force close channel maturity height is reached the return amount shows up in unconfirmed wallet balance AND in total limbo balance for a period before being moved from unconfirmed to confirmed and getting removed from total limbo balance.

This PR also fixes an issue with the desktop notifications and prevents notifications from showing that say you sent coins when you open or close a channel.

## Motivation and Context:

Fix https://github.com/LN-Zap/zap-desktop/issues/3310

## How Has This Been Tested?

Regtest

## Types of changes:

Fix
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
