### PR TITLE
Fetch latest paymet on external htlc settle

### DIFF
--- a/renderer/reducers/index.js
+++ b/renderer/reducers/index.js
@@ -44,6 +44,7 @@ import lnurl from './lnurl'
  * @property {import('./invoice').State} invoice Invoice reducer.
  * @property {import('./lnurl').State} lnurl Lnurl reducer.
  * @property {import('./network').State} network Network reducer.
+ * @property {import('./payment').State} payment Payment reducer.
  * @property {import('./settings').State} settings Settings reducer.
  * @property {import('./transaction').State} transaction Transaction reducer.
  */

--- a/renderer/reducers/payment/reducer.js
+++ b/renderer/reducers/payment/reducer.js
@@ -143,7 +143,7 @@ export const paymentComplete = paymentId => async dispatch => {
     indexOffset: 0,
     reversed: true,
   })
-  dispatch(receivePayments(payments))
+  payments && dispatch(receivePayments(payments))
   dispatch({ type: PAYMENT_COMPLETED, paymentId })
 }
 
@@ -379,7 +379,7 @@ export const receiveHtlcEventData = htlcEvent => async (dispatch, getState) => {
         indexOffset: 0,
         reversed: true,
       })
-      dispatch(receivePayments(payments))
+      payments && dispatch(receivePayments(payments))
       dispatch(fetchChannels())
       dispatch(fetchBalance())
     }

--- a/services/grpc/grpc.js
+++ b/services/grpc/grpc.js
@@ -256,7 +256,9 @@ class ZapGrpc extends EventEmitter {
       const service = this.services[serviceName]
 
       if (!service) {
-        grpcLog.warn(`gRPC subscription "${key}" not available.`)
+        grpcLog.warn(
+          `Attempt to initialize ${serviceName} has failed. gRPC subscription "${key}" not available.`
+        )
         return
       }
 

--- a/services/grpc/router.subscriptions.js
+++ b/services/grpc/router.subscriptions.js
@@ -12,17 +12,17 @@ function subscribeHtlcEvents(payload = {}) {
   if (this.service.subscribeHtlcEvents) {
     const call = this.service.subscribeHtlcEvents(payload)
     call.on('data', data => {
-      grpcLog.debug('HTLC EVENT: %o', data)
+      grpcLog.debug('HTLC EVENT DATA: %o', data)
       this.emit('subscribeHtlcEvents.data', data)
     })
     call.on('error', error => {
       if (error.code !== status.CANCELLED) {
-        grpcLog.error('HTLC EVENT: %o', error)
+        grpcLog.error('HTLC EVENT ERROR: %o', error)
         this.emit('subscribeHtlcEvents.error', error)
       }
     })
     call.on('status', s => {
-      grpcLog.debug('HTLC EVENT: %o', s)
+      grpcLog.debug('HTLC EVENT STATUS: %o', s)
       this.emit('subscribeHtlcEvents.status', s)
     })
     call.on('end', () => {

--- a/services/grpc/router.subscriptions.js
+++ b/services/grpc/router.subscriptions.js
@@ -1,0 +1,39 @@
+/* eslint-disable react/no-this-in-sfc */
+import { status } from '@grpc/grpc-js'
+import { grpcLog } from '@zap/utils/log'
+
+/**
+ * subscribeHtlcEvents - Call lnd grpc subscribeHtlcEvents method and emit events on updates to the stream.
+ *
+ * @param {object} payload Payload
+ * @returns {object} Grpc Call
+ */
+function subscribeHtlcEvents(payload = {}) {
+  if (this.service.subscribeHtlcEvents) {
+    const call = this.service.subscribeHtlcEvents(payload)
+    call.on('data', data => {
+      grpcLog.debug('HTLC EVENT: %o', data)
+      this.emit('subscribeHtlcEvents.data', data)
+    })
+    call.on('error', error => {
+      if (error.code !== status.CANCELLED) {
+        grpcLog.error('HTLC EVENT: %o', error)
+        this.emit('subscribeHtlcEvents.error', error)
+      }
+    })
+    call.on('status', s => {
+      grpcLog.debug('HTLC EVENT: %o', s)
+      this.emit('subscribeHtlcEvents.status', s)
+    })
+    call.on('end', () => {
+      grpcLog.debug('HTLC EVENT END')
+      this.emit('subscribeHtlcEvents.end')
+    })
+    return call
+  }
+  return null
+}
+
+export default {
+  subscribeHtlcEvents,
+}


### PR DESCRIPTION
## Description:

Fetch latest payment data if we detect an HTLC settlement event that was probably not triggered by us. 

## Motivation and Context:

Ensures that payments sent by other wallet clients show up immediately in the activity list.

fix #3420

## How Has This Been Tested?

Manually

## Types of changes:

Enhancement

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
