### PR TITLE
Ability to add wallet name when connecting to remote node

### DIFF
--- a/renderer/components/Onboarding/Steps/ConnectionConfirm.js
+++ b/renderer/components/Onboarding/Steps/ConnectionConfirm.js
@@ -18,6 +18,7 @@ class ConnectionConfirm extends React.Component {
     isLightningGrpcActive: PropTypes.bool,
     isWalletUnlockerGrpcActive: PropTypes.bool,
     lndConnect: PropTypes.string,
+    name: PropTypes.string,
     startLnd: PropTypes.func.isRequired,
     startLndCertError: PropTypes.string,
     startLndHostError: PropTypes.string,
@@ -40,10 +41,11 @@ class ConnectionConfirm extends React.Component {
 
   handleSubmit = async () => {
     const {
-      connectionHost,
       connectionCert,
+      connectionHost,
       connectionMacaroon,
       connectionString,
+      name,
       startLnd,
     } = this.props
     const cleanConnectionString = connectionString && connectionString.trim()
@@ -57,6 +59,7 @@ class ConnectionConfirm extends React.Component {
           cert: connectionCert,
           macaroon: connectionMacaroon,
         }),
+        name,
       })
     }
 
@@ -78,6 +81,7 @@ class ConnectionConfirm extends React.Component {
         type: 'custom',
         decoder: 'lnd.lndconnect.v1',
         lndconnectUri,
+        name,
       })
     }
 
@@ -93,6 +97,7 @@ class ConnectionConfirm extends React.Component {
       type: 'custom',
       decoder: 'lnd.lndconnect.v1',
       lndconnectUri,
+      name,
     })
   }
 
