### PR TITLE
Include limbo balance in balance breakdown

### DIFF
--- a/renderer/containers/Channels/ChannelsMenu.js
+++ b/renderer/containers/Channels/ChannelsMenu.js
@@ -8,7 +8,7 @@ import { channelsSelectors } from 'reducers/channels'
 const mapStateToProps = state => ({
   cryptoUnitName: tickerSelectors.cryptoUnitName(state),
   lightningBalance: balanceSelectors.channelBalanceConfirmed(state),
-  pendingBalance: balanceSelectors.channelBalancePending(state),
+  pendingBalance: balanceSelectors.pendingBalance(state),
   onchainBalance: balanceSelectors.walletBalance(state),
   channelCount: channelsSelectors.allChannelsCount(state),
 })

--- a/renderer/reducers/balance/selectors.js
+++ b/renderer/reducers/balance/selectors.js
@@ -62,6 +62,16 @@ export const walletBalanceUnconfirmed = state => state.balance.walletBalanceUnco
 export const limboBalance = state => state.channels.pendingChannels.totalLimboBalance
 
 /**
+ * pendingBalance - Pending balance.
+ *
+ * @param {State} state Redux state
+ * @returns {string|null} Pending balance
+ */
+export const pendingBalance = createSelector(channelBalancePending, limboBalance, (cb, lb) => {
+  return CoinBig.sum(cb, lb).toString()
+})
+
+/**
  * totalBalance - Total balance.
  *
  * @param {State} state Redux state
@@ -96,5 +106,6 @@ export default {
   walletBalanceConfirmed,
   walletBalanceUnconfirmed,
   limboBalance,
+  pendingBalance,
   totalBalance,
 }


### PR DESCRIPTION
## Description:

Include limbo balance in balance breakdown

## Motivation and Context:

Limbo balance is currently not displayed 

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):

**Before:**

![image](https://user-images.githubusercontent.com/200251/93641116-a7742f80-f9f3-11ea-8e1f-707b5dacb3a3.png)

**After:**

![image](https://user-images.githubusercontent.com/200251/93641182-c5419480-f9f3-11ea-89e8-1796531ddb9b.png)

## Types of changes:

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
