### PR TITLE
Selecting correct htlc from probe attempt

### DIFF
--- a/services/grpc/router.methods.js
+++ b/services/grpc/router.methods.js
@@ -129,8 +129,12 @@ async function probePaymentV2(payload) {
           }
 
           grpcLog.info('PROBE SUCCESS: %o', data)
+
           // Prior to lnd v0.10.0 sendPayment would return a single route under the `route` key.
-          route = data.route || data.htlcs[0].route
+          route =
+            data.route ||
+            data.htlcs.find(a => a.failure.code === 'INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS').route
+
           // FIXME: For some reason the customRecords key is corrupt in the grpc response object.
           // For now, assume that if a custom_record key is set that it is a keysend record and fix it accordingly.
           route.hops = route.hops.map(hop => {


### PR DESCRIPTION
## Description:

Probes can return multiple htlcs but our code assumes there can only be one. This means that we can end up selecting a non-viable route sometimes.

## Motivation and Context:

Improve probe success rate.

## How Has This Been Tested?

Manually

## Types of changes:

Bug fix
