### PR TITLE
Adjust desktop icon name as per icon images

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
       ],
       "desktop": {
         "Comment": "Zap - Lightning wallet",
-        "Icon": "zap",
+        "Icon": "zap-desktop.png",
         "Name": "Zap",
         "StartupNotify": "true",
         "Terminal": "false",


### PR DESCRIPTION
fix 3608

<!--- Provide a general summary of your changes in the Title above -->

## Description:

Adjusts the desktop file generated for AppImage to make sure it's inline with the format

## Motivation and Context:

Fixes #3608 

## How Has This Been Tested?

By running the AppImage generated after changes via https://github.com/TheAssassin/AppImageLauncher 

## Screenshots (if appropriate):

![AppImageIcon](https://user-images.githubusercontent.com/1453255/99281899-0cfc6500-2859-11eb-83ed-e23319b74321.png)


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have reviewed and updated the documentation accordingly.
- [ ] I have read the _CONTRIBUTING_ document.
- [ ] I have added tests to cover my changes where needed.
- [ ] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
