### PR TITLE
feat(ui): allow user to choose denomination during onboarding setup

### DIFF
--- a/renderer/components/Home/Home.js
+++ b/renderer/components/Home/Home.js
@@ -25,6 +25,7 @@ class Home extends React.Component {
     activeWallet: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     activeWalletSettings: PropTypes.object,
     clearStartLndError: PropTypes.func.isRequired,
+    cryptoUnit: PropTypes.string.isRequired,
     deleteWallet: PropTypes.func.isRequired,
     generateLndConfigFromWallet: PropTypes.func.isRequired,
     history: PropTypes.object.isRequired,
@@ -90,6 +91,7 @@ class Home extends React.Component {
       putWallet,
       showNotification,
       generateLndConfigFromWallet,
+      cryptoUnit,
     } = this.props
 
     return (
@@ -130,6 +132,7 @@ class Home extends React.Component {
                   <WalletLauncher
                     key={wallet.id}
                     clearStartLndError={clearStartLndError}
+                    cryptoUnit={cryptoUnit}
                     deleteWallet={deleteWallet}
                     generateLndConfigFromWallet={generateLndConfigFromWallet}
                     isLightningGrpcActive={isLightningGrpcActive}

--- a/renderer/components/Home/WalletLauncher.js
+++ b/renderer/components/Home/WalletLauncher.js
@@ -190,6 +190,7 @@ const unsafeShallowCompare = (obj1, obj2, whiteList) => {
 class WalletLauncher extends React.Component {
   static propTypes = {
     clearStartLndError: PropTypes.func.isRequired,
+    cryptoUnit: PropTypes.string.isRequired,
     deleteWallet: PropTypes.func.isRequired,
     generateLndConfigFromWallet: PropTypes.func.isRequired,
     history: PropTypes.shape({
@@ -393,7 +394,7 @@ class WalletLauncher extends React.Component {
   }
 
   render() {
-    const { wallet, isStartingLnd, isNeutrinoRunning, ...rest } = this.props
+    const { cryptoUnit, wallet, isStartingLnd, isNeutrinoRunning, ...rest } = this.props
     const { isValidating } = this.state
     const actionBarButtons = formState => (
       <>
@@ -501,6 +502,7 @@ class WalletLauncher extends React.Component {
 
                   <WalletSettingsFormLocal
                     autopilotDefaults={autopilotDefaults}
+                    cryptoUnit={cryptoUnit}
                     wallet={walletConverted}
                   />
                 </>

--- a/renderer/components/Home/WalletSettingsFormLocal.js
+++ b/renderer/components/Home/WalletSettingsFormLocal.js
@@ -8,7 +8,15 @@ import { Box, Flex } from 'rebass/styled-components'
 import uniq from 'lodash/uniq'
 import { intlShape } from '@zap/i18n'
 import { Bar, Button, DataRow, Text, Tooltip } from 'components/UI'
-import { Input, Label, Toggle, TextArea, FieldLabelFactory } from 'components/Form'
+import {
+  Input,
+  Label,
+  Toggle,
+  TextArea,
+  FieldLabelFactory,
+  CryptoAmountInput,
+} from 'components/Form'
+import { CryptoSelector } from 'containers/UI'
 import messages from './messages'
 import AutopilotAllocation from './AutopilotAllocation'
 
@@ -62,6 +70,7 @@ const formatNeutrinoNodes = value => value && value.join('\n')
 class WalletSettingsFormLocal extends React.Component {
   static propTypes = {
     autopilotDefaults: PropTypes.object.isRequired,
+    cryptoUnit: PropTypes.string.isRequired,
     formApi: PropTypes.object.isRequired,
     formState: PropTypes.object.isRequired,
     intl: intlShape.isRequired,
@@ -89,7 +98,7 @@ class WalletSettingsFormLocal extends React.Component {
   }
 
   render() {
-    const { intl, formState, autopilotDefaults, wallet } = this.props
+    const { cryptoUnit, intl, formState, autopilotDefaults, wallet } = this.props
     const { chain, network } = wallet
 
     const {
@@ -272,19 +281,24 @@ class WalletSettingsFormLocal extends React.Component {
                 }
                 py={2}
                 right={
-                  <Input
-                    field="autopilotMinchansize"
-                    id="autopilotMinchansize"
-                    initialValue={autopilotMinchansize || autopilotDefaults.autopilotMinchansize}
-                    justifyContent="flex-end"
-                    max={autopilotDefaults.autopilotMaxchansize}
-                    min={autopilotDefaults.autopilotMinchansize}
-                    ml="auto"
-                    step="1"
-                    textAlign="right"
-                    type="number"
-                    width={150}
-                  />
+                  <Flex alignItems="center">
+                    <CryptoSelector />
+
+                    <CryptoAmountInput
+                      cryptoUnit={cryptoUnit}
+                      field="autopilotMinchansize"
+                      id="autopilotMinchansize"
+                      initialValue={autopilotMinchansize || autopilotDefaults.autopilotMinchansize}
+                      justifyContent="flex-end"
+                      max={autopilotDefaults.autopilotMaxchansize}
+                      min={autopilotDefaults.autopilotMinchansize}
+                      ml="2"
+                      step="1"
+                      textAlign="right"
+                      type="number"
+                      width={150}
+                    />
+                  </Flex>
                 }
               />
 
@@ -296,19 +310,24 @@ class WalletSettingsFormLocal extends React.Component {
                 }
                 py={2}
                 right={
-                  <Input
-                    field="autopilotMaxchansize"
-                    id="autopilotMaxchansize"
-                    initialValue={autopilotMaxchansize || autopilotDefaults.autopilotMaxchansize}
-                    justifyContent="flex-end"
-                    max={autopilotDefaults.autopilotMaxchansize}
-                    min={autopilotDefaults.autopilotMinchansize}
-                    ml="auto"
-                    step="1"
-                    textAlign="right"
-                    type="number"
-                    width={150}
-                  />
+                  <Flex alignItems="center">
+                    <CryptoSelector />
+
+                    <CryptoAmountInput
+                      cryptoUnit={cryptoUnit}
+                      field="autopilotMaxchansize"
+                      id="autopilotMaxchansize"
+                      initialValue={autopilotMaxchansize || autopilotDefaults.autopilotMaxchansize}
+                      justifyContent="flex-end"
+                      max={autopilotDefaults.autopilotMaxchansize}
+                      min={autopilotDefaults.autopilotMinchansize}
+                      ml="2"
+                      step="1"
+                      textAlign="right"
+                      type="number"
+                      width={150}
+                    />
+                  </Flex>
                 }
               />
 

--- a/renderer/containers/Home/Home.js
+++ b/renderer/containers/Home/Home.js
@@ -19,6 +19,7 @@ import {
 } from 'reducers/lnd'
 import { openDialog } from 'reducers/modal'
 import { showError, showNotification } from 'reducers/notification'
+import { tickerSelectors } from 'reducers/ticker'
 import Home from 'components/Home'
 import DeleteWalletDialog from './DeleteWalletDialog'
 import AppErrorBoundary from 'components/ErrorBoundary/AppErrorBoundary'
@@ -44,6 +45,7 @@ const mapStateToProps = state => ({
   isStartingLnd: state.lnd.isStartingLnd,
   isUnlockingWallet: state.lnd.isUnlockingWallet,
   unlockWalletError: state.lnd.unlockWalletError,
+  cryptoUnit: tickerSelectors.cryptoUnit(state),
 })
 
 const mapDispatchToProps = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:

Add the `<CryptoSelector />` component to the wallet setup screen to let users choose their bitcoin denomination while they set the max/min channel amounts

## Motivation and Context:

Closes #3721 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manual testing. I haven't noticed any issues from my changes to the `ticker` selectors, but it seems like there could be potential side effects from those changes.

## Screenshots (if appropriate):

![zap](https://user-images.githubusercontent.com/16882830/111368810-b10de580-866c-11eb-873a-9a82864d3fde.gif)


## Types of changes:

<!--- What types of changes does your code introduce? -->
<!--- Bug fix? (non-breaking change which fixes an issue)? -->
<!--- New feature? (non-breaking change which adds functionality) -->
New feature
<!--- Breaking change? (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have reviewed and updated the documentation accordingly.
- [x] I have read the _CONTRIBUTING_ document.
- [x] I have added tests to cover my changes where needed.
- [x] All new and existing tests passed.
- [x] My commits have been squashed into a concise set of changes.
