### PR TITLE
Support for interceptor nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "config": {
     "lnd-binary": {
-      "binaryVersion": "0.11.1-beta-3-g9fc02c041",
+      "binaryVersion": "0.11.1-beta-4-gb305c99fb",
       "binarySite": "https://github.com/LN-Zap/lnd/releases/download"
     }
   },

--- a/renderer/reducers/payment/utils.js
+++ b/renderer/reducers/payment/utils.js
@@ -1,7 +1,13 @@
 import get from 'lodash/get'
 import cloneDeep from 'lodash/cloneDeep'
 import { chanNumber } from 'bolt07'
-import { getTag, decodePayReq, getNodeAlias, generatePreimage } from '@zap/utils/crypto'
+import {
+  getTag,
+  decodePayReq,
+  getNodeAlias,
+  generatePreimage,
+  generateProbeHash,
+} from '@zap/utils/crypto'
 import { convert } from '@zap/utils/btc'
 import { getIntl } from '@zap/i18n'
 import { sha256digest } from '@zap/utils/sha256'
@@ -169,6 +175,7 @@ export const prepareBolt11Probe = (payReq, feeLimit) => {
 
   // Extract route hints from the invoice.
   const routingInfo = getTag(invoice, 'routing_info') || []
+  const paymentHash = getTag(invoice, 'payment_hash')
   const hopHints = routingInfo.map(hint => ({
     nodeId: hint.pubkey,
     chanId: chanNumber({ id: hint.short_channel_id }).number,
@@ -183,6 +190,7 @@ export const prepareBolt11Probe = (payReq, feeLimit) => {
     amtMsat: millisatoshis,
     finalCltvDelta: getTag(invoice, 'min_final_cltv_expiry') || DEFAULT_CLTV_DELTA,
     routeHints: [{ hopHints }],
+    paymentHash: generateProbeHash(paymentHash),
   }
 }
 

--- a/services/grpc/router.methods.js
+++ b/services/grpc/router.methods.js
@@ -1,5 +1,4 @@
 import { grpcLog } from '@zap/utils/log'
-import { generatePreimage } from '@zap/utils/crypto'
 import { logGrpcCmd } from './helpers'
 
 export const KEYSEND_PREIMAGE_TYPE = '5482373484'
@@ -15,10 +14,6 @@ export const KEYSEND_PREIMAGE_TYPE = '5482373484'
  * @returns {Promise} The route route when state is SUCCEEDED
  */
 async function probePayment(payload) {
-  // Use a payload that has the payment hash set to some random bytes.
-  // This will cause the payment to fail at the final destination.
-  payload.paymentHash = new Uint8Array(generatePreimage())
-
   logGrpcCmd('Router.probePayment', payload)
 
   let result
@@ -94,10 +89,6 @@ async function probePayment(payload) {
  * @returns {Promise} The route route when state is SUCCEEDED
  */
 async function probePaymentV2(payload) {
-  // Use a payload that has the payment hash set to some random bytes.
-  // This will cause the payment to fail at the final destination.
-  payload.paymentHash = new Uint8Array(generatePreimage())
-
   logGrpcCmd('Router.probePaymentV2', payload)
 
   let result

--- a/utils/crypto.js
+++ b/utils/crypto.js
@@ -8,6 +8,7 @@ import bip21 from 'bip21'
 import coininfo from 'coininfo'
 import { CoinBig } from '@zap/utils/coin'
 import { convert } from '@zap/utils/btc'
+import { sha256digest } from '@zap/utils/sha256'
 
 export const PREIMAGE_BYTE_LENGTH = 32
 
@@ -315,3 +316,20 @@ export const getFeeRange = (routes = []) => ({
  * @returns {Uint8Array} hash bytes
  */
 export const generatePreimage = () => randomBytes(PREIMAGE_BYTE_LENGTH)
+
+/**
+ * generateHash - Generates probe hash from payment hash.
+ *
+ * @param {string} paymentHash payment hash (hex)
+ * @returns {Uint8Array} probe hash (bytes)
+ */
+export const generateProbeHash = paymentHash => {
+  const idx = Buffer.from('probing-01:', 'utf8')
+  const hash = Buffer.from(paymentHash, 'hex')
+  const totalLength = idx.length + hash.length
+
+  const probeHashBuffer = Buffer.concat([idx, hash], totalLength)
+  const probeHash = sha256digest(probeHashBuffer)
+
+  return probeHash
+}


### PR DESCRIPTION
## Description:

Patch lnd to support interceptors (stops penalising intermediate nodes that return `FailIncorrectPaymentAmount` or `FailIncorrectDetails`.

Generates probe hashes deterministically using the schema `sha256("probing-01:" || payment_hash)` (where `||` is the concatenation operator).

## Motivation and Context:

Make it possible to pay Breeze users that sit behind an htlc interceptor.

## How Has This Been Tested?

Manually

## Types of changes:

Enhancements

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