@@ -106,6 +111,7 @@ class ConnectionConfirm extends React.Component {
       connectionMacaroon,
       connectionString,
       lndConnect,
+      name,
       isLightningGrpcActive,
       isWalletUnlockerGrpcActive,
       startLndHostError,

--- a/renderer/components/Onboarding/Steps/ConnectionDetails.js
+++ b/renderer/components/Onboarding/Steps/ConnectionDetails.js
@@ -18,11 +18,13 @@ class ConnectionDetails extends React.Component {
     connectionMacaroon: PropTypes.string,
     connectionString: PropTypes.string,
     lndConnect: PropTypes.string,
+    name: PropTypes.string,
     setConnectionCert: PropTypes.func.isRequired,
     setConnectionHost: PropTypes.func.isRequired,
     setConnectionMacaroon: PropTypes.func.isRequired,
     setConnectionString: PropTypes.func.isRequired,
     setLndconnect: PropTypes.func.isRequired,
+    setName: PropTypes.func.isRequired,
     startLndCertError: PropTypes.string,
     startLndHostError: PropTypes.string,
     startLndMacaroonError: PropTypes.string,
@@ -46,22 +48,25 @@ class ConnectionDetails extends React.Component {
   componentDidUpdate(prevProps, prevState) {
     const {
       lndConnect,
-      setConnectionHost,
       setConnectionCert,
+      setConnectionHost,
       setConnectionMacaroon,
       setConnectionString,
+      setName,
     } = this.props
     const { formType } = this.state
     if (formType && formType !== prevState.formType && prevState.formType) {
       switch (formType) {
         case FORM_TYPE_CONNECTION_STRING:
-          setConnectionHost(null)
           setConnectionCert(null)
+          setConnectionHost(null)
           setConnectionMacaroon(null)
+          setName(null)
           break
 
         case FORM_TYPE_MANUAL:
           setConnectionString(null)
+          setName(null)
           break
 
         default:
@@ -79,25 +84,27 @@ class ConnectionDetails extends React.Component {
 
   render() {
     const {
-      wizardApi,
-      wizardState,
-      connectionHost,
+      clearStartLndError,
       connectionCert,
+      connectionHost,
       connectionMacaroon,
       connectionString,
-      startLndHostError,
-      startLndCertError,
-      startLndMacaroonError,
       lndConnect,
-      setLndconnect,
-      setConnectionHost,
+      name,
       setConnectionCert,
+      setConnectionHost,
       setConnectionMacaroon,
       setConnectionString,
-      clearStartLndError,
-      validateHost,
+      setLndconnect,
+      setName,
+      startLndCertError,
+      startLndHostError,
+      startLndMacaroonError,
       validateCert,
+      validateHost,
       validateMacaroon,
+      wizardApi,
+      wizardState,
     } = this.props
     const { formType } = this.state
 
@@ -123,8 +130,10 @@ class ConnectionDetails extends React.Component {
               clearStartLndError={clearStartLndError}
               connectionString={connectionString}
               lndConnect={lndConnect}
+              name={name}
               setConnectionString={setConnectionString}
               setLndconnect={setLndconnect}
+              setName={setName}
               startLndCertError={startLndCertError}
               startLndHostError={startLndHostError}
               startLndMacaroonError={startLndMacaroonError}
@@ -139,10 +148,12 @@ class ConnectionDetails extends React.Component {
               connectionMacaroon={connectionMacaroon}
               connectionString={connectionString}
               lndConnect={lndConnect}
+              name={name}
               setConnectionCert={setConnectionCert}
               setConnectionHost={setConnectionHost}
               setConnectionMacaroon={setConnectionMacaroon}
               setLndconnect={setLndconnect}
+              setName={setName}
               startLndCertError={startLndCertError}
               startLndHostError={startLndHostError}
               startLndMacaroonError={startLndMacaroonError}

--- a/renderer/components/Onboarding/Steps/ConnectionDetailsManual.js
+++ b/renderer/components/Onboarding/Steps/ConnectionDetailsManual.js
@@ -14,10 +14,12 @@ class ConnectionDetailsManual extends React.Component {
     connectionMacaroon: PropTypes.string,
     connectionString: PropTypes.string,
     lndConnect: PropTypes.string,
+    name: PropTypes.string,
     setConnectionCert: PropTypes.func.isRequired,
     setConnectionHost: PropTypes.func.isRequired,
     setConnectionMacaroon: PropTypes.func.isRequired,
     setLndconnect: PropTypes.func.isRequired,
+    setName: PropTypes.func.isRequired,
 
     startLndCertError: PropTypes.string,
     startLndHostError: PropTypes.string,
@@ -32,6 +34,7 @@ class ConnectionDetailsManual extends React.Component {
   static defaultProps = {
     wizardApi: {},
     wizardState: {},
+    name: null,
   }
 
   componentDidMount() {
@@ -90,10 +93,11 @@ class ConnectionDetailsManual extends React.Component {
   }
 
   handleSubmit = values => {
-    const { setConnectionHost, setConnectionCert, setConnectionMacaroon } = this.props
+    const { setConnectionHost, setConnectionCert, setConnectionMacaroon, setName } = this.props
     setConnectionHost(values.connectionHost)
     setConnectionCert(values.connectionCert)
     setConnectionMacaroon(values.connectionMacaroon)
+    setName(values.name)
   }
 
   validateHost = () => {
@@ -124,10 +128,12 @@ class ConnectionDetailsManual extends React.Component {
       connectionMacaroon,
       connectionString,
       lndConnect,
+      name,
       setConnectionHost,
       setConnectionCert,
       setConnectionMacaroon,
       setLndconnect,
+      setName,
       startLndHostError,
       startLndCertError,
       startLndMacaroonError,
@@ -211,11 +217,21 @@ class ConnectionDetailsManual extends React.Component {
                 initialValue={connectionMacaroon}
                 isRequired
                 label="Macaroon"
+                mb={3}
                 name="connectionMacaroon"
                 onBlur={this.validateMacaroon}
                 validateOnBlur={willValidateInline}
                 validateOnChange={willValidateInline}
                 width={1}
+              />
+
+              <Input
+                description={<FormattedMessage {...messages.wallet_name_description} />}
+                field="name"
+                initialValue={name}
+                label={<FormattedMessage {...messages.wallet_name_label} />}
+                maxLength={30}
+                name="name"
               />
             </>
           )

--- a/renderer/components/Onboarding/Steps/ConnectionDetailsString.js
+++ b/renderer/components/Onboarding/Steps/ConnectionDetailsString.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { FormattedMessage, injectIntl } from 'react-intl'
 import { Box } from 'rebass/styled-components'
 import { Bar, Header } from 'components/UI'
-import { Form, LndConnectionStringInput } from 'components/Form'
+import { Form, Input, LndConnectionStringInput } from 'components/Form'
 import ConnectionDetailsTabs from './ConnectionDetailsTabs'
 import messages from './messages'
 
@@ -12,8 +12,10 @@ class ConnectionDetailsString extends React.Component {
     clearStartLndError: PropTypes.func.isRequired,
     connectionString: PropTypes.string,
     lndConnect: PropTypes.string,
+    name: PropTypes.string,
     setConnectionString: PropTypes.func.isRequired,
     setLndconnect: PropTypes.func.isRequired,
+    setName: PropTypes.func.isRequired,
     startLndCertError: PropTypes.string,
     startLndHostError: PropTypes.string,
 
@@ -25,6 +27,7 @@ class ConnectionDetailsString extends React.Component {
   static defaultProps = {
     wizardApi: {},
     wizardState: {},
+    name: null,
   }
 
   componentDidMount() {
@@ -85,8 +88,9 @@ class ConnectionDetailsString extends React.Component {
   }
 
   handleSubmit = values => {
-    const { setConnectionString } = this.props
+    const { setConnectionString, setName } = this.props
     setConnectionString(values.connectionString)
+    setName(values.name)
   }
 
   render() {
@@ -98,8 +102,10 @@ class ConnectionDetailsString extends React.Component {
       startLndCertError,
       startLndMacaroonError,
       lndConnect,
+      name,
       setLndconnect,
       setConnectionString,
+      setName,
       clearStartLndError,
       ...rest
     } = this.props
@@ -158,10 +164,20 @@ class ConnectionDetailsString extends React.Component {
                 field="connectionString"
                 initialValue={connectionString}
                 isRequired
+                mb={3}
                 rows="12"
                 validateOnBlur={willValidateInline}
                 validateOnChange={willValidateInline}
                 willAutoFocus
+              />
+
+              <Input
+                description={<FormattedMessage {...messages.wallet_name_description} />}
+                field="name"
+                initialValue={name}
+                label={<FormattedMessage {...messages.wallet_name_label} />}
+                maxLength={30}
+                name="name"
               />
             </>
           )

--- a/renderer/components/Onboarding/Steps/Name.js
+++ b/renderer/components/Onboarding/Steps/Name.js
@@ -19,7 +19,7 @@ class Name extends React.Component {
   static defaultProps = {
     wizardApi: {},
     wizardState: {},
-    name: '',
+    name: null,
   }
 
   setFormApi = formApi => {

--- a/renderer/containers/Onboarding/Steps/ConnectionConfirm.js
+++ b/renderer/containers/Onboarding/Steps/ConnectionConfirm.js
@@ -11,6 +11,7 @@ const mapStateToProps = state => ({
   isLightningGrpcActive: state.lnd.isLightningGrpcActive,
   isWalletUnlockerGrpcActive: state.lnd.isWalletUnlockerGrpcActive,
   lndConnect: state.onboarding.lndConnect,
+  name: state.onboarding.name,
   startLndHostError: lndSelectors.startLndHostError(state),
   startLndCertError: lndSelectors.startLndCertError(state),
   startLndMacaroonError: lndSelectors.startLndMacaroonError(state),

--- a/renderer/containers/Onboarding/Steps/ConnectionDetails.js
+++ b/renderer/containers/Onboarding/Steps/ConnectionDetails.js
@@ -10,6 +10,7 @@ import {
   setConnectionMacaroon,
   setConnectionString,
   setLndconnect,
+  setName,
 } from 'reducers/onboarding'
 
 const mapStateToProps = state => ({
@@ -19,6 +20,7 @@ const mapStateToProps = state => ({
   connectionHost: state.onboarding.connectionHost,
   connectionCert: state.onboarding.connectionCert,
   lndConnect: state.onboarding.lndConnect,
+  name: state.onboarding.name,
   startLndHostError: lndSelectors.startLndHostError(state),
   startLndCertError: lndSelectors.startLndCertError(state),
   startLndMacaroonError: lndSelectors.startLndMacaroonError(state),
@@ -33,6 +35,7 @@ const mapDispatchToProps = {
   setConnectionMacaroon,
   setConnectionString,
   setLndconnect,
+  setName,
   clearStartLndError,
 }
 

--- a/renderer/containers/Onboarding/Steps/ConnectionDetailsManual.js
+++ b/renderer/containers/Onboarding/Steps/ConnectionDetailsManual.js
@@ -10,6 +10,7 @@ import {
   setConnectionMacaroon,
   setConnectionString,
   setLndconnect,
+  setName,
 } from 'reducers/onboarding'
 
 const mapStateToProps = state => ({
@@ -19,6 +20,7 @@ const mapStateToProps = state => ({
   connectionHost: state.onboarding.connectionHost,
   connectionCert: state.onboarding.connectionCert,
   lndConnect: state.onboarding.lndConnect,
+  name: state.onboarding.name,
   startLndHostError: lndSelectors.startLndHostError(state),
   startLndCertError: lndSelectors.startLndCertError(state),
   startLndMacaroonError: lndSelectors.startLndMacaroonError(state),
@@ -33,6 +35,7 @@ const mapDispatchToProps = {
   setConnectionMacaroon,
   setConnectionString,
   setLndconnect,
+  setName,
   clearStartLndError,
 }
 

--- a/test/e2e/basic-ui.spec.js
+++ b/test/e2e/basic-ui.spec.js
@@ -51,6 +51,7 @@ test('provide access to basic wallet functionality', async t => {
     .typeText(onboarding.macaroonInput, path.join(__dirname, 'fixtures', 'readonly.macaroon'), {
       paste: true,
     })
+    .typeText(onboarding.nameInput, 'My Test Wallet', { paste: true })
     .click(onboarding.nextButton)
 
     // Confirm connection details and submit

--- a/test/e2e/onboarding-connect-btcpay.spec.js
+++ b/test/e2e/onboarding-connect-btcpay.spec.js
@@ -55,6 +55,10 @@ test('should connect to an external wallet (btcpay)', async t => {
   }`,
       { paste: true }
     )
+    // Fill out wallet name and submit.
+    .expect(onboarding.nameInput.exists)
+    .ok()
+    .typeText(onboarding.nameInput, 'External Wallet (lndconnect)', { paste: true })
     .click(onboarding.nextButton)
 
     // Confirm connection details and submit.

--- a/test/e2e/onboarding-connect-lndconnect.spec.js
+++ b/test/e2e/onboarding-connect-lndconnect.spec.js
@@ -43,6 +43,11 @@ test('should connect to an external wallet (lndconnect)', async t => {
       'lndconnect://testnet4-lnd.zaphq.io:10009?cert=MIICYTCCAgagAwIBAgIRAJMTFnc73j4iP6VAU_-nSOowCgYIKoZIzj0EAwIwPjEfMB0GA1UEChMWbG5kIGF1dG9nZW5lcmF0ZWQgY2VydDEbMBkGA1UEAxMSemFwLXRlc3RuZXQ0LWxuZC0wMB4XDTE5MTAyMzEwMDIyNloXDTIwMTIxNzEwMDIyNlowPjEfMB0GA1UEChMWbG5kIGF1dG9nZW5lcmF0ZWQgY2VydDEbMBkGA1UEAxMSemFwLXRlc3RuZXQ0LWxuZC0wMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEESndkptIDcgVAdH7ulBVDPZNsKWgD12WJhII2VmbUN9IU1ZFFcv43kg_DyzCH0_158tDGqHp-Npyf9JEQ--y4aOB5DCB4TAOBgNVHQ8BAf8EBAMCAqQwDwYDVR0TAQH_BAUwAwEB_zCBvQYDVR0RBIG1MIGyghJ6YXAtdGVzdG5ldDQtbG5kLTCCCWxvY2FsaG9zdIIVdGVzdG5ldDQtbG5kLnphcGhxLmlvgj56YXBuMzRxZmVlZHcybDV5MjZwM2hubmt1c3FuYmh4Y3h3NjRscTVjb2ptdnE0NXl3NGJjM3NxZC5vbmlvboIEdW5peIIKdW5peHBhY2tldIcEfwAAAYcQAAAAAAAAAAAAAAAAAAAAAYcECjQEPocEIklopocECjf8YDAKBggqhkjOPQQDAgNJADBGAiEAiBiCFmgYrgQyF_OKoZb_I47xnaZYTkdUNeajomMoFKoCIQC6X3YEAMV2r1rbNs0faOUYS3hCTmFK75coXBJHHWFsFw&macaroon=AgEDbG5kAooBAwoQGE3tbiKnewTcFZ2PksnBLxIBMBoPCgdhZGRyZXNzEgRyZWFkGgwKBGluZm8SBHJlYWQaEAoIaW52b2ljZXMSBHJlYWQaDwoHbWVzc2FnZRIEcmVhZBoQCghvZmZjaGFpbhIEcmVhZBoPCgdvbmNoYWluEgRyZWFkGg0KBXBlZXJzEgRyZWFkAAAGILUucIJstjca7--eeHDbtkIQ1BLlYOEXKgxLWQDiuReD',
       { paste: true }
     )
+
+    // Fill out wallet name and submit.
+    .expect(onboarding.nameInput.exists)
+    .ok()
+    .typeText(onboarding.nameInput, 'External Wallet (lndconnect)', { paste: true })
     .click(onboarding.nextButton)
 
     // Confirm connection details and submit

--- a/test/e2e/pages/onboarding.js
+++ b/test/e2e/pages/onboarding.js
@@ -91,7 +91,9 @@ class Onboarding {
 
   passwordInputSeePasswordButton = ReactSelector('Password Input').find('svg')
 
-  nameInput = ReactSelector('Name Input').find('input')
+  nameInput = ReactSelector('Input')
+    .nth(-1)
+    .find('input')
 
   hostInput = ReactSelector('ConnectionDetailsManual Input')
     .nth(0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Currently, when connecting to a remote mode, you cannot specify the wallet name, having ability to do it in onboarding process would be helpful

<!--- Describe your changes in detail -->

## Motivation and Context:

The feature request was requested in #1262 

## How Has This Been Tested?

Manually and via e2e tests

## Screenshots (if appropriate):
<img width="736" alt="Screenshot 2020-11-13 at 9 39 32 PM" src="https://user-images.githubusercontent.com/1453255/99093710-daecc800-25f8-11eb-81ac-dccb02edd13f.png">

## Types of changes:

New feature: To allow adding wallet name in the onboarding process for external wallets

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x ] My commits have been squashed into a concise set of changes.
