### PR TITLE
Only count active channels as usable capacity

### DIFF
--- a/renderer/reducers/channels/selectors.js
+++ b/renderer/reducers/channels/selectors.js
@@ -313,7 +313,7 @@ channelsSelectors.selectedChannel = createSelector(
 )
 
 channelsSelectors.capacity = createSelector(
-  channelsSelectors.allChannelsRaw,
+  channelsSelectors.activeChannels,
   infoSelectors.hasMppSupport,
   (allChannels, hasMppSupport) => {
     let maxOneTimeSend = 0


### PR DESCRIPTION
## Description:

Ensures that "Total can send" and "Toal can receive" only include balances from active channels.
 
## Motivation and Context:

These numbers are wrong - they include amounts relating to inactive channels.

## How Has This Been Tested?

Manually

## Types of changes:

Fix