### PR TITLE
Ensure node pubkey is correctly loaded from node info

### DIFF
--- a/renderer/reducers/info/selectors.js
+++ b/renderer/reducers/info/selectors.js
@@ -177,7 +177,7 @@ const hasMppSupport = createSelector(grpcProtoVersion, v => {
  * @returns {string} Node pubkey
  */
 const nodePubkey = createSelector(nodeUris, identityPubkey, (n, pk) => {
-  const parseFromDataUri = () => n && n[0].split('@')[0]
+  const parseFromDataUri = () => n && n[0] && n[0].split('@')[0]
   return pk || parseFromDataUri()
 })
 

--- a/renderer/reducers/info/selectors.js
+++ b/renderer/reducers/info/selectors.js
@@ -85,7 +85,7 @@ const version = state => get(state, 'info.data.version')
  * @param {State} state Redux state
  * @returns {string} Node pubkey
  */
-const identityPubkey = state => get(state, 'info.data.identity_pubkey')
+const identityPubkey = state => get(state, 'info.data.identityPubkey')
 
 /**
  * version - Node urls.

--- a/renderer/reducers/info/selectors.js
+++ b/renderer/reducers/info/selectors.js
@@ -186,7 +186,12 @@ const nodePubkey = createSelector(nodeUris, identityPubkey, (n, pk) => {
  *
  * @returns {string} Node uri or pubkey
  */
-const nodeUrisOrPubkey = createSelector(nodeUris, nodePubkey, (uris, pk) => uris || [pk])
+const nodeUrisOrPubkey = createSelector(nodeUris, nodePubkey, (uris, pk) => {
+  if (uris && uris.length) {
+    return uris
+  }
+  return [pk]
+})
 
 /**
  * networkInfo - Node network info.


### PR DESCRIPTION
## Description:

Ensure node pubkey is correctly loaded from node info.

## Motivation and Context:

We're fetching the wrong key for pubkey from lnd node info since we updated to using cammel case with grpc (as per https://github.com/LN-Zap/zap-desktop/pull/3427)

## How Has This Been Tested?

Manually

## Types of changes:

Bug fix
