### PR TITLE
Ensure password lock/unlock works again

### DIFF
--- a/renderer/components/Settings/Security/PasswordPromptDialog.js
+++ b/renderer/components/Settings/Security/PasswordPromptDialog.js
@@ -7,7 +7,7 @@ import { PasswordInput, Form } from 'components/Form'
 import messages from './messages'
 import { useFormError } from 'hooks'
 
-const DialogWrapper = ({ loginError, clearLoginError, onOk, onCancel }) => {
+const PasswordPromptDialog = ({ loginError, clearLoginError, onOk, onCancel }) => {
   const intl = useIntl()
   const formApiRef = useRef(null)
   useFormError(loginError, clearLoginError, formApiRef)
@@ -71,7 +71,7 @@ const DialogWrapper = ({ loginError, clearLoginError, onOk, onCancel }) => {
   )
 }
 
-DialogWrapper.propTypes = {
+PasswordPromptDialog.propTypes = {
   clearLoginError: PropTypes.func.isRequired,
   isRestoreMode: PropTypes.bool,
   loginError: PropTypes.string,
@@ -79,4 +79,4 @@ DialogWrapper.propTypes = {
   onOk: PropTypes.func.isRequired,
 }
 
-export default DialogWrapper
+export default PasswordPromptDialog

--- a/renderer/components/Settings/Security/SetPasswordDialog.js
+++ b/renderer/components/Settings/Security/SetPasswordDialog.js
@@ -7,7 +7,7 @@ import { PasswordInput, Form } from 'components/Form'
 import messages from './messages'
 import { useFormError } from 'hooks'
 
-const DialogWrapper = ({ loginError, clearLoginError, onOk, onCancel }) => {
+const SetPasswordDialog = ({ loginError, clearLoginError, onOk, onCancel }) => {
   const intl = useIntl()
   const formApiRef = useRef(null)
 
@@ -93,11 +93,11 @@ const DialogWrapper = ({ loginError, clearLoginError, onOk, onCancel }) => {
   )
 }
 
-DialogWrapper.propTypes = {
+SetPasswordDialog.propTypes = {
   clearLoginError: PropTypes.func.isRequired,
   loginError: PropTypes.string,
   onCancel: PropTypes.func.isRequired,
   onOk: PropTypes.func.isRequired,
 }
 
-export default DialogWrapper
+export default SetPasswordDialog

--- a/renderer/reducers/account/reducer.js
+++ b/renderer/reducers/account/reducer.js
@@ -102,7 +102,7 @@ export const initAccount = () => async dispatch => {
  */
 const setPassword = password => async dispatch => {
   const { sha256digest } = window.Zap
-  dispatch(waitForIpcEvent('setPassword', { value: await sha256digest(password) }))
+  dispatch(waitForIpcEvent('setPassword', { value: await sha256digest(password, 'hex') }))
 }
 
 /**
@@ -114,7 +114,7 @@ const setPassword = password => async dispatch => {
 const requirePassword = password => async dispatch => {
   const { sha256digest } = window.Zap
   const { password: hash } = await dispatch(waitForIpcEvent('getPassword'))
-  const passwordHash = await sha256digest(password)
+  const passwordHash = await sha256digest(password, 'hex')
   // compare hash received from the main thread to a hash of a password provided
   if (hash === passwordHash) {
     return true

--- a/renderer/reducers/account/selectors.js
+++ b/renderer/reducers/account/selectors.js
@@ -11,7 +11,7 @@
 export const isAccountLoading = state => state.account.isAccountLoading
 
 /**
- * isLoggingIn - Aaccount logging in state.
+ * isLoggingIn - Account logging in state.
  *
  * @param {State} state Redux state
  * @returns {boolean} Boolean indicating wether the current account is being logged into

--- a/utils/sha256.js
+++ b/utils/sha256.js
@@ -4,8 +4,8 @@ import { createHash } from 'crypto'
  * sha256digest - Generates a digest of the `message`(hex)
  *
  * @param {string} message message to hash
- * @param {string} encoding Endoding to output
- * @returns {string|Buffer} sha256 hash of a message`. If encoding is provided a string will be returned;
+ * @param {string} [encoding] Endoding to output
+ * @returns {Buffer|string} sha256 hash of a message`. If encoding is provided a string will be returned;
  *  otherwise a Buffer is returned.
  */
 export const sha256digest = (message, encoding) =>


### PR DESCRIPTION
## Description:

Ensure password is stored in the keychain as hex encoded sha256 digest,.

## Motivation and Context:

Ref https://twitter.com/cryptonobo/status/1282019127876558848

It seems that as part of this commit https://github.com/LN-Zap/zap-desktop/commit/dc9c73611ba415dce0d4dde9b8f34f810a9c4f51 our `sha256digest` utility was updated to support multiple encoding mechanisms however as part of this the default encoding changed from a hex string to a buffer.

This was done in preparation for keysend support however in the process it broke the password encoding/decoding which expects passwords to be encoded as a hex string for storage in the keychain.

## How Has This Been Tested?

Manually - enable password, change password, disable password. Also, install 0.6.2, enable the password, then upgrade to 0.7.0 and verify that the password still works.

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
